### PR TITLE
capa explorer: updating supported IDA versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### capa explorer IDA Pro plugin
 
+- pin supported versions to >= 7.4 and < 8.0 #849 @mike-hunhoff
+
 ### Development
 
 - add profiling infrastructure #828 @williballenthin

--- a/capa/ida/helpers.py
+++ b/capa/ida/helpers.py
@@ -21,13 +21,6 @@ import capa.features.common
 
 logger = logging.getLogger("capa")
 
-# IDA version as returned by idaapi.get_kernel_version()
-SUPPORTED_IDA_VERSIONS = (
-    "7.4",
-    "7.5",
-    "7.6",
-)
-
 # file type as returned by idainfo.file_type
 SUPPORTED_FILE_TYPES = (
     idaapi.f_PE,
@@ -45,13 +38,11 @@ def inform_user_ida_ui(message):
 
 
 def is_supported_ida_version():
-    version = idaapi.get_kernel_version()
-    if version not in SUPPORTED_IDA_VERSIONS:
+    version = float(idaapi.get_kernel_version())
+    if version < 7.4 or version >= 8:
         warning_msg = "This plugin does not support your IDA Pro version"
         logger.warning(warning_msg)
-        logger.warning(
-            "Your IDA Pro version is: %s. Supported versions are: %s." % (version, ", ".join(SUPPORTED_IDA_VERSIONS))
-        )
+        logger.warning("Your IDA Pro version is: %s. Supported versions are: IDA >= 7.4 and IDA < 8.0." % version)
         return False
     return True
 

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -39,6 +39,7 @@ capa explorer supports Python versions >= 3.6.x and the following IDA Pro versio
 * IDA 7.4
 * IDA 7.5
 * IDA 7.6 (caveat below)
+* IDA 7.7
 
 capa explorer is however limited to the Python versions supported by your IDA installation (which may not include all Python versions >= 3.6.x). Based on our testing the following matrix shows the Python versions supported
 by each supported IDA version:


### PR DESCRIPTION
fixes #845. pinning supported IDA version to IDA >= 7.4 and IDA < 8.0.