### PR TITLE
 Document how to install development dependencies

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -55,6 +55,8 @@ If you are using zsh, do not forget to escape the square brackets:
 
 `$ pip install -e ./local/path/to/src\[dev\]`
 
+Note that some development dependencies require Python3.
+
 ### 4. Setup hooks [optional]
 
 If you plan to contribute to capa, you may want to setup the hooks.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,13 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        "dev": ["pytest", "pytest-sugar", "pytest-instafail", "pytest-cov", "pycodestyle", "black", "isort"]
+        "dev": ["pytest",
+                "pytest-sugar",
+                "pytest-instafail",
+                "pytest-cov",
+                "pycodestyle",
+                "black ; python_version>'3.0'",
+                "isort"]
     },
     zip_safe=False,
     keywords="capa",


### PR DESCRIPTION
- Document how to install development dependencies, introduced on d1dd997
- Add Python3 requirement for black 