### PR TITLE
Remove Build Status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # capa
-[![Build Status](https://drone.oneteamed.net/api/badges/FLARE/capa/status.svg)](https://drone.oneteamed.net/FLARE/capa)
 
 capa detects capabilities in executable files.
 You run it against a .exe or .dll and it tells you what it thinks the program can do.


### PR DESCRIPTION
This should have been removed as part of the migration. I assume we want to reimplement the build status label in the README using GitHub Actions and https://shields.io