### PR TITLE
Don't require typing package; it's in the stdlib now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+- remove typing package as a requirement for Python 3.7+ compatibility #901 @uckelman-sf
 - elf: fix OS detection for Linux kernel modules #867 @williballenthin
 
 ### capa explorer IDA Pro plugin

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ requirements = [
     "vivisect==1.0.5",
     "smda==1.7.0",
     "pefile==2021.9.3",
-    "typing==3.7.4.3",
     "pyelftools==0.28",
 ]
 


### PR DESCRIPTION
Remove requirement for separate typing package; typing is in the Python stdlib from 3.5, and we require >= 3.6. From 3.7, installing the typing package causes import failures.

See [here](https://github.com/python/typing/issues/573) for numerous examples of the `typing` package causing import exceptions with Python >= 3.7.


- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [X] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
