### PR TITLE
adding new checks for file format limitations in capa explorer plugin

### DIFF
--- a/capa/ida/helpers/__init__.py
+++ b/capa/ida/helpers/__init__.py
@@ -3,7 +3,7 @@ import logging
 import idaapi
 import idc
 
-logger = logging.getLogger()
+logger = logging.getLogger('capa')
 
 # file type names as returned by idaapi.get_file_type_name()
 SUPPORTED_FILE_TYPES = [
@@ -19,33 +19,16 @@ def inform_user_ida_ui(message):
 
 def is_supported_file_type():
     file_type = idaapi.get_file_type_name()
-
     if file_type not in SUPPORTED_FILE_TYPES:
         logger.error('-' * 80)
         logger.error(' Input file does not appear to be a PE file.')
         logger.error(' ')
-        logger.error(' capa currently only supports analyzing PE files (or x86/AMD64 shellcode).')
+        logger.error(
+            ' capa currently only supports analyzing PE files (or binary files containing x86/AMD64 shellcode) with IDA.')
         logger.error(' If you don\'t know the input file type, you can try using the `file` utility to guess it.')
         logger.error('-' * 80)
-
         inform_user_ida_ui('capa does not support the format of this file')
-
         return False
-
-    # support binary files specifically for x86/AMD64 shellcode
-    # warn user binary file is loaded but still allow capa to process it
-    # TODO: check specific architecture of binary files based on how user configured IDA processors
-    if file_type == 'Binary file':
-        logger.warning('-' * 80)
-        logger.warning(' Input file appears to be a binary file.')
-        logger.warning(' ')
-        logger.warning(' capa currently only supports analyzing binary files containing x86/AMD64 shellcode.')
-        logger.warning(' This means the results may be misleading or incomplete if the binary file is not x86/AMD64.')
-        logger.warning(' If you don\'t know the input file type, you can try using the `file` utility to guess it.')
-        logger.warning('-' * 80)
-
-        inform_user_ida_ui('capa encountered warnings during analysis')
-
     return True
 
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -404,62 +404,57 @@ def appears_rule_cat(rules, capabilities, rule_cat):
     return False
 
 
-def is_file_limitation(rules, capabilities):
-    if appears_rule_cat(rules, capabilities, 'other-features/installer/'):
-        logger.warning('-' * 80)
-        logger.warning(' This sample appears to be an installer.')
-        logger.warning(' ')
-        logger.warning(' capa cannot handle installers well. This means the results may be misleading or incomplete.')
-        logger.warning(' You should try to understand the install mechanism and analyze created files with capa.')
-        logger.warning(' ')
-        logger.warning(' Use -v or -vv if you really want to see the capabilities identified by capa.')
-        logger.warning('-' * 80)
+def is_file_limitation(rules, capabilities, is_standalone=True):
+    file_limitations = {
         # capa will likely detect installer specific functionality.
         # this is probably not what the user wants.
-        return True
-
-    if appears_rule_cat(rules, capabilities, 'other-features/compiled-to-dot-net'):
-        logger.warning('-' * 80)
-        logger.warning(' This sample appears to be a .NET module.')
-        logger.warning(' ')
-        logger.warning(' .NET is a cross-platform framework for running managed applications.')
-        logger.warning(
-            ' capa cannot handle non-native files. This means that the results may be misleading or incomplete.')
-        logger.warning(' You may have to analyze the file manually, using a tool like the .NET decompiler dnSpy.')
-        logger.warning(' ')
-        logger.warning(' Use -v or -vv if you really want to see the capabilities identified by capa.')
-        logger.warning('-' * 80)
+        'other-features/installer/': [
+            ' This sample appears to be an installer.',
+            ' ',
+            ' capa cannot handle installers well. This means the results may be misleading or incomplete.'
+            ' You should try to understand the install mechanism and analyze created files with capa.'
+        ],
         # capa won't detect much in .NET samples.
         # it might match some file-level things.
         # for consistency, bail on things that we don't support.
-        return True
-
-    if appears_rule_cat(rules, capabilities, 'other-features/compiled-with-autoit'):
-        logger.warning('-' * 80)
-        logger.warning(' This sample appears to be compiled with AutoIt.')
-        logger.warning(' ')
-        logger.warning(' AutoIt is a freeware BASIC-like scripting language designed for automating the Windows GUI.')
-        logger.warning(
-            ' capa cannot handle AutoIt scripts. This means that the results will be misleading or incomplete.')
-        logger.warning(' You may have to analyze the file manually, using a tool like the AutoIt decompiler MyAut2Exe.')
-        logger.warning(' ')
-        logger.warning(' Use -v or -vv if you really want to see the capabilities identified by capa.')
-        logger.warning('-' * 80)
+        'other-features/compiled-to-dot-net': [
+            ' This sample appears to be a .NET module.',
+            ' ',
+            ' .NET is a cross-platform framework for running managed applications.',
+            ' capa cannot handle non-native files. This means that the results may be misleading or incomplete.',
+            ' You may have to analyze the file manually, using a tool like the .NET decompiler dnSpy.'
+        ],
         # capa will detect dozens of capabilities for AutoIt samples,
         # but these are due to the AutoIt runtime, not the payload script.
         # so, don't confuse the user with FP matches - bail instead
-        return True
+        'other-features/compiled-with-autoit': [
+            ' This sample appears to be compiled with AutoIt.',
+            ' ',
+            ' AutoIt is a freeware BASIC-like scripting language designed for automating the Windows GUI.',
+            ' capa cannot handle AutoIt scripts. This means that the results will be misleading or incomplete.',
+            ' You may have to analyze the file manually, using a tool like the AutoIt decompiler MyAut2Exe.'
+        ],
+        # capa won't detect much in packed samples
+        'anti-analysis/packing/': [
+            ' This sample appears to be packed.',
+            ' ',
+            ' Packed samples have often been obfuscated to hide their logic.',
+            ' capa cannot handle obfuscation well. This means the results may be misleading or incomplete.',
+            ' If possible, you should try to unpack this input file before analyzing it with capa.'
+        ]
+    }
 
-    if appears_rule_cat(rules, capabilities, 'anti-analysis/packing/'):
+    for category, dialogue in file_limitations.items():
+        if not appears_rule_cat(rules, capabilities, category):
+            continue
         logger.warning('-' * 80)
-        logger.warning(' This sample appears packed.')
-        logger.warning(' ')
-        logger.warning(' Packed samples have often been obfuscated to hide their logic.')
-        logger.warning(' capa cannot handle obfuscation well. This means the results may be misleading or incomplete.')
-        logger.warning(' If possible, you should try to unpack this input file before analyzing it with capa.')
+        for line in dialogue:
+            logger.warning(line)
+        if is_standalone:
+            logger.warning(' ')
+            logger.warning(' Use -v or -vv if you really want to see the capabilities identified by capa.')
         logger.warning('-' * 80)
         return True
-
     return False
 
 
@@ -738,6 +733,10 @@ def ida_main():
     logging.basicConfig(level=logging.INFO)
     logging.getLogger().setLevel(logging.INFO)
 
+    import capa.ida.helpers
+    if not capa.ida.helpers.is_supported_file_type():
+        return -1
+
     logger.info('-' * 80)
     logger.info(' Using default embedded rules.')
     logger.info(' ')
@@ -761,11 +760,7 @@ def ida_main():
     import capa.features.extractors.ida
     capabilities = find_capabilities(rules, capa.features.extractors.ida.IdaFeatureExtractor())
 
-    import capa.ida.helpers
-    if not capa.ida.helpers.is_supported_file_type():
-        return -1
-
-    if is_file_limitation(rules, capabilities):
+    if is_file_limitation(rules, capabilities, is_standalone=False):
         capa.ida.helpers.inform_user_ida_ui('capa encountered warnings during analysis')
 
     render_capabilities_default(rules, capabilities)
@@ -774,7 +769,6 @@ def ida_main():
 def is_runtime_ida():
     try:
         import idc
-        import idaapi
     except ImportError:
         return False
     else:


### PR DESCRIPTION
Added checks and dialog for file limitations when processing binaries with IDA.

![snip](https://user-images.githubusercontent.com/42192796/85635863-32839a80-b63c-11ea-8a5f-e7e37fb1f292.png)