### PR TITLE
types: Add assert_never for exhaustivenes checking with mypy

### DIFF
--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -7,6 +7,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import os
+from typing import NoReturn
 
 _hex = hex
 
@@ -30,3 +31,7 @@ def is_runtime_ida():
         return False
     else:
         return True
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    assert False, f'Unhandled value: {value} ({type(value).__name__})'

--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -34,4 +34,4 @@ def is_runtime_ida():
 
 
 def assert_never(value: NoReturn) -> NoReturn:
-    assert False, f'Unhandled value: {value} ({type(value).__name__})'
+    assert False, f"Unhandled value: {value} ({type(value).__name__})"

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -1202,6 +1202,7 @@ class RuleSet:
         this routine should act just like `capa.engine.match`,
         except that it may be more performant.
         """
+        easy_rules_by_feature = {}
         if scope is Scope.FILE:
             easy_rules_by_feature = self._easy_file_rules_by_feature
             hard_rule_names = self._hard_file_rules

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -1187,13 +1187,13 @@ class RuleSet:
         this routine should act just like `capa.engine.match`,
         except that it may be more performant.
         """
-        if scope == scope.FILE:
+        if scope is Scope.FILE:
             easy_rules_by_feature = self._easy_file_rules_by_feature
             hard_rule_names = self._hard_file_rules
-        elif scope == scope.FUNCTION:
+        elif scope is Scope.FUNCTION:
             easy_rules_by_feature = self._easy_function_rules_by_feature
             hard_rule_names = self._hard_function_rules
-        elif scope == scope.BASIC_BLOCK:
+        elif scope is Scope.BASIC_BLOCK:
             easy_rules_by_feature = self._easy_basic_block_rules_by_feature
             hard_rule_names = self._hard_basic_block_rules
         else:

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -1090,6 +1090,21 @@ class RuleSet:
             elif isinstance(node, (ceng.And, ceng.Or, ceng.Some)):
                 for child in node.children:
                     rec(rule_name, child)
+            elif isinstance(node, ceng.Statement):
+                # unhandled type of statement.
+                # this should only happen if a new subtype of `Statement`
+                # has since been added to capa.
+                #
+                # ideally, we'd like to use mypy for exhaustiveness checking
+                # for all the subtypes of `Statement`.
+                # but, as far as i can tell, mypy does not support this type
+                # of checking.
+                #
+                # in a way, this makes some intuitive sense:
+                # the set of subtypes of type A is unbounded,
+                # because any user might come along and create a new subtype B,
+                # so mypy can't reason about this set of types.
+                assert False, f"Unhandled value: {node} ({type(node).__name__})"
             else:
                 # programming error
                 assert_never(node)

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -16,6 +16,8 @@ import functools
 import collections
 from enum import Enum
 
+from capa.helpers import assert_never
+
 try:
     from functools import lru_cache
 except ImportError:
@@ -1090,7 +1092,7 @@ class RuleSet:
                     rec(rule_name, child)
             else:
                 # programming error
-                raise Exception("programming error: unexpected node type: %s" % (node))
+                assert_never(node)
 
         for rule in rules:
             rule_name = rule.meta["name"]
@@ -1195,7 +1197,7 @@ class RuleSet:
             easy_rules_by_feature = self._easy_basic_block_rules_by_feature
             hard_rule_names = self._hard_basic_block_rules
         else:
-            raise Exception("programming error: unexpected scope")
+            assert_never(scope)
 
         candidate_rule_names = set()
         for feature in features:


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
This PR addresses issue #835, and should help with exhaustiveness checking for types. Running `mypy capa/rules.py` showed no errors before I made these changes.

Output of `mypy capa/rules.py` after change:
```
capa/rules.py:1095: error: Argument 1 to "assert_never" has incompatible type "Statement"; expected "NoReturn"
capa/rules.py:1200: error: Argument 1 to "assert_never" has incompatible type "Scope"; expected "NoReturn"
Found 2 errors in 1 file (checked 1 source file)
```
### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
