### PR TITLE
capa explorer: bug fix for #93

### DIFF
--- a/capa/features/extractors/__init__.py
+++ b/capa/features/extractors/__init__.py
@@ -1,18 +1,5 @@
 import abc
 
-try:
-    import ida
-except (ImportError, SyntaxError):
-    pass
-
-try:
-    import viv
-except (ImportError, SyntaxError):
-    pass
-
-__all__ = ["ida", "viv"]
-
-
 class FeatureExtractor(object):
     """
     FeatureExtractor defines the interface for fetching features from a sample.

--- a/capa/features/extractors/ida/__init__.py
+++ b/capa/features/extractors/ida/__init__.py
@@ -5,9 +5,9 @@ import idaapi
 
 import capa.features.extractors.ida.file
 import capa.features.extractors.ida.insn
-import capa.features.extractors.ida.helpers
 import capa.features.extractors.ida.function
 import capa.features.extractors.ida.basicblock
+
 from capa.features.extractors import FeatureExtractor
 
 
@@ -51,7 +51,8 @@ class IdaFeatureExtractor(FeatureExtractor):
             yield feature, va
 
     def get_functions(self):
-        for f in capa.features.extractors.ida.helpers.get_functions(ignore_thunks=True, ignore_libs=True):
+        import capa.features.extractors.ida.helpers as ida_helpers
+        for f in ida_helpers.get_functions(ignore_thunks=True, ignore_libs=True):
             yield add_va_int_cast(f)
 
     def extract_function_features(self, f):
@@ -67,7 +68,8 @@ class IdaFeatureExtractor(FeatureExtractor):
             yield feature, va
 
     def get_instructions(self, f, bb):
-        for insn in capa.features.extractors.ida.helpers.get_instructions_in_range(bb.start_ea, bb.end_ea):
+        import capa.features.extractors.ida.helpers as ida_helpers
+        for insn in ida_helpers.get_instructions_in_range(bb.start_ea, bb.end_ea):
             yield add_va_int_cast(insn)
 
     def extract_insn_features(self, f, bb, insn):


### PR DESCRIPTION
Addresses #93 - tested IDA 7.4, Python 3.7.8 and IDA 7.5, Python 3.7.8/2.7.16.

Apparently IDA 7.5 likes to complain about import issues more than IDA 7.4. I believe this bug is a symptom of a larger problem of circular imports found in capa e.g. `capa.engine` imports `capa.features` and `capa.features` imports `capa.engine`.

At some point it may be worth taking a closer look at code refactoring in order to address/remove additional circular imports that may exist.