### PR TITLE
Get rid of the Element class

### DIFF
--- a/capa/engine.py
+++ b/capa/engine.py
@@ -145,22 +145,6 @@ class Some(Statement):
         return Result(success, self, results)
 
 
-class Element(Statement):
-    '''match if the child is contained in the ctx set.'''
-    def __init__(self, child):
-        super(Element, self).__init__()
-        self.child = child
-
-    def __hash__(self):
-        return hash((self.name, self.child))
-
-    def __eq__(self, other):
-        return self.name == other.name and self.child == other.child
-
-    def evaluate(self, ctx):
-        return Result(self.child in ctx, self, [])
-
-
 class Range(Statement):
     '''match if the child is contained in the ctx set with a count in the given range.'''
     def __init__(self, child, min=None, max=None):

--- a/capa/ida/explorer/model.py
+++ b/capa/ida/explorer/model.py
@@ -322,7 +322,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                     parent2 = parent
             else:
                 parent2 = CapaExplorerDefaultItem(parent, '%d or more' % result.statement.count)
-        elif not isinstance(result.statement, (capa.features.Feature, capa.engine.Element, capa.engine.Range, capa.engine.Regex)):
+        elif not isinstance(result.statement, (capa.features.Feature, capa.engine.Range, capa.engine.Regex)):
             # when rending a structural node (and/or/not) then we only care about the node name.
             '''
             succs = list(filter(lambda c: bool(c), result.children))

--- a/capa/main.py
+++ b/capa/main.py
@@ -350,7 +350,7 @@ def render_result(res, indent=''):
                 print('%soptional:' % indent)
         else:
             print('%s%d or more' % (indent, res.statement.count))
-    elif not isinstance(res.statement, (capa.features.Feature, capa.engine.Element, capa.engine.Range, capa.engine.Regex)):
+    elif not isinstance(res.statement, (capa.features.Feature, capa.engine.Range, capa.engine.Regex)):
         # when rending a structural node (and/or/not),
         #  then we only care about the node name.
         #

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -24,7 +24,6 @@ BASIC_BLOCK_SCOPE = 'basic block'
 
 SUPPORTED_FEATURES = {
     FILE_SCOPE: set([
-        capa.engine.Element,
         capa.features.MatchedRule,
         capa.features.file.Export,
         capa.features.file.Import,
@@ -33,7 +32,6 @@ SUPPORTED_FEATURES = {
         capa.features.String,
     ]),
     FUNCTION_SCOPE: set([
-        capa.engine.Element,
         capa.features.MatchedRule,
         capa.features.insn.API,
         capa.features.insn.Number,
@@ -56,7 +54,6 @@ SUPPORTED_FEATURES = {
         capa.features.Characteristic('recursive call')
     ]),
     BASIC_BLOCK_SCOPE: set([
-        capa.engine.Element,
         capa.features.MatchedRule,
         capa.features.insn.API,
         capa.features.insn.Number,
@@ -180,8 +177,6 @@ def parse_feature(key):
         return capa.features.insn.Mnemonic
     elif key == 'basic blocks':
         return capa.features.basicblock.BasicBlock
-    elif key == 'element':
-        return Element
     elif key.startswith('characteristic(') and key.endswith(')'):
         characteristic = key[len('characteristic('):-len(')')]
         return lambda v: capa.features.Characteristic(characteristic, v)
@@ -311,9 +306,6 @@ def build_statements(d, scope):
                 if term in ('number', 'offset', 'bytes'):
                     value, symbol = parse_symbol(arg, term)
                     feature = Feature(value, symbol)
-                elif term in ('element'):
-                    arg = parse_int(arg)
-                    feature = Feature(arg)
                 else:
                     # arg is string, like:
                     #

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -3,14 +3,13 @@ import textwrap
 import pytest
 
 import capa.rules
-from capa.engine import Element
 from capa.features.insn import Number, Offset
 
 
 def test_rule_ctor():
-    r = capa.rules.Rule('test rule', capa.rules.FUNCTION_SCOPE, Element(1), {})
-    assert r.evaluate(set([0])) == False
-    assert r.evaluate(set([1])) == True
+    r = capa.rules.Rule('test rule', capa.rules.FUNCTION_SCOPE, Number(1), {})
+    assert r.evaluate({Number(0): {1}}) == False
+    assert r.evaluate({Number(1): {1}}) == True
 
 
 def test_rule_yaml():
@@ -25,14 +24,14 @@ def test_rule_yaml():
                     - bar5678
             features:
                 - and:
-                    - element: 1
-                    - element: 2
+                    - number: 1
+                    - number: 2
     ''')
     r = capa.rules.Rule.from_yaml(rule)
-    assert r.evaluate(set([0])) == False
-    assert r.evaluate(set([0, 1])) == False
-    assert r.evaluate(set([0, 1, 2])) == True
-    assert r.evaluate(set([0, 1, 2, 3])) == True
+    assert r.evaluate({Number(0): {1}}) == False
+    assert r.evaluate({Number(0): {1}, Number(1): {1}}) == False
+    assert r.evaluate({Number(0): {1}, Number(1): {1}, Number(2): {1}}) == True
+    assert r.evaluate({Number(0): {1}, Number(1): {1}, Number(2): {1}, Number(3): {1}}) == True
 
 
 def test_rule_yaml_complex():
@@ -43,18 +42,18 @@ def test_rule_yaml_complex():
             features:
                 - or:
                     - and:
-                        - element: 1
-                        - element: 2
+                        - number: 1
+                        - number: 2
                     - or:
-                        - element: 3
+                        - number: 3
                         - 2 or more:
-                            - element: 4
-                            - element: 5
-                            - element: 6
+                            - number: 4
+                            - number: 5
+                            - number: 6
     ''')
     r = capa.rules.Rule.from_yaml(rule)
-    assert r.evaluate(set([5, 6, 7, 8])) == True
-    assert r.evaluate(set([6, 7, 8])) == False
+    assert r.evaluate({Number(5): {1}, Number(6): {1}, Number(7): {1}, Number(8): {1}}) == True
+    assert r.evaluate({Number(6): {1}, Number(7): {1}, Number(8): {1}}) == False
 
 
 def test_rule_yaml_not():
@@ -64,13 +63,13 @@ def test_rule_yaml_not():
                     name: test rule
                 features:
                     - and:
-                        - element: 1
+                        - number: 1
                         - not:
-                            - element: 2
+                            - number: 2
         ''')
     r = capa.rules.Rule.from_yaml(rule)
-    assert r.evaluate(set([1])) == True
-    assert r.evaluate(set([1, 2])) == False
+    assert r.evaluate({Number(1): {1}}) == True
+    assert r.evaluate({Number(1): {1}, Number(2): {1}}) == False
 
 
 def test_rule_yaml_count():
@@ -79,12 +78,12 @@ def test_rule_yaml_count():
             meta:
                 name: test rule
             features:
-                - count(element(100)): 1
+                - count(number(100)): 1
     ''')
     r = capa.rules.Rule.from_yaml(rule)
-    assert r.evaluate({Element(100): {}}) == False
-    assert r.evaluate({Element(100): {1}}) == True
-    assert r.evaluate({Element(100): {1, 2}}) == False
+    assert r.evaluate({Number(100): {}}) == False
+    assert r.evaluate({Number(100): {1}}) == True
+    assert r.evaluate({Number(100): {1, 2}}) == False
 
 
 def test_rule_yaml_count_range():
@@ -93,13 +92,13 @@ def test_rule_yaml_count_range():
             meta:
                 name: test rule
             features:
-                - count(element(100)): (1, 2)
+                - count(number(100)): (1, 2)
     ''')
     r = capa.rules.Rule.from_yaml(rule)
-    assert r.evaluate({Element(100): {}}) == False
-    assert r.evaluate({Element(100): {1}}) == True
-    assert r.evaluate({Element(100): {1, 2}}) == True
-    assert r.evaluate({Element(100): {1, 2, 3}}) == False
+    assert r.evaluate({Number(100): {}}) == False
+    assert r.evaluate({Number(100): {1}}) == True
+    assert r.evaluate({Number(100): {1, 2}}) == True
+    assert r.evaluate({Number(100): {1, 2, 3}}) == False
 
 
 def test_invalid_rule_feature():
@@ -239,7 +238,7 @@ def test_invalid_rules():
                     meta:
                         name: test rule
                     features:
-                        - characteristic(count(element(100))): True
+                        - characteristic(count(number(100))): True
             '''))
 
 


### PR DESCRIPTION
The `Element` class is just used for testing. By using `Element` we are not testing the actual code. Also, every time we implement a new feature for the `Feature` class, we need to implement it for `Element` as well. Replace `Element` by `Integer`.

Closes https://github.com/fireeye/capa/issues/12
