### PR TITLE
Fix deprication warning from IDA

### DIFF
--- a/capa/features/extractors/ida/global_.py
+++ b/capa/features/extractors/ida/global_.py
@@ -40,11 +40,11 @@ def extract_os():
 
 def extract_arch():
     info = idaapi.get_inf_structure()
-    if info.procName == "metapc" and info.is_64bit():
+    if info.procname == "metapc" and info.is_64bit():
         yield Arch(ARCH_AMD64), 0x0
-    elif info.procName == "metapc" and info.is_32bit():
+    elif info.procname == "metapc" and info.is_32bit():
         yield Arch(ARCH_I386), 0x0
-    elif info.procName == "metapc":
+    elif info.procname == "metapc":
         logger.debug("unsupported architecture: non-32-bit nor non-64-bit intel")
         return
     else:


### PR DESCRIPTION
```
    if info.procName == "metapc" and info.is_64bit():

Please use "procname" instead of "procName" ("procName" is kept for backward-compatibility, and will be removed soon.)
```

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
