### PR TITLE
render: meta: display rule paths on separate lines

### DIFF
--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -62,7 +62,7 @@ def render_meta(ostream, doc):
         ("arch", doc["meta"]["analysis"]["arch"]),
         ("extractor", doc["meta"]["analysis"]["extractor"]),
         ("base address", hex(doc["meta"]["analysis"]["base_address"])),
-        ("rules", ", ".join(doc["meta"]["analysis"]["rules"])),
+        ("rules", doc["meta"]["analysis"]["rules"][0]),
         ("function count", len(doc["meta"]["analysis"]["feature_counts"]["functions"])),
         ("library function count", len(doc["meta"]["analysis"]["library_functions"])),
         (
@@ -71,6 +71,13 @@ def render_meta(ostream, doc):
             + sum(doc["meta"]["analysis"]["feature_counts"]["functions"].values()),
         ),
     ]
+
+    if len(doc["meta"]["analysis"]["rules"]) > 1:
+        idx = rows.index(("rules", doc["meta"]["analysis"]["rules"][0])) + 1
+        for rule in doc["meta"]["analysis"]["rules"][1:]:
+            rows.insert(idx, ("", rule))
+            idx += 1
+
     ostream.writeln(tabulate.tabulate(rows, tablefmt="plain"))
 
 

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -62,7 +62,7 @@ def render_meta(ostream, doc):
         ("arch", doc["meta"]["analysis"]["arch"]),
         ("extractor", doc["meta"]["analysis"]["extractor"]),
         ("base address", hex(doc["meta"]["analysis"]["base_address"])),
-        ("rules", doc["meta"]["analysis"]["rules"][0]),
+        ("rules", "\n".join(doc["meta"]["analysis"]["rules"])),
         ("function count", len(doc["meta"]["analysis"]["feature_counts"]["functions"])),
         ("library function count", len(doc["meta"]["analysis"]["library_functions"])),
         (
@@ -71,19 +71,6 @@ def render_meta(ostream, doc):
             + sum(doc["meta"]["analysis"]["feature_counts"]["functions"].values()),
         ),
     ]
-
-    # when there are multiple rule paths,
-    # display each one on its own line, like:
-    #
-    #     base address            0x10000000
-    #     rules                   /path/1
-    #                             /path/2
-    #     function count          2
-    if len(doc["meta"]["analysis"]["rules"]) > 1:
-        idx = rows.index(("rules", doc["meta"]["analysis"]["rules"][0])) + 1
-        for rule in doc["meta"]["analysis"]["rules"][1:]:
-            rows.insert(idx, ("", rule))
-            idx += 1
 
     ostream.writeln(tabulate.tabulate(rows, tablefmt="plain"))
 

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -72,6 +72,13 @@ def render_meta(ostream, doc):
         ),
     ]
 
+    # when there are multiple rule paths,
+    # display each one on its own line, like:
+    #
+    #     base address            0x10000000
+    #     rules                   /path/1
+    #                             /path/2
+    #     function count          2
     if len(doc["meta"]["analysis"]["rules"]) > 1:
         idx = rows.index(("rules", doc["meta"]["analysis"]["rules"][0])) + 1
         for rule in doc["meta"]["analysis"]["rules"][1:]:


### PR DESCRIPTION
closes #971

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/156560/162052000-55d9d65a-4f0c-4382-89eb-1d9c0358161a.png">

[x] No CHANGELOG update needed