### PR TITLE
setup: bump viv-utils to v0.6.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Install dependencies
       run: pip install -e .[dev]
     - name: Lint with isort
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Install capa
       run: pip install -e .
     - name: Run rule linter
@@ -65,15 +65,15 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         # across all operating systems
-        python-version: [3.6, 3.10]
+        python-version: ["3.6", "3.10"]
         include:
           # on Ubuntu run these as well
           - os: ubuntu-20.04
-            python-version: 3.7
+            python-version: "3.7"
           - os: ubuntu-20.04
-            python-version: 3.8
+            python-version: "3.8"
           - os: ubuntu-20.04
-            python-version: 3.9
+            python-version: "3.9"
     steps:
     - name: Checkout capa with submodules
       uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,13 +65,15 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         # across all operating systems
-        python-version: [3.6, 3.9]
+        python-version: [3.6, 3.10]
         include:
           # on Ubuntu run these as well
           - os: ubuntu-20.04
             python-version: 3.7
           - os: ubuntu-20.04
             python-version: 3.8
+          - os: ubuntu-20.04
+            python-version: 3.9
     steps:
     - name: Checkout capa with submodules
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - engine: short circuit logic nodes for better performance #824 @williballenthin
 - engine: add optimizer the order faster nodes first #829 @williballenthin
 - engine: optimize rule evaluation by skipping rules that can't match #830 @williballenthin
+- support python 3.10 #816 @williballenthin
+- support aarch64 #683
 
 ### Breaking Changes
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "termcolor==1.1.0",
     "wcwidth==0.2.5",
     "ida-settings==2.1.0",
-    "viv-utils[flirt]==0.6.8",
+    "viv-utils[flirt]==0.6.9",
     "halo==0.0.31",
     "networkx==2.5.1",
     "ruamel.yaml==0.17.17",


### PR DESCRIPTION
viv-utils v0.6.9 depends on python-flirt v0.7.0 that adds:
  - python 3.10 builds
  - aarch64 and armv7 builds
  - macOS universal2 and x86_64 builds

closes #816 
closes #683 

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
