### PR TITLE
capa explorer: add subscope item type

### DIFF
--- a/capa/ida/explorer/item.py
+++ b/capa/ida/explorer/item.py
@@ -184,6 +184,14 @@ class CapaExplorerFunctionItem(CapaExplorerDataItem):
         self._data[0] = self.fmt % display
 
 
+class CapaExplorerSubscopeItem(CapaExplorerDataItem):
+
+    fmt = 'subscope(%s)'
+
+    def __init__(self, parent, scope):
+        super(CapaExplorerSubscopeItem, self).__init__(parent, [self.fmt % scope, '', ''])
+
+
 class CapaExplorerBlockItem(CapaExplorerDataItem):
     """ store data relevant to capa basic block result """
 

--- a/capa/ida/explorer/model.py
+++ b/capa/ida/explorer/model.py
@@ -16,7 +16,8 @@ from capa.ida.explorer.item import (
     CapaExplorerByteViewItem,
     CapaExplorerBlockItem,
     CapaExplorerRuleMatchItem,
-    CapaExplorerFeatureItem
+    CapaExplorerFeatureItem,
+    CapaExplorerSubscopeItem
 )
 
 import capa.ida.helpers
@@ -105,7 +106,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
 
         if role == QtCore.Qt.FontRole and isinstance(item, (CapaExplorerRuleItem, CapaExplorerRuleMatchItem,
                                                             CapaExplorerBlockItem, CapaExplorerFunctionItem,
-                                                            CapaExplorerFeatureItem)) and \
+                                                            CapaExplorerFeatureItem, CapaExplorerSubscopeItem)) and \
                 column == CapaExplorerDataModel.COLUMN_INDEX_RULE_INFORMATION:
             # set bold font for top-level rules
             font = QtGui.QFont()
@@ -334,7 +335,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
 
             return CapaExplorerFeatureItem(parent, display=display)
         elif statement['type'] == 'subscope':
-            return CapaExplorerFeatureItem(parent, 'subscope(%s)' % statement['subscope'])
+            return CapaExplorerSubscopeItem(parent, statement['subscope'])
         elif statement['type'] == 'regex':
             # regex is a `Statement` not a `Feature`
             # this is because it doesn't get extracted, but applies to all strings in scope.


### PR DESCRIPTION
Adding subscope item type to help render subscope like functions, basic blocks, rules, and rule matches.

![Capture](https://user-images.githubusercontent.com/42192796/86284560-5432d380-bba0-11ea-8d5b-0cf45ea5d633.PNG)
