### PR TITLE
Add hooks for running linters and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 *.idb
 *.i64
 !rules/lib
+
+# hooks output
+style-checker-output.log
+rule-linter-output.log

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -42,3 +42,11 @@ Next, use `pip` to install the source code in "editable" mode. This means that P
 `$ pip install -e ./local/path/to/src`
 
 You'll find that the `capa.exe` (Windows) or `capa` (Linux) executables in your path now invoke the capa binary from this directory.
+
+### 4. Setup hooks [optional]
+
+If you plan to contribute to capa, you may want to setup the hooks.
+Run `scripts/setup-hooks.sh` to set the following hooks up:
+- The `post-commit` hook runs the linter after every `git commit`, letting you know if there are code style or rule linter offenses you need to fix.
+- The `pre-push` hook runs the linter and the tests and block the `git push` if they do not succeed.
+  This way you realise if everything is alright without the need of sending a PR.

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,34 @@
+
+# Use a console with emojis support for a better experience
+
+# Stash uncommited changes
+MSG="post-commit-$(date +%s)"
+git stash push -kqum $MSG
+STASH_LIST=$(git stash list)
+if [[ "$STASH_LIST" == *"$MSG"* ]]; then
+  echo "Uncommited changes stashed with message '$MSG', if you abort before they are restored run \`git stash pop\`"
+fi
+
+# Run style checker and print state (it doesn't block the commit)
+pycodestyle --config=./ci/tox.ini ./capa/ > style-checker-output.log 2>&1
+if [ $? == 0 ]; then
+  echo 'Style checker succeeds!! 💘'
+else
+  echo 'Style checker failed 😭\nCheck style-checker-output.log for details'
+  exit 1
+fi
+
+# Run rule linter and print state (it doesn't block the commit)
+python ./scripts/lint.py ./rules/ > rule-linter-output.log 2>&1
+if [ $? == 0 ]; then
+  echo 'Rule linter succeeds!! 💖'
+else
+  echo 'Rule linter failed 😭\nCheck rule-linter-output.log for details'
+  exit 2
+fi
+
+# Restore stashed changes
+if [[ "$STASH_LIST" == *"$MSG"* ]]; then
+  git stash pop -q --index
+  echo "Stashed changes '$MSG' restored"
+fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,52 @@
+
+# Use a console with emojis support for a better experience
+
+# Stash uncommited changes
+MSG="pre-push-$(date +%s)"
+git stash push -kqum $MSG
+STASH_LIST=$(git stash list)
+if [[ "$STASH_LIST" == *"$MSG"* ]]; then
+  echo "Uncommited changes stashed with message '$MSG', if you abort before they are restored run \`git stash pop\`"
+fi
+
+restore_stashed() {
+  if [[ "$STASH_LIST" == *"$MSG"* ]]; then
+    git stash pop -q --index
+    echo "Stashed changes '$MSG' restored"
+  fi
+}
+
+# Run style checker and print state
+pycodestyle --config=./ci/tox.ini ./capa/ > style-checker-output.log 2>&1
+if [ $? == 0 ]; then
+  echo 'Style checker succeeds!! 💘'
+else
+  echo 'Style checker failed 😭 PUSH ABORTED\nCheck style-checker-output.log for details'
+  restore_stashed
+  exit 1
+fi
+
+# Run rule linter and print state
+python ./scripts/lint.py ./rules/ > rule-linter-output.log 2>&1
+if [ $? == 0 ]; then
+  echo 'Rule linter succeeds!! 💖'
+else
+  echo 'Rule linter failed 😭 PUSH ABORTED\nCheck rule-linter-output.log for details'
+  restore_stashed
+  exit 2
+fi
+
+# Run tests
+echo 'Running tests, please wait ⌛'
+pytest tests/ --maxfail=1
+if [ $? == 0 ]; then
+  echo 'Tests succeed!! 🎉'
+else
+  echo 'Tests failed 😓 PUSH ABORTED\nRun `pytest -v --cov=capa test/` if you need more details'
+  restore_stashed
+  exit 3
+fi
+
+echo 'PUSH SUCCEEDED 🎉🎉'
+
+restore_stashed

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+GIT_DIR=`git rev-parse --show-toplevel`
+cd $GIT_DIR
+
+# hooks may exist already (e.g. git-lfs configuration)
+# If the `.git/hooks/$arg` file doesn't exist it, initialize with `#!/bin/sh`
+# After that append `scripts/hooks/$arg` and ensure they can be run
+create_hook() {
+  if [[ ! -e .git/hooks/$1 ]]; then
+    echo '#!/bin/sh' > .git/hooks/$1
+  fi
+  cat scripts/hooks/$1 >> .git/hooks/$1
+  chmod +x .git/hooks/$1
+}
+
+echo '\n#### Copying hooks into .git/hooks'
+create_hook 'post-commit'
+create_hook 'pre-push'
+
+echo '\n#### Installing linter/test dependencies\n'
+pip install pycodestyle
+pytest-sugar
+pip install https://github.com/williballenthin/vivisect/zipball/master
+python setup.py develop


### PR DESCRIPTION
Add the `scripts/setup-hooks.sh` script which sets the following hooks up:
- The `post-commit` hook runs the linter after every `git commit`, letting you know if there are code style or rule linter offenses you need to fix.
- The `pre-push` hook runs the linter and the tests and block the `git push` if they do not succeed. This way you realise if everything is alright without the need of sending a PR.

#### `git commit` when the linter fails
![Screenshot 2020-06-22 at 11 08 58](https://user-images.githubusercontent.com/16052290/85269875-cefd3f80-b478-11ea-824c-8a8b8e24ea40.png)

#### `git push` in process with uncommited changes
![Screenshot 2020-06-22 at 11 15 35](https://user-images.githubusercontent.com/16052290/85270595-d113ce00-b479-11ea-808a-b9166c467048.png)

Be careful if you are using **git 2.24** as there is a bug affecting `git stash pop`: https://www.spinics.net/lists/git/msg369520.html It is fixed in the last git version.

