### PR TITLE
feat: add IDA handles and type annotations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ master, dotnet-main ]
   pull_request:
-    branches: [ master, dotnet-main ]
+    # TODO cleanup these
+    branches: [ master, dotnet-main, feature-981 ]
 
 # save workspaces to speed up testing
 env:

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -27,6 +27,9 @@ class AbsoluteVirtualAddress(int, Address):
         assert v >= 0
         return int.__new__(cls, v)
 
+    def __str__(self):
+        return str(self)
+
 
 class RelativeVirtualAddress(int, Address):
     """a memory address relative to a base address"""
@@ -40,6 +43,9 @@ class FileOffsetAddress(int, Address):
     def __new__(cls, v):
         assert v >= 0
         return int.__new__(cls, v)
+
+    def __str__(self):
+        return str(self)
 
 
 class DNTokenAddress(Address):

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -47,7 +47,10 @@ class OS(str, Enum):
     NACL = "nacl"
 
 
-def detect_elf_os(f: BinaryIO) -> str:
+def detect_elf_os(f) -> str:
+    """
+    f: type Union[BinaryIO, IDAIO]
+    """
     f.seek(0x0)
     file_header = f.read(0x40)
 

--- a/capa/features/extractors/ida/basicblock.py
+++ b/capa/features/extractors/ida/basicblock.py
@@ -8,22 +8,21 @@
 
 import string
 import struct
+from typing import Tuple, Iterator
 
 import idaapi
 
 import capa.features.extractors.ida.helpers
-from capa.features.common import Characteristic
+from capa.features.common import Feature, Characteristic
+from capa.features.address import Address
 from capa.features.basicblock import BasicBlock
 from capa.features.extractors.ida import helpers
 from capa.features.extractors.helpers import MIN_STACKSTRING_LEN
+from capa.features.extractors.base_extractor import BBHandle, FunctionHandle
 
 
-def get_printable_len(op):
-    """Return string length if all operand bytes are ascii or utf16-le printable
-
-    args:
-        op (IDA op_t)
-    """
+def get_printable_len(op: idaapi.op_t) -> int:
+    """Return string length if all operand bytes are ascii or utf16-le printable"""
     op_val = capa.features.extractors.ida.helpers.mask_op_val(op)
 
     if op.dtype == idaapi.dt_byte:
@@ -37,12 +36,12 @@ def get_printable_len(op):
     else:
         raise ValueError("Unhandled operand data type 0x%x." % op.dtype)
 
-    def is_printable_ascii(chars):
-        return all(c < 127 and chr(c) in string.printable for c in chars)
+    def is_printable_ascii(chars_: bytes):
+        return all(c < 127 and chr(c) in string.printable for c in chars_)
 
-    def is_printable_utf16le(chars):
-        if all(c == 0x00 for c in chars[1::2]):
-            return is_printable_ascii(chars[::2])
+    def is_printable_utf16le(chars_: bytes):
+        if all(c == 0x00 for c in chars_[1::2]):
+            return is_printable_ascii(chars_[::2])
 
     if is_printable_ascii(chars):
         return idaapi.get_dtype_size(op.dtype)
@@ -53,12 +52,8 @@ def get_printable_len(op):
     return 0
 
 
-def is_mov_imm_to_stack(insn):
-    """verify instruction moves immediate onto stack
-
-    args:
-        insn (IDA insn_t)
-    """
+def is_mov_imm_to_stack(insn: idaapi.insn_t) -> bool:
+    """verify instruction moves immediate onto stack"""
     if insn.Op2.type != idaapi.o_imm:
         return False
 
@@ -71,14 +66,10 @@ def is_mov_imm_to_stack(insn):
     return True
 
 
-def bb_contains_stackstring(f, bb):
+def bb_contains_stackstring(f: idaapi.func_t, bb: idaapi.BasicBlock) -> bool:
     """check basic block for stackstring indicators
 
     true if basic block contains enough moves of constant bytes to the stack
-
-    args:
-        f (IDA func_t)
-        bb (IDA BasicBlock)
     """
     count = 0
     for insn in capa.features.extractors.ida.helpers.get_instructions_in_range(bb.start_ea, bb.end_ea):
@@ -89,39 +80,24 @@ def bb_contains_stackstring(f, bb):
     return False
 
 
-def extract_bb_stackstring(f, bb):
-    """extract stackstring indicators from basic block
-
-    args:
-        f (IDA func_t)
-        bb (IDA BasicBlock)
-    """
-    if bb_contains_stackstring(f, bb):
-        yield Characteristic("stack string"), bb.start_ea
+def extract_bb_stackstring(fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[Feature, Address]]:
+    """extract stackstring indicators from basic block"""
+    if bb_contains_stackstring(fh.inner, bbh.inner):
+        yield Characteristic("stack string"), bbh.address
 
 
-def extract_bb_tight_loop(f, bb):
-    """extract tight loop indicators from a basic block
-
-    args:
-        f (IDA func_t)
-        bb (IDA BasicBlock)
-    """
-    if capa.features.extractors.ida.helpers.is_basic_block_tight_loop(bb):
-        yield Characteristic("tight loop"), bb.start_ea
+def extract_bb_tight_loop(fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[Feature, Address]]:
+    """extract tight loop indicators from a basic block"""
+    if capa.features.extractors.ida.helpers.is_basic_block_tight_loop(bbh.inner):
+        yield Characteristic("tight loop"), bbh.address
 
 
-def extract_features(f, bb):
-    """extract basic block features
-
-    args:
-        f (IDA func_t)
-        bb (IDA BasicBlock)
-    """
+def extract_features(fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[Feature, Address]]:
+    """extract basic block features"""
     for bb_handler in BASIC_BLOCK_HANDLERS:
-        for (feature, ea) in bb_handler(f, bb):
-            yield feature, ea
-    yield BasicBlock(), bb.start_ea
+        for (feature, addr) in bb_handler(fh, bbh):
+            yield feature, addr
+    yield BasicBlock(), bbh.address
 
 
 BASIC_BLOCK_HANDLERS = (
@@ -132,9 +108,10 @@ BASIC_BLOCK_HANDLERS = (
 
 def main():
     features = []
-    for f in helpers.get_functions(skip_thunks=True, skip_libs=True):
+    for fhandle in helpers.get_functions(skip_thunks=True, skip_libs=True):
+        f: idaapi.func_t = fhandle.inner
         for bb in idaapi.FlowChart(f, flags=idaapi.FC_PREDS):
-            features.extend(list(extract_features(f, bb)))
+            features.extend(list(extract_features(fhandle, bb)))
 
     import pprint
 

--- a/capa/features/extractors/ida/extractor.py
+++ b/capa/features/extractors/ida/extractor.py
@@ -5,6 +5,8 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+from typing import List, Tuple, Iterator
+
 import idaapi
 
 import capa.ida.helpers
@@ -14,57 +16,20 @@ import capa.features.extractors.ida.insn
 import capa.features.extractors.ida.global_
 import capa.features.extractors.ida.function
 import capa.features.extractors.ida.basicblock
-from capa.features.extractors.base_extractor import FeatureExtractor
-
-
-class FunctionHandle:
-    """this acts like an idaapi.func_t but with __int__()"""
-
-    def __init__(self, inner):
-        self._inner = inner
-
-    def __int__(self):
-        return self.start_ea
-
-    def __getattr__(self, name):
-        return getattr(self._inner, name)
-
-
-class BasicBlockHandle:
-    """this acts like an idaapi.BasicBlock but with __int__()"""
-
-    def __init__(self, inner):
-        self._inner = inner
-
-    def __int__(self):
-        return self.start_ea
-
-    def __getattr__(self, name):
-        return getattr(self._inner, name)
-
-
-class InstructionHandle:
-    """this acts like an idaapi.insn_t but with __int__()"""
-
-    def __init__(self, inner):
-        self._inner = inner
-
-    def __int__(self):
-        return self.ea
-
-    def __getattr__(self, name):
-        return getattr(self._inner, name)
+from capa.features.common import Feature
+from capa.features.address import Address, AbsoluteVirtualAddress
+from capa.features.extractors.base_extractor import BBHandle, InsnHandle, FunctionHandle, FeatureExtractor
 
 
 class IdaFeatureExtractor(FeatureExtractor):
     def __init__(self):
         super(IdaFeatureExtractor, self).__init__()
-        self.global_features = []
+        self.global_features: List[Tuple[Feature, Address]] = []
         self.global_features.extend(capa.features.extractors.ida.global_.extract_os())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_arch())
 
     def get_base_address(self):
-        return idaapi.get_imagebase()
+        return AbsoluteVirtualAddress(idaapi.get_imagebase())
 
     def extract_global_features(self):
         yield from self.global_features
@@ -72,41 +37,34 @@ class IdaFeatureExtractor(FeatureExtractor):
     def extract_file_features(self):
         yield from capa.features.extractors.ida.file.extract_features()
 
-    def get_functions(self):
+    def get_functions(self) -> Iterator[FunctionHandle]:
         import capa.features.extractors.ida.helpers as ida_helpers
-
-        # data structure shared across functions yielded here.
-        # useful for caching analysis relevant across a single workspace.
-        ctx = {}
 
         # ignore library functions and thunk functions as identified by IDA
-        for f in ida_helpers.get_functions(skip_thunks=True, skip_libs=True):
-            setattr(f, "ctx", ctx)
-            yield FunctionHandle(f)
+        yield from ida_helpers.get_functions(skip_thunks=True, skip_libs=True)
 
     @staticmethod
-    def get_function(ea):
+    def get_function(ea: int) -> FunctionHandle:
         f = idaapi.get_func(ea)
-        setattr(f, "ctx", {})
-        return FunctionHandle(f)
+        return FunctionHandle(address=AbsoluteVirtualAddress(f.start_ea), inner=f)
 
-    def extract_function_features(self, f):
-        yield from capa.features.extractors.ida.function.extract_features(f)
+    def extract_function_features(self, fh: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
+        yield from capa.features.extractors.ida.function.extract_features(fh)
 
-    def get_basic_blocks(self, f):
+    def get_basic_blocks(self, fh: FunctionHandle) -> Iterator[BBHandle]:
         import capa.features.extractors.ida.helpers as ida_helpers
 
-        for bb in ida_helpers.get_function_blocks(f):
-            yield BasicBlockHandle(bb)
+        for bb in ida_helpers.get_function_blocks(fh.inner):
+            yield BBHandle(address=AbsoluteVirtualAddress(bb.start_ea), inner=bb)
 
-    def extract_basic_block_features(self, f, bb):
-        yield from capa.features.extractors.ida.basicblock.extract_features(f, bb)
+    def extract_basic_block_features(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[Feature, Address]]:
+        yield from capa.features.extractors.ida.basicblock.extract_features(fh, bbh)
 
-    def get_instructions(self, f, bb):
+    def get_instructions(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[InsnHandle]:
         import capa.features.extractors.ida.helpers as ida_helpers
 
-        for insn in ida_helpers.get_instructions_in_range(bb.start_ea, bb.end_ea):
-            yield InstructionHandle(insn)
+        for insn in ida_helpers.get_instructions_in_range(bbh.inner.start_ea, bbh.inner.end_ea):
+            yield InsnHandle(address=AbsoluteVirtualAddress(insn.ea), inner=insn)
 
-    def extract_insn_features(self, f, bb, insn):
-        yield from capa.features.extractors.ida.insn.extract_features(f, bb, insn)
+    def extract_insn_features(self, fh: FunctionHandle, bbh: BBHandle, ih: InsnHandle):
+        yield from capa.features.extractors.ida.insn.extract_features(fh, bbh, ih)

--- a/capa/features/extractors/ida/file.py
+++ b/capa/features/extractors/ida/file.py
@@ -7,27 +7,26 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import struct
+from typing import Tuple, Iterator
 
 import idc
 import idaapi
 import idautils
-import ida_loader
 
+import capa.features.extractors.common
 import capa.features.extractors.helpers
 import capa.features.extractors.strings
 import capa.features.extractors.ida.helpers
 from capa.features.file import Export, Import, Section, FunctionName
-from capa.features.common import OS, FORMAT_PE, FORMAT_ELF, OS_WINDOWS, Format, String, Characteristic
+from capa.features.common import FORMAT_PE, FORMAT_ELF, Format, Feature, Characteristic
+from capa.features.address import NO_ADDRESS, Address, FileOffsetAddress, AbsoluteVirtualAddress
 
 
-def check_segment_for_pe(seg):
+def check_segment_for_pe(seg: idaapi.segment_t) -> Iterator[Tuple[int, int]]:
     """check segment for embedded PE
 
     adapted for IDA from:
     https://github.com/vivisect/vivisect/blob/7be4037b1cecc4551b397f840405a1fc606f9b53/PE/carve.py#L19
-
-    args:
-        seg (IDA segment_t)
     """
     seg_max = seg.end_ea
     mz_xor = [
@@ -60,13 +59,13 @@ def check_segment_for_pe(seg):
             continue
 
         if idc.get_bytes(peoff, 2) == pex:
-            yield (off, i)
+            yield off, i
 
         for nextres in capa.features.extractors.ida.helpers.find_byte_sequence(off + 1, seg.end_ea, mzx):
             todo.append((nextres, mzx, pex, i))
 
 
-def extract_file_embedded_pe():
+def extract_file_embedded_pe() -> Iterator[Tuple[Feature, Address]]:
     """extract embedded PE features
 
     IDA must load resource sections for this to be complete
@@ -75,16 +74,16 @@ def extract_file_embedded_pe():
     """
     for seg in capa.features.extractors.ida.helpers.get_segments(skip_header_segments=True):
         for (ea, _) in check_segment_for_pe(seg):
-            yield Characteristic("embedded pe"), ea
+            yield Characteristic("embedded pe"), FileOffsetAddress(ea)
 
 
-def extract_file_export_names():
+def extract_file_export_names() -> Iterator[Tuple[Feature, Address]]:
     """extract function exports"""
     for (_, _, ea, name) in idautils.Entries():
-        yield Export(name), ea
+        yield Export(name), AbsoluteVirtualAddress(ea)
 
 
-def extract_file_import_names():
+def extract_file_import_names() -> Iterator[Tuple[Feature, Address]]:
     """extract function imports
 
     1. imports by ordinal:
@@ -96,11 +95,12 @@ def extract_file_import_names():
      - importname
     """
     for (ea, info) in capa.features.extractors.ida.helpers.get_file_imports().items():
+        addr = AbsoluteVirtualAddress(ea)
         if info[1] and info[2]:
             # e.g. in mimikatz: ('cabinet', 'FCIAddFile', 11L)
             # extract by name here and by ordinal below
             for name in capa.features.extractors.helpers.generate_symbols(info[0], info[1]):
-                yield Import(name), ea
+                yield Import(name), addr
             dll = info[0]
             symbol = "#%d" % (info[2])
         elif info[1]:
@@ -113,10 +113,10 @@ def extract_file_import_names():
             continue
 
         for name in capa.features.extractors.helpers.generate_symbols(dll, symbol):
-            yield Import(name), ea
+            yield Import(name), addr
 
 
-def extract_file_section_names():
+def extract_file_section_names() -> Iterator[Tuple[Feature, Address]]:
     """extract section names
 
     IDA must load resource sections for this to be complete
@@ -124,10 +124,10 @@ def extract_file_section_names():
         - Check 'Load resource sections' when opening binary in IDA manually
     """
     for seg in capa.features.extractors.ida.helpers.get_segments(skip_header_segments=True):
-        yield Section(idaapi.get_segm_name(seg)), seg.start_ea
+        yield Section(idaapi.get_segm_name(seg)), AbsoluteVirtualAddress(seg.start_ea)
 
 
-def extract_file_strings():
+def extract_file_strings() -> Iterator[Tuple[Feature, Address]]:
     """extract ASCII and UTF-16 LE strings
 
     IDA must load resource sections for this to be complete
@@ -136,37 +136,33 @@ def extract_file_strings():
     """
     for seg in capa.features.extractors.ida.helpers.get_segments():
         seg_buff = capa.features.extractors.ida.helpers.get_segment_buffer(seg)
-
-        for s in capa.features.extractors.strings.extract_ascii_strings(seg_buff):
-            yield String(s.s), (seg.start_ea + s.offset)
-
-        for s in capa.features.extractors.strings.extract_unicode_strings(seg_buff):
-            yield String(s.s), (seg.start_ea + s.offset)
+        yield from capa.features.extractors.common.extract_file_strings(seg_buff)
 
 
-def extract_file_function_names():
+def extract_file_function_names() -> Iterator[Tuple[Feature, Address]]:
     """
     extract the names of statically-linked library functions.
     """
     for ea in idautils.Functions():
+        addr = AbsoluteVirtualAddress(ea)
         if idaapi.get_func(ea).flags & idaapi.FUNC_LIB:
             name = idaapi.get_name(ea)
-            yield FunctionName(name), ea
+            yield FunctionName(name), addr
             if name.startswith("_"):
                 # some linkers may prefix linked routines with a `_` to avoid name collisions.
                 # extract features for both the mangled and un-mangled representations.
                 # e.g. `_fwrite` -> `fwrite`
                 # see: https://stackoverflow.com/a/2628384/87207
-                yield FunctionName(name[1:]), ea
+                yield FunctionName(name[1:]), addr
 
 
-def extract_file_format():
+def extract_file_format() -> Iterator[Tuple[Feature, Address]]:
     file_info = idaapi.get_inf_structure()
 
     if file_info.filetype == idaapi.f_PE:
-        yield Format(FORMAT_PE), 0x0
+        yield Format(FORMAT_PE), NO_ADDRESS
     elif file_info.filetype == idaapi.f_ELF:
-        yield Format(FORMAT_ELF), 0x0
+        yield Format(FORMAT_ELF), NO_ADDRESS
     elif file_info.filetype == idaapi.f_BIN:
         # no file type to return when processing a binary file, but we want to continue processing
         return
@@ -174,11 +170,11 @@ def extract_file_format():
         raise NotImplementedError("file format: %d" % file_info.filetype)
 
 
-def extract_features():
+def extract_features() -> Iterator[Tuple[Feature, Address]]:
     """extract file features"""
     for file_handler in FILE_HANDLERS:
-        for feature, va in file_handler():
-            yield feature, va
+        for feature, addr in file_handler():
+            yield feature, addr
 
 
 FILE_HANDLERS = (

--- a/capa/features/extractors/ida/global_.py
+++ b/capa/features/extractors/ida/global_.py
@@ -1,27 +1,29 @@
 import logging
 import contextlib
+from typing import Tuple, Iterator
 
 import idaapi
 import ida_loader
 
 import capa.ida.helpers
 import capa.features.extractors.elf
-from capa.features.common import OS, ARCH_I386, ARCH_AMD64, OS_WINDOWS, Arch
+from capa.features.common import OS, ARCH_I386, ARCH_AMD64, OS_WINDOWS, Arch, Feature
+from capa.features.address import NO_ADDRESS, Address
 
 logger = logging.getLogger(__name__)
 
 
-def extract_os():
-    format_name = ida_loader.get_file_type_name()
+def extract_os() -> Iterator[Tuple[Feature, Address]]:
+    format_name: str = ida_loader.get_file_type_name()
 
     if "PE" in format_name:
-        yield OS(OS_WINDOWS), 0x0
+        yield OS(OS_WINDOWS), NO_ADDRESS
 
     elif "ELF" in format_name:
         with contextlib.closing(capa.ida.helpers.IDAIO()) as f:
             os = capa.features.extractors.elf.detect_elf_os(f)
 
-        yield OS(os), 0x0
+        yield OS(os), NO_ADDRESS
 
     else:
         # we likely end up here:
@@ -38,12 +40,12 @@ def extract_os():
         return
 
 
-def extract_arch():
-    info = idaapi.get_inf_structure()
+def extract_arch() -> Iterator[Tuple[Feature, Address]]:
+    info: idaapi.idainfo = idaapi.get_inf_structure()
     if info.procname == "metapc" and info.is_64bit():
-        yield Arch(ARCH_AMD64), 0x0
+        yield Arch(ARCH_AMD64), NO_ADDRESS
     elif info.procname == "metapc" and info.is_32bit():
-        yield Arch(ARCH_I386), 0x0
+        yield Arch(ARCH_I386), NO_ADDRESS
     elif info.procname == "metapc":
         logger.debug("unsupported architecture: non-32-bit nor non-64-bit intel")
         return

--- a/capa/features/extractors/smda/extractor.py
+++ b/capa/features/extractors/smda/extractor.py
@@ -39,19 +39,19 @@ class SmdaFeatureExtractor(FeatureExtractor):
         for function in self.smda_report.getFunctions():
             yield FunctionHandle(address=AbsoluteVirtualAddress(function.offset), inner=function)
 
-    def extract_function_features(self, f):
-        yield from capa.features.extractors.smda.function.extract_features(f)
+    def extract_function_features(self, fh):
+        yield from capa.features.extractors.smda.function.extract_features(fh)
 
-    def get_basic_blocks(self, f):
-        for bb in f.getBlocks():
+    def get_basic_blocks(self, fh):
+        for bb in fh.inner.getBlocks():
             yield BBHandle(address=AbsoluteVirtualAddress(bb.offset), inner=bb)
 
-    def extract_basic_block_features(self, f, bb):
-        yield from capa.features.extractors.smda.basicblock.extract_features(f, bb)
+    def extract_basic_block_features(self, fh, bbh):
+        yield from capa.features.extractors.smda.basicblock.extract_features(fh, bbh)
 
-    def get_instructions(self, f, bb):
-        for smda_ins in bb.getInstructions():
+    def get_instructions(self, fh, bbh):
+        for smda_ins in bbh.inner.getInstructions():
             yield InsnHandle(address=AbsoluteVirtualAddress(smda_ins.offset), inner=smda_ins)
 
-    def extract_insn_features(self, f, bb, insn):
-        yield from capa.features.extractors.smda.insn.extract_features(f, bb, insn)
+    def extract_insn_features(self, fh, bbh, ih):
+        yield from capa.features.extractors.smda.insn.extract_features(fh, bbh, ih)

--- a/capa/features/extractors/smda/insn.py
+++ b/capa/features/extractors/smda/insn.py
@@ -271,10 +271,10 @@ def is_security_cookie(f, bb, insn):
     for index, block in enumerate(f.getBlocks()):
         # expect security cookie init in first basic block within first bytes (instructions)
         block_instructions = [i for i in block.getInstructions()]
-        if index == 0 and insn.address < (block_instructions[0].offset + SECURITY_COOKIE_BYTES_DELTA):
+        if index == 0 and insn.offset < (block_instructions[0].offset + SECURITY_COOKIE_BYTES_DELTA):
             return True
         # ... or within last bytes (instructions) before a return
-        if block_instructions[-1].mnemonic.startswith("ret") and insn.address > (
+        if block_instructions[-1].mnemonic.startswith("ret") and insn.offset > (
             block_instructions[-1].offset - SECURITY_COOKIE_BYTES_DELTA
         ):
             return True

--- a/capa/features/extractors/viv/function.py
+++ b/capa/features/extractors/viv/function.py
@@ -17,7 +17,7 @@ from capa.features.extractors import loops
 from capa.features.extractors.base_extractor import FunctionHandle
 
 
-def interface_extract_function_XXX(f: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
+def interface_extract_function_XXX(fh: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
     """
     parse features from the given function.
 
@@ -33,7 +33,7 @@ def interface_extract_function_XXX(f: FunctionHandle) -> Iterator[Tuple[Feature,
 def extract_function_calls_to(fhandle: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
     f: viv_utils.Function = fhandle.inner
     for src, _, _, _ in f.vw.getXrefsTo(f.va, rtype=vivisect.const.REF_CODE):
-        yield Characteristic("calls to"), fhandle.address
+        yield Characteristic("calls to"), AbsoluteVirtualAddress(src)
 
 
 def extract_function_loop(fhandle: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
@@ -60,18 +60,18 @@ def extract_function_loop(fhandle: FunctionHandle) -> Iterator[Tuple[Feature, Ad
         yield Characteristic("loop"), fhandle.address
 
 
-def extract_features(f: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
+def extract_features(fh: FunctionHandle) -> Iterator[Tuple[Feature, Address]]:
     """
     extract features from the given function.
 
     args:
-      f (viv_utils.Function): the function from which to extract features
+      fh: the function handle from which to extract features
 
     yields:
       Tuple[Feature, int]: the features and their location found in this function.
     """
     for func_handler in FUNCTION_HANDLERS:
-        for feature, addr in func_handler(f):
+        for feature, addr in func_handler(fh):
             yield feature, addr
 
 

--- a/capa/features/extractors/viv/indirect_calls.py
+++ b/capa/features/extractors/viv/indirect_calls.py
@@ -16,7 +16,7 @@ import envi.archs.amd64.disasm
 from vivisect import VivWorkspace
 
 if TYPE_CHECKING:
-    from capa.features.extractors.viv.extractor import InstructionHandle
+    from capa.features.extractors.viv.extractor import VivInstructionHandle
 
 # pull out consts for lookup performance
 i386RegOper = envi.archs.i386.disasm.i386RegOper
@@ -135,7 +135,7 @@ def find_definition(vw: VivWorkspace, va: int, reg: int) -> Tuple[int, Union[int
     raise NotFoundError()
 
 
-def is_indirect_call(vw: VivWorkspace, va: int, insn: Optional["InstructionHandle"] = None) -> bool:
+def is_indirect_call(vw: VivWorkspace, va: int, insn: Optional["VivInstructionHandle"] = None) -> bool:
     if insn is None:
         insn = vw.parseOpcode(va)
 
@@ -143,7 +143,7 @@ def is_indirect_call(vw: VivWorkspace, va: int, insn: Optional["InstructionHandl
 
 
 def resolve_indirect_call(
-    vw: VivWorkspace, va: int, insn: Optional["InstructionHandle"] = None
+    vw: VivWorkspace, va: int, insn: Optional["VivInstructionHandle"] = None
 ) -> Tuple[int, Optional[int]]:
     """
     inspect the given indirect call instruction and attempt to resolve the target address.

--- a/capa/ida/plugin/__init__.py
+++ b/capa/ida/plugin/__init__.py
@@ -5,7 +5,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-
 import logging
 
 import idaapi

--- a/capa/ida/plugin/item.py
+++ b/capa/ida/plugin/item.py
@@ -216,6 +216,8 @@ class CapaExplorerFunctionItem(CapaExplorerDataItem):
         @param parent: parent node
         @param location: virtual address of function as seen by IDA
         """
+        # location can be an Address now, so need to get the VA
+        location = int(location)
         super(CapaExplorerFunctionItem, self).__init__(
             parent, [self.fmt % idaapi.get_name(location), location_to_hex(location), ""], can_check
         )

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -6,7 +6,8 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-from collections import deque, defaultdict
+from typing import List
+from collections import deque
 
 import idc
 import idaapi
@@ -545,6 +546,14 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
         @param location: address of feature
         @param display: text to display in plugin UI
         """
+
+        # convert to offset from locations: List[Address]
+        try:
+            location = int(location)
+        except TypeError:
+            # e.g. capa.features.address._NoAddress, global features
+            return
+
         # special handling for characteristic pending type
         if feature["type"] == "characteristic":
             if feature[feature["type"]] in ("embedded pe",):

--- a/capa/main.py
+++ b/capa/main.py
@@ -172,7 +172,7 @@ def find_basic_block_capabilities(
 
 
 def find_code_capabilities(
-    ruleset: RuleSet, extractor: FeatureExtractor, f: FunctionHandle
+    ruleset: RuleSet, extractor: FeatureExtractor, fh: FunctionHandle
 ) -> Tuple[MatchResults, MatchResults, MatchResults, int]:
     """
     find matches for the given rules within the given function.
@@ -191,8 +191,8 @@ def find_code_capabilities(
     # might be found at different instructions, thats ok.
     insn_matches = collections.defaultdict(list)  # type: MatchResults
 
-    for bb in extractor.get_basic_blocks(f):
-        features, bmatches, imatches = find_basic_block_capabilities(ruleset, extractor, f, bb)
+    for bb in extractor.get_basic_blocks(fh):
+        features, bmatches, imatches = find_basic_block_capabilities(ruleset, extractor, fh, bb)
         for feature, vas in features.items():
             function_features[feature].update(vas)
 
@@ -202,10 +202,10 @@ def find_code_capabilities(
         for rule_name, res in imatches.items():
             insn_matches[rule_name].extend(res)
 
-    for feature, va in itertools.chain(extractor.extract_function_features(f), extractor.extract_global_features()):
+    for feature, va in itertools.chain(extractor.extract_function_features(fh), extractor.extract_global_features()):
         function_features[feature].add(va)
 
-    _, function_matches = ruleset.match(Scope.FUNCTION, function_features, f.address)
+    _, function_matches = ruleset.match(Scope.FUNCTION, function_features, fh.address)
     return function_matches, bb_matches, insn_matches, len(function_features)
 
 

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -130,23 +130,24 @@ def main(argv=None):
         for feature, addr in extractor.extract_file_features():
             print("file: %s: %s" % (capa.render.verbose.format_address(addr), feature))
 
-    functions = extractor.get_functions()
+    function_handles = extractor.get_functions()
 
     if args.function:
         if args.format == "freeze":
-            functions = tuple(filter(lambda f: f == args.function, functions))
+            # TODO fix
+            function_handles = tuple(filter(lambda fh: fh.address == args.function, function_handles))
         else:
-            functions = tuple(filter(lambda f: str(f) == args.function, functions))
+            function_handles = tuple(filter(lambda fh: fh.address == args.function, function_handles))
 
-            if args.function not in [str(f) for f in functions]:
+            if args.function not in [str(f) for f in function_handles]:
                 print("%s not a function" % args.function)
                 return -1
 
-        if len(functions) == 0:
+        if len(function_handles) == 0:
             print("%s not a function", args.function)
             return -1
 
-    print_features(functions, extractor)
+    print_features(function_handles, extractor)
 
     return 0
 

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -137,9 +137,11 @@ def main(argv=None):
             # TODO fix
             function_handles = tuple(filter(lambda fh: fh.address == args.function, function_handles))
         else:
-            function_handles = tuple(filter(lambda fh: fh.address == args.function, function_handles))
+            function_handles = tuple(
+                filter(lambda fh: capa.render.verbose.format_address(fh.address) == args.function, function_handles)
+            )
 
-            if args.function not in [str(f) for f in function_handles]:
+            if args.function not in [capa.render.verbose.format_address(fh.address) for fh in function_handles]:
                 print("%s not a function" % args.function)
                 return -1
 
@@ -167,16 +169,16 @@ def ida_main():
             print("file: %s: %s" % (capa.render.verbose.format_address(addr), feature))
         return
 
-    functions = extractor.get_functions()
+    function_handles = extractor.get_functions()
 
     if function:
-        functions = tuple(filter(lambda f: f.start_ea == function, functions))
+        function_handles = tuple(filter(lambda fh: fh.inner.start_ea == function, function_handles))
 
-        if len(functions) == 0:
+        if len(function_handles) == 0:
             print("0x%X not a function" % function)
             return -1
 
-    print_features(functions, extractor)
+    print_features(function_handles, extractor)
 
     return 0
 


### PR DESCRIPTION
and various other fixes

test in IDA pass, outstanding test fails are due to freeze, JSON, and dotnet issues

```
OK   mimikatz-function=0x40E5C2-basic block-7
OK   mimikatz-function=0x4702FD-characteristic(calls from)-0
OK   mimikatz-function=0x40E5C2-characteristic(calls from)-3
OK   mimikatz-function=0x4556E5-characteristic(calls to)-0
OK   mimikatz-function=0x40B1F1-characteristic(calls to)-3
SKIP 3b13b...-function=0x10006860-characteristic(nzxor)-True
SKIP 64d9f-function=0x10001510,bb=0x100015B0-offset(0x4000)-True
SKIP 7351f.elf-file-os(linux)-True
SKIP 7351f.elf-file-os(windows)-False
SKIP 7351f.elf-file-format(elf)-True
SKIP 7351f.elf-file-format(pe)-False
SKIP 7351f.elf-file-arch(i386)-False
SKIP 7351f.elf-file-arch(amd64)-True
SKIP 7351f.elf-function=0x408753-string(/dev/null)-True
SKIP 7351f.elf-function=0x408753,bb=0x408781-api(open)-True
SKIP 773290...-function=0x140001140-string(%s:\\OfficePackagesForWDAG)-True
SKIP 79abd...-function=0x10002385,bb=0x10002385-characteristic(call $+5)-True
SKIP 946a9...-function=0x10001510,bb=0x100015c0-characteristic(call $+5)-True
SKIP a1982...-function=0x4014D0-characteristic(cross section flow)-True
SKIP al-khaser x64-function=0x14004B4F0-api(__vcrt_GetModuleHandle)-True
SKIP c91887...-function=0x40156F-api(CloseClipboard)-True
SKIP c91887...-function=0x401A77-api(kernel32.CreatePipe)-True
SKIP c91887...-function=0x401A77-api(kernel32.SetHandleInformation)-True
SKIP c91887...-function=0x401A77-api(kernel32.CloseHandle)-True
SKIP c91887...-function=0x401A77-api(kernel32.WriteFile)-True
SKIP kernel32-file-export(BaseThreadInitThunk)-True
SKIP kernel32-file-export(lstrlenW)-True
SKIP kernel32-file-export(nope)-False
SKIP kernel32-64-function=0x180001010-api(RtlVirtualUnwind)-True
SKIP kernel32-64-function=0x180001010-api(RtlVirtualUnwind)-True
SKIP kernel32-64-function=0x180001068-characteristic(gs access)-True
SKIP kernel32-64-function=0x180001068-characteristic(cross section flow)-False
SKIP kernel32-64-function=0x1800017D0-characteristic(peb access)-True
SKIP kernel32-64-function=0x1800202B0-api(RtlCaptureContext)-True
SKIP kernel32-64-function=0x1800202B0-api(RtlCaptureContext)-True
OK   mimikatz-file-string(SCardControl)-True
OK   mimikatz-file-string(SCardTransmit)-True
OK   mimikatz-file-string(ACR  > )-True
OK   mimikatz-file-string(nope)-False
OK   mimikatz-file-section(.text)-True
OK   mimikatz-file-section(.nope)-False
OK   mimikatz-file-import(advapi32.CryptSetHashParam)-True
OK   mimikatz-file-import(CryptSetHashParam)-True
OK   mimikatz-file-import(kernel32.IsWow64Process)-True
OK   mimikatz-file-import(msvcrt.exit)-True
OK   mimikatz-file-import(cabinet.#11)-True
OK   mimikatz-file-import(#11)-False
OK   mimikatz-file-import(#nope)-False
OK   mimikatz-file-import(nope)-False
OK   mimikatz-file-import(advapi32.CryptAcquireContextW)-True
OK   mimikatz-file-import(advapi32.CryptAcquireContext)-True
OK   mimikatz-file-import(CryptAcquireContextW)-True
OK   mimikatz-file-import(CryptAcquireContext)-True
OK   mimikatz-function=0x401000-characteristic(loop)-False
OK   mimikatz-function=0x401000-characteristic(tight loop)-False
OK   mimikatz-function=0x401000-characteristic(stack string)-False
OK   mimikatz-function=0x401000-number(0x0)-True
OK   mimikatz-function=0x401000,bb=0x401000-characteristic(tight loop)-False
OK   mimikatz-function=0x40105D-mnemonic(push)-True
OK   mimikatz-function=0x40105D-mnemonic(movzx)-True
OK   mimikatz-function=0x40105D-mnemonic(xor)-True
OK   mimikatz-function=0x40105D-mnemonic(in)-False
OK   mimikatz-function=0x40105D-mnemonic(out)-False
OK   mimikatz-function=0x40105D-number(0xFF)-True
OK   mimikatz-function=0x40105D-number(0x3136B0)-True
OK   mimikatz-function=0x40105D-number(0xC)-False
OK   mimikatz-function=0x40105D-number(0x10)-False
OK   mimikatz-function=0x40105D-offset(0x0)-True
OK   mimikatz-function=0x40105D-offset(0x4)-True
OK   mimikatz-function=0x40105D-offset(0xC)-True
OK   mimikatz-function=0x40105D-offset(0x8)-False
OK   mimikatz-function=0x40105D-offset(0x10)-False
OK   mimikatz-function=0x40105D-string(SCardControl)-True
OK   mimikatz-function=0x40105D-string(SCardTransmit)-True
OK   mimikatz-function=0x40105D-string(ACR  > )-True
OK   mimikatz-function=0x40105D-string(nope)-False
OK   mimikatz-function=0x40105D-bytes(53 00 43 00 61 00 72 00 64 00 43 00 6F 00 6E 00 74 00 72 00 6F 00 6C 00)-True
OK   mimikatz-function=0x40105D-bytes(53 00 43 00 61 00 72 00 64 00 54 00 72 00 61 00 6E 00 73 00 6D 00 69 00 74 00)-True
OK   mimikatz-function=0x40105D-bytes(41 00 43 00 52 00 20 00 20 00 3E 00 20 00)-True
OK   mimikatz-function=0x40105D-bytes(6E 6F 70 65)-False
OK   mimikatz-function=0x40105D-characteristic(nzxor)-False
OK   mimikatz-function=0x40105D-characteristic(calls to)-True
OK   mimikatz-function=0x40105D,bb=0x401073-operand[1].number(0xFF)-True
OK   mimikatz-function=0x40105D,bb=0x401073-operand[0].number(0xFF)-False
OK   mimikatz-function=0x40105D,bb=0x4010B0-operand[0].offset(0x4)-True
OK   mimikatz-function=0x40105D,bb=0x4010B0-operand[1].offset(0x4)-False
OK   mimikatz-function=0x4011FB-offset(-0x1)-True
OK   mimikatz-function=0x4011FB-offset(-0x2)-True
OK   mimikatz-function=0x401517-characteristic(loop)-True
OK   mimikatz-function=0x401553-number(0xFFFFFFFF)-True
OK   mimikatz-function=0x401873,bb=0x4018B2,insn=0x4018C0-number(0x2)-True
OK   mimikatz-function=0x401CC7,bb=0x401CDE,insn=0x401CF6-offset(0x10)-False
OK   mimikatz-function=0x401D64,bb=0x401D73,insn=0x401D85-offset(0x80000000)-False
OK   mimikatz-function=0x402203,bb=0x402221,insn=0x40223C-offset(0x4)-True
OK   mimikatz-function=0x402EC4-characteristic(tight loop)-True
OK   mimikatz-function=0x402EC4,bb=0x402F8E-characteristic(tight loop)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptAcquireContextW)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptAcquireContext)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptGenKey)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptImportKey)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptDestroyKey)-True
OK   mimikatz-function=0x403BAC-api(CryptAcquireContextW)-True
OK   mimikatz-function=0x403BAC-api(CryptAcquireContext)-True
OK   mimikatz-function=0x403BAC-api(CryptGenKey)-True
OK   mimikatz-function=0x403BAC-api(CryptImportKey)-True
OK   mimikatz-function=0x403BAC-api(CryptDestroyKey)-True
OK   mimikatz-function=0x403BAC-api(Nope)-False
OK   mimikatz-function=0x403BAC-api(advapi32.Nope)-False
OK   mimikatz-function=0x40640e-characteristic(recursive call)-True
OK   mimikatz-function=0x40B3C6-api(LocalFree)-True
OK   mimikatz-function=0x410DFC-characteristic(nzxor)-True
OK   mimikatz-function=0x4175FF-characteristic(recursive call)-False
OK   mimikatz-function=0x4175FF-characteristic(indirect call)-True
OK   mimikatz-function=0x43e543-number(0xFFFFFFF0)-True
OK   mimikatz-function=0x44570F-bytes(FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF)-False
OK   mimikatz-function=0x44EDEF-string(INPUTEVENT)-True
OK   mimikatz-function=0x44EDEF-bytes(49 00 4E 00 50 00 55 00 54 00 45 00 56 00 45 00 4E 00 54 00)-True
OK   mimikatz-function=0x4556E5-characteristic(stack string)-True
OK   mimikatz-function=0x4556E5-api(advapi32.LsaQueryInformationPolicy)-True
OK   mimikatz-function=0x4556E5-api(LsaQueryInformationPolicy)-True
OK   mimikatz-function=0x4556E5-characteristic(peb access)-False
OK   mimikatz-function=0x4556E5-characteristic(gs access)-False
OK   mimikatz-function=0x4556E5-characteristic(cross section flow)-False
OK   mimikatz-function=0x4556E5-characteristic(indirect call)-False
OK   mimikatz-function=0x4556E5-characteristic(calls from)-True
OK   mimikatz-function=0x456BB9-characteristic(calls to)-False
OK   mimikatz-function=0x46D534-characteristic(nzxor)-False
OK   mimikatz-function=0x46D6CE-string((null))-True
OK   mimikatz-function=0x4702FD-characteristic(calls from)-False
OK   mimikatz-function=0x47153B,bb=0x4717AB,insn=0x4717B1-number(-0x30)-False
OK   mimikatz-function=0x471EAB,bb=0x471ED8,insn=0x471EE6-number(0x4)-False
SKIP pma12-04-file-characteristic(embedded pe)-True
SKIP pma16-01-file-function-name(__aulldiv)-True
SKIP pma16-01-file-os(windows)-True
SKIP pma16-01-file-os(linux)-False
SKIP pma16-01-file-arch(i386)-True
SKIP pma16-01-file-arch(amd64)-False
SKIP pma16-01-file-format(pe)-True
SKIP pma16-01-file-format(elf)-False
SKIP pma16-01-function=0x4021B0-regex(string =~ HTTP/1.0)-True
SKIP pma16-01-function=0x402F40-regex(string =~ www.practicalmalwareanalysis.com)-True
SKIP pma16-01-function=0x402F40-substring(practicalmalwareanalysis.com)-True
SKIP pma16-01-function=0x404356-os(windows)-True
SKIP pma16-01-function=0x404356-arch(i386)-True
SKIP pma16-01-function=0x404356,bb=0x4043B9-os(windows)-True
SKIP pma16-01-function=0x404356,bb=0x4043B9-arch(i386)-True
OK   mimikatz-file-import(cabinet.FCIAddFile)-True
DONE
```

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
