### PR TITLE
smda: fix negative number extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### Bug Fixes
 
 - fix circular import error #825 @williballenthin
+- fix smda negative number extraction #430 @kn0wl3dge
 
 ### capa explorer IDA Pro plugin
 

--- a/capa/features/extractors/smda/insn.py
+++ b/capa/features/extractors/smda/insn.py
@@ -84,8 +84,12 @@ def extract_insn_number_features(f, bb, insn):
         return
     for operand in operands:
         try:
-            yield Number(int(operand, 16)), insn.offset
-            yield Number(int(operand, 16), bitness=get_bitness(f.smda_report)), insn.offset
+            # The result of bitwise operations is calculated as though carried out
+            # in two’s complement with an infinite number of sign bits
+            value = int(operand, 16) & ((1 << f.smda_report.bitness) - 1)
+
+            yield Number(value), insn.offset
+            yield Number(value, bitness=get_bitness(f.smda_report)), insn.offset
         except:
             continue
 

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -86,7 +86,7 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     parser = argparse.ArgumentParser(description="Show the features that capa extracts from the given sample")
-    capa.main.install_common_args(parser, wanted={"format", "sample", "signatures"})
+    capa.main.install_common_args(parser, wanted={"format", "sample", "signatures", "backend"})
 
     parser.add_argument("-F", "--function", type=lambda x: int(x, 0x10), help="Show features for specific function")
     args = parser.parse_args(args=argv)
@@ -111,7 +111,7 @@ def main(argv=None):
         should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
         try:
             extractor = capa.main.get_extractor(
-                args.sample, args.format, capa.main.BACKEND_VIV, sig_paths, should_save_workspace
+                args.sample, args.format, args.backend, sig_paths, should_save_workspace
             )
         except capa.main.UnsupportedFormatError:
             logger.error("-" * 80)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -413,6 +413,7 @@ FEATURE_PRESENCE_TESTS = sorted(
         # insn/number
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xFF), True),
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0x3136B0), True),
+        ("mimikatz", "function=0x401000", capa.features.insn.Number(0x0), True),
         # insn/number: stack adjustments
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xC), False),
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0x10), False),
@@ -420,6 +421,9 @@ FEATURE_PRESENCE_TESTS = sorted(
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xFF), True),
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xFF, bitness=BITNESS_X32), True),
         ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xFF, bitness=BITNESS_X64), False),
+        # insn/number: negative
+        ("mimikatz", "function=0x401553", capa.features.insn.Number(0xFFFFFFFF), True),
+        ("mimikatz", "function=0x43e543", capa.features.insn.Number(0xFFFFFFF0), True),
         # insn/offset
         ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x0), True),
         ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x4), True),


### PR DESCRIPTION
SMDA extractor is extracting negative Number features as described in #430.

This is not compliant with the rule format described in capa documentation:

> Note that capa treats all numbers as unsigned values. A negative number is not a valid feature value. To match a negative number you may specify its two's complement representation. For example, 0xFFFFFFF0 (-2) in a 32-bit file.
https://github.com/fireeye/capa-rules/blob/master/doc/format.md#number

This PR adds the following fixtures:
- number(0x0): to check feature extraction for null number
- number(0xFFFFFFFF): to check feature extraction for -1 number
- number(0xFFFFFFF0): to check feature extraction for another negative number (-0x10 in this case)

The function `extract_insn_number_features` now converts the parsed smda number operands in its two's complement representation.

I also edited the `show-features.py` script to be able to compare the feature extraction of smda and vivisect. I think that it could be useful  and it does not seem to cause any issue.

The documentation is not updated since I am just fixing a simple issue.

closes #430 

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
