### PR TITLE
Fix KeyError when deleting nonexistent keys

### DIFF
--- a/capa/rules.py
+++ b/capa/rules.py
@@ -590,10 +590,11 @@ class Rule(object):
         # save off the existing hidden meta values,
         # emit the document,
         # and re-add the hidden meta.
-        hidden_meta = {
-            key: meta.get(key)
-            for key in HIDDEN_META_KEYS
-        }
+        hidden_meta = {}
+        for key in HIDDEN_META_KEYS:
+            value = meta.get(key)
+            if value:
+                hidden_meta[key] = value
 
         for key in hidden_meta.keys():
             del meta[key]


### PR DESCRIPTION
`hidden_meta` saves not only the existing hidden meta keys, but also those who don't exist with value `None`. For example:
```
{'capa/path': None, 'capa/nursery': None}
```

Deleting nonexistent keys raises a `KeyError` exception. Tests fail.