### PR TITLE
Fix KeyError in Range#evaluate()

### DIFF
--- a/capa/engine.py
+++ b/capa/engine.py
@@ -158,7 +158,7 @@ class Range(Statement):
         if self.min == 0 and count == 0:
             return Result(True, self, [])
 
-        return Result(self.min <= count <= self.max, self, [], locations=ctx[self.child])
+        return Result(self.min <= count <= self.max, self, [], locations=ctx.get(self.child))
 
     def __str__(self):
         if self.max == (1 << 64 - 1):


### PR DESCRIPTION
If the key doesn't exist, `evaluate` raises a `KeyError` Exception, making the tests fail.