### PR TITLE
Fix description

### DIFF
--- a/capa/rules.py
+++ b/capa/rules.py
@@ -224,7 +224,7 @@ def parse_description(s, value_type, description=None):
                 'unexpected value: "%s", only one description allowed (inline description with `%s`)'
                 % (s, DESCRIPTION_SEPARATOR)
             )
-        value, _, description = s.rpartition(DESCRIPTION_SEPARATOR)
+        value, _, description = s.partition(DESCRIPTION_SEPARATOR)
         if description == "":
             raise InvalidRule('unexpected value: "%s", description cannot be empty' % s)
     else:


### PR DESCRIPTION
@williballenthin I am not sure what you meant with:
`use rpartition instead of split(..., 1) to better express intent`
But this breaks the description feature. Tests are failing. I think maybe you meant `partition`:

```
s = 'number: 4 = I am a description with an = yes'
s.rpartition(' = ') => ('4 = I am a description with an', ' = ', 'yes')
s.partition(' = ') => ('4', ' = ', 'I am a description with an = yes')
s.split(' = ', 1) => ['4', 'I am a description with an = yes']
```

Otherwise we can't support `=` in the description, which I think we agreed we wanted to do.