### PR TITLE
Python 3 serialization changes

### DIFF
--- a/capa/features/__init__.py
+++ b/capa/features/__init__.py
@@ -1,11 +1,19 @@
 import codecs
 import logging
+import sys
 
 import capa.engine
 
 
 logger = logging.getLogger(__name__)
 MAX_BYTES_FEATURE_SIZE = 0x100
+
+
+def bytes_to_str(b):
+    if sys.version_info[0] >= 3:
+        return str(codecs.encode(b, 'hex').decode('utf-8'))
+    else:
+        return codecs.encode(b, 'hex')
 
 
 class Feature(object):
@@ -100,14 +108,14 @@ class Bytes(Feature):
 
     def __str__(self):
         if self.symbol:
-            return 'bytes(0x%s = %s)' % (codecs.encode(self.value, 'hex').upper(), self.symbol)
+            return 'bytes(0x%s = %s)' % (bytes_to_str(self.value).upper(), self.symbol)
         else:
-            return 'bytes(0x%s)' % (codecs.encode(self.value, 'hex').upper())
+            return 'bytes(0x%s)' % (bytes_to_str(self.value).upper())
 
     def freeze_serialize(self):
         return (self.__class__.__name__,
-                map(lambda x: codecs.encode(x, 'hex').upper(), self.args))
+                [bytes_to_str(x).upper() for x in self.args])
 
     @classmethod
     def freeze_deserialize(cls, args):
-        return cls(*map(lambda x: codecs.decode(x, 'hex'), args))
+        return cls(*[codecs.decode(x, 'hex') for x in args])

--- a/capa/render/__init__.py
+++ b/capa/render/__init__.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 import capa.engine
 
@@ -261,7 +262,7 @@ def render_default(rules, capabilities):
 
 class CapaJsonObjectEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, (list, dict, str, unicode, int, float, bool, type(None))):
+        if isinstance(obj, (list, dict, int, float, bool, type(None))) or isinstance(obj, six.string_types):
             return json.JSONEncoder.default(self, obj)
         elif isinstance(obj, set):
             return list(sorted(obj))


### PR DESCRIPTION
Changes were made to fix errors that were encountered while running the IDA plugin with Python 3. There errors occurred as a result of the incompatible de/serialization of the `Bytes` feature and use of the `unicode` keyword (deprecated Python 3).