### PR TITLE
Test all supported Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,10 @@ jobs:
       matrix:
         include:
           - python: 2.7
+          - python: 3.6
+          - python: 3.7
           - python: 3.8
+          - python: '3.9.0-alpha - 3.9.x' # Python latest
     steps:
     - name: Checkout capa with submodules
       uses: actions/checkout@v2


### PR DESCRIPTION
Use a matrix with the Python version to avoid duplication when testing different Python versions, as suggested in https://github.com/fireeye/capa/pull/239/files#r474523055. :bowtie: 

I assume once we migrate to Python3, we want to support Python 3.6-9. Python 3.5 will stop receiving security fixes next month, so I don't think we need to support it.

As running the test as many times as we want is free and easy to implement, run them for all supported versions to ensure capa work in all of them. 😄 


![Screen Shot 2020-08-21 at 15 46 25](https://user-images.githubusercontent.com/16052290/90897484-7b9a6580-e3c5-11ea-97b0-80182024a3a6.png)