### PR TITLE
remove windows-2016

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             # use old linux so that the shared library versioning is more portable
             artifact_name: capa
             asset_name: linux
-          - os: windows-2019
+          - os: windows-2022
             artifact_name: capa.exe
             asset_name: windows
           - os: macos-10.15
@@ -68,12 +68,16 @@ jobs:
           - os: ubuntu-20.04
             artifact_name: capa
             asset_name: linux
+          - os: windows-2022
+            artifact_name: capa.exe
+            asset_name: windows
     steps:
       - name: Download ${{ matrix.asset_name }}
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.asset_name }}
       - name: Set executable flag
+        if: matrix.os != 'windows-2022'      
         run: chmod +x ${{ matrix.artifact_name }}
       - name: Run capa
         run: ./${{ matrix.artifact_name }} -h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,16 +68,12 @@ jobs:
           - os: ubuntu-20.04
             artifact_name: capa
             asset_name: linux
-          - os: windows-2016
-            artifact_name: capa.exe
-            asset_name: windows
     steps:
       - name: Download ${{ matrix.asset_name }}
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.asset_name }}
       - name: Set executable flag
-        if: matrix.os != 'windows-2016'
         run: chmod +x ${{ matrix.artifact_name }}
       - name: Run capa
         run: ./${{ matrix.artifact_name }} -h


### PR DESCRIPTION
The Windows 2016 runner image will be removed from GitHub-hosted runners
on March 15, 2022:
https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
