### PR TITLE
doc: add usage examples

### DIFF
--- a/capa/main.py
+++ b/capa/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 """
-capa - detect capabilities in programs.
+identify capabilities in programs.
 """
 import os
 import sys
@@ -8,6 +8,7 @@ import hashlib
 import logging
 import os.path
 import datetime
+import textwrap
 import collections
 
 import tqdm
@@ -382,7 +383,26 @@ def main(argv=None):
     ]
     format_help = ", ".join(["%s: %s" % (f[0], f[1]) for f in formats])
 
-    parser = argparse.ArgumentParser(description="detect capabilities in programs.")
+    epilog = textwrap.dedent("""
+                examples:
+                  identify capabilities in a binary
+                    capa suspicous.exe
+
+                  identify capabilities in 32-bit shellcode, see `-f` for all supported formats
+                    capa -f sc32 shellcode.bin
+
+                  report match locations
+                    capa -v suspicous.exe
+
+                  report all feature match details
+                    capa -vv suspicious.exe
+
+                  filter rules by meta fields, e.g. rule name or namespace
+                    capa -t <rule name> suspicious.exe
+                 """)
+
+    parser = argparse.ArgumentParser(description=__doc__, epilog=epilog,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("sample", type=str, help="Path to sample to analyze")
     parser.add_argument(
         "-r",


### PR DESCRIPTION
```
$ capa -h
usage: capa [-h] [-r RULES] [-t TAG] [--version] [-j] [-v] [-vv] [-d] [-q]
            [--color {auto,always,never}] [-f {auto,pe,sc32,sc64,freeze}]
            sample

identify capabilities in programs.

positional arguments:
  sample                Path to sample to analyze

optional arguments:
  -h, --help            show this help message and exit
  -r RULES, --rules RULES
                        Path to rule file or directory, use embedded rules by
                        default
  -t TAG, --tag TAG     Filter on rule meta field values
  --version             Print the executable version and exit
  -j, --json            Emit JSON instead of text
  -v, --verbose         Enable verbose result document (no effect with --json)
  -vv, --vverbose       Enable very verbose result document (no effect with
                        --json)
  -d, --debug           Enable debugging output on STDERR
  -q, --quiet           Disable all output but errors
  --color {auto,always,never}
                        Enable ANSI color codes in results, default: only
                        during interactive session
  -f {auto,pe,sc32,sc64,freeze}, --format {auto,pe,sc32,sc64,freeze}
                        Select sample format, auto: (default) detect file type
                        automatically, pe: Windows PE file, sc32: 32-bit
                        shellcode, sc64: 64-bit shellcode, freeze: features
                        previously frozen by capa

examples:
  identify capabilities in a binary
    capa suspicous.exe

  identify capabilities in 32-bit shellcode, see `-f` for all supported formats
    capa -f sc32 shellcode.bin

  report match locations
    capa -v suspicous.exe

  report all feature match details
    capa -vv suspicious.exe

  filter rules by meta fields, e.g. rule name or namespace
    capa -t <rule name> suspicious.exe

```