### PR TITLE
capa explorer: add support for "basicblock" feature

### DIFF
--- a/capa/ida/explorer/model.py
+++ b/capa/ida/explorer/model.py
@@ -530,6 +530,9 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                 parent, display, source=doc["rules"].get(feature[feature["type"]], {}).get("source", "")
             )
 
+        if feature["type"] == "basicblock":
+            return CapaExplorerBlockItem(parent, location)
+
         if feature["type"] in instruction_view:
             return CapaExplorerInstructionViewItem(parent, display, location)
 


### PR DESCRIPTION
Addresses bug introduced by #83 which resulted in a new feature called `basicblock`.