### PR TITLE
support maec/malware-family meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - engine: optimize rule evaluation by skipping rules that can't match #830 @williballenthin
 - support python 3.10 #816 @williballenthin
 - support aarch64 #683
+- rules: support maec/malware-family meta #841 @mr-tz
 
 ### Breaking Changes
 

--- a/capa/render/utils.py
+++ b/capa/render/utils.py
@@ -60,6 +60,8 @@ def capability_rules(doc):
             continue
         if rule["meta"].get("maec/analysis-conclusion-ov"):
             continue
+        if rule["meta"].get("maec/malware-family"):
+            continue
         if rule["meta"].get("maec/malware-category"):
             continue
         if rule["meta"].get("maec/malware-category-ov"):

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -51,6 +51,7 @@ META_KEYS = (
     "rule-category",
     "maec/analysis-conclusion",
     "maec/analysis-conclusion-ov",
+    "maec/malware-family",
     "maec/malware-category",
     "maec/malware-category-ov",
     "author",


### PR DESCRIPTION
closes #841 

see https://github.com/mandiant/capa-rules/pull/515

note: none of the `maec/*` fields is displayed and the so tagged rules are not shown as capability rules.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
