### PR TITLE
Fix unrestored stashed changes in post-commit hook

### DIFF
--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -18,7 +18,6 @@ if [ $? == 0 ]; then
 else
   echo 'Style checker failed 😭';
   echo 'Check style-checker-output.log for details';
-  exit 1;
 fi
 
 # Run rule linter and print state (it doesn't block the commit)
@@ -28,7 +27,6 @@ if [ $? == 0 ]; then
 else
   echo 'Rule linter failed 😭';
   echo 'Check rule-linter-output.log for details';
-  exit 2;
 fi
 
 # Restore stashed changes


### PR DESCRIPTION
If the style checker of the rule linter failed, the stashed changes were not restored. There is no reason to exist with an error code in a post hook. In pre hooks this causes the action to be aborted.

Note that if you manually abort while the hook is running, the stashed changes are still not restored (as the code to restore them is not executed). But there is a warning printing the message used to stash the changes in case it is needed to restore it manually:

```
"Uncommited changes stashed with message '$MSG', if you abort before they are restored run \`git stash pop\`"
```

With `git stash list` you should be able to see the unrestored changes in that case. Something like:
`stash@{0}: On ana-description: post-commit-1593425589`

And then restore the right index with `git stash pop`

Fixes https://github.com/fireeye/capa/issues/32