### PR TITLE
Update capa_as_library.py

### DIFF
--- a/scripts/capa_as_library.py
+++ b/scripts/capa_as_library.py
@@ -163,13 +163,12 @@ def render_dictionary(doc):
 
 # ==== render dictionary helpers
 def capa_details(file_path, output_format="dictionary"):
-    # collect metadata (used only to make rendering more complete)
-    meta = capa.main.collect_metadata("", file_path, RULES_PATH, extractor)
-
     # extract features and find capabilities
     extractor = capa.main.get_extractor(file_path, "auto", capa.main.BACKEND_VIV, [], False, disable_progress=True)
     capabilities, counts = capa.main.find_capabilities(rules, extractor, disable_progress=True)
 
+    # collect metadata (used only to make rendering more complete)
+    meta = capa.main.collect_metadata("", file_path, RULES_PATH, extractor)
     meta["analysis"].update(counts)
     meta["analysis"]["layout"] = capa.main.compute_layout(rules, extractor, capabilities)
 


### PR DESCRIPTION
### Checklist
- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed

Simple bugfix, `extractor` was being referenced prior to assignment.  

```
Traceback (most recent call last):
  File "capa_as_library.py", line 167, in capa_details
    meta = capa.main.collect_metadata("", file_path, RULES_PATH, extractor)
UnboundLocalError: local variable 'extractor' referenced before assignment
```

Side note: this script saved me a lot of time.  Thanks!