### PR TITLE
vverbose: don't show examples in output

### DIFF
--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -196,7 +196,6 @@ def render_rules(ostream, doc):
         author     michael.hunhoff@mandiant.com
         scope      function
         mbc        Anti-Behavioral Analysis::Detect Debugger::OutputDebugString
-        examples   Practical Malware Analysis Lab 16-02.exe_:0x401020
         function @ 0x10004706
           and:
             api: kernel32.SetLastError @ 0x100047C2
@@ -232,6 +231,13 @@ def render_rules(ostream, doc):
         rows = []
         for key in capa.rules.META_KEYS:
             if key == "name" or key not in rule["meta"]:
+                continue
+
+            if key == "examples":
+                # I can't think of a reason that an analyst would pivot to the concrete example
+                # directly from the capa output.
+                # the more likely flow is to review the rule and go from there.
+                # so, don't make the output messy by showing the examples.
                 continue
 
             v = rule["meta"][key]


### PR DESCRIPTION
closes #970

<img width="444" alt="image" src="https://user-images.githubusercontent.com/156560/162053064-6955728b-8112-4698-95bf-aea4a01f364b.png">

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
