### PR TITLE
fix bug when rendering bytes feature in vverbose

### DIFF
--- a/capa/render/utils.py
+++ b/capa/render/utils.py
@@ -17,6 +17,11 @@ def hex(n):
     return '0x%X' % n
 
 
+def hex_string(h):
+    """ render hex string e.g. "0a40b1" as "0A 40 B1" """
+    return ' '.join(h[i:i + 2] for i in range(0, len(h), 2)).upper()
+
+
 def capability_rules(doc):
     """enumerate the rules in (namespace, name) order that are 'capability' rules (not lib/subscope/disposition/etc)."""
     for (_, _, rule) in sorted(map(lambda rule: (rule['meta'].get('namespace', ''), rule['meta']['name'], rule), doc.values())):

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -22,10 +22,12 @@ def render_statement(ostream, statement, indent=0):
         # so, we have to inline some of the feature rendering here.
 
         child = statement['child']
-        if child['type'] in ('string', 'bytes', 'api', 'mnemonic', 'basic block', 'export', 'import', 'section', 'match'):
+        if child['type'] in ('string', 'api', 'mnemonic', 'basic block', 'export', 'import', 'section', 'match'):
             feature = '%s(%s)' % (child['type'], rutils.bold2(child[child['type']]))
         elif child['type'] in ('number', 'offset'):
             feature = '%s(%s)' % (child['type'], rutils.bold2(rutils.hex(child[child['type']])))
+        elif child['type'] == 'bytes':
+            feature = '%s(%s)' % (child['type'], rutils.bold2(rutils.hex_string(child[child['type']])))
         elif child['type'] == 'characteristic':
             feature = 'characteristic(%s)' % (rutils.bold2(child['characteristic'][0]))
         else:
@@ -68,10 +70,7 @@ def render_feature(ostream, match, feature, indent=0):
         ostream.write('bytes: ')
         # bytes is the uppercase, hex-encoded string.
         # it should always be an even number of characters (its hex).
-        bytes = feature['bytes']
-        for i in range(len(bytes) // 2):
-            ostream.write(rutils.bold2(bytes[i:i + 2]))
-            ostream.write(' ')
+        ostream.write(rutils.bold2(rutils.hex_string(feature[feature['type']])))
     elif feature['type'] == 'characteristic':
         ostream.write('characteristic(%s)' % (rutils.bold2(feature['characteristic'][0])))
     # note that regex is found in `render_statement`


### PR DESCRIPTION
Fixes bug in rendering of `bytes` feature in vverbose mode. Previous implementation cut characters from the original hex string.

Before fix:
```
create shortcut via IShellLink
namespace   host-interaction/file-system/write
author      matthew.williams@fireeye.com
scope       function
references  https://docs.microsoft.com/en-us/windows/win32/shell/links#creating-a-shortcut-and-a-folder-shortcut-to-a-file
function @ 0x46BBA6
  and:
    bytes: 01 11 14 40 02 20 00 00 00 00 00 00 00 00 00 0C  @ 0x46BC3A
    or:
      bytes: F9 91 14 40 02 20 00 00 00 00 00 00 00 00 00 0C  @ 0x46BC31
    bytes: 0B B0 01 10 00 00 00 00 00 00 00 00 00 00 00 0C  @ 0x46BE26
    offset: 0x50 @ 0x46BC82
    offset: 0x18 @ 0x46BD26, 0x46BE43
    api: ole32.CoCreateInstance @ 0x46BC3F
```

After fix:
```
create shortcut via IShellLink
namespace   host-interaction/file-system/write
author      matthew.williams@fireeye.com
scope       function
references  https://docs.microsoft.com/en-us/windows/win32/shell/links#creating-a-shortcut-and-a-folder-shortcut-to-a-file
function @ 0x46BBA6
  and:
    bytes: 01 14 02 00 00 00 00 00 C0 00 00 00 00 00 00 46 @ 0x46BC3A
    or:
      bytes: F9 14 02 00 00 00 00 00 C0 00 00 00 00 00 00 46 @ 0x46BC31
    bytes: 0B 01 00 00 00 00 00 00 C0 00 00 00 00 00 00 46 @ 0x46BE26
    offset: 0x50 @ 0x46BC82
    offset: 0x18 @ 0x46BD26, 0x46BE43
    api: ole32.CoCreateInstance @ 0x46BC3F
```