### PR TITLE
bug fix: remove lazy map() eval

### DIFF
--- a/capa/features/extractors/ida/function.py
+++ b/capa/features/extractors/ida/function.py
@@ -36,7 +36,8 @@ def extract_function_loop(f):
 
     # construct control flow graph
     for bb in idaapi.FlowChart(f):
-        map(lambda s: edges.append((bb.start_ea, s.start_ea)), bb.succs())
+        for succ in bb.succs():
+            edges.append((bb.start_ea, succ.start_ea))
 
     if loops.has_loop(edges):
         yield Characteristic("loop"), f.start_ea


### PR DESCRIPTION
Closes #101. Use of `map()` causes loop detection to fail in IDA extractor when running under Python 3.