### PR TITLE
ignore .git/ when loading capa rules

### DIFF
--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -650,14 +650,16 @@ class CapaExplorerForm(idaapi.PluginForm):
                 rule_paths.append(rule_path)
             elif os.path.isdir(rule_path):
                 for root, dirs, files in os.walk(rule_path):
-                    if ".github" in root:
+                    if ".git" in root:
                         # the .github directory contains CI config in capa-rules
                         # this includes some .yml files
                         # these are not rules
+                        # additionally, .git has files that are not .yml and generate the warning
+                        # skip those too
                         continue
                     for file in files:
                         if not file.endswith(".yml"):
-                            if not ("/.git" in root or file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
+                            if not (file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
                                 # expect to see .git* files, readme.md, format.md, and maybe a .git directory
                                 # other things maybe are rules, but are mis-named.
                                 logger.warning("skipping non-.yml file: %s", file)

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -657,7 +657,7 @@ class CapaExplorerForm(idaapi.PluginForm):
                         continue
                     for file in files:
                         if not file.endswith(".yml"):
-                            if not (file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
+                            if not ("/.git" in root or file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
                                 # expect to see .git* files, readme.md, format.md, and maybe a .git directory
                                 # other things maybe are rules, but are mis-named.
                                 logger.warning("skipping non-.yml file: %s", file)

--- a/capa/main.py
+++ b/capa/main.py
@@ -583,20 +583,20 @@ def get_rules(rule_paths: List[str], disable_progress=False) -> List[Rule]:
         elif os.path.isdir(rule_path):
             logger.debug("reading rules from directory %s", rule_path)
             for root, dirs, files in os.walk(rule_path):
-                if ".github" in root:
+                if ".git" in root:
                     # the .github directory contains CI config in capa-rules
                     # this includes some .yml files
                     # these are not rules
+                    # additionally, .git has files that are not .yml and generate the warning
+                    # skip those too
                     continue
-
                 for file in files:
                     if not file.endswith(".yml"):
-                        if not ("/.git" in root or file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
+                        if not (file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
                             # expect to see .git* files, readme.md, format.md, and maybe a .git directory
                             # other things maybe are rules, but are mis-named.
                             logger.warning("skipping non-.yml file: %s", file)
                         continue
-
                     rule_path = os.path.join(root, file)
                     rule_file_paths.append(rule_path)
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -591,7 +591,7 @@ def get_rules(rule_paths: List[str], disable_progress=False) -> List[Rule]:
 
                 for file in files:
                     if not file.endswith(".yml"):
-                        if not (file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
+                        if not ("/.git" in root or file.startswith(".git") or file.endswith((".git", ".md", ".txt"))):
                             # expect to see .git* files, readme.md, format.md, and maybe a .git directory
                             # other things maybe are rules, but are mis-named.
                             logger.warning("skipping non-.yml file: %s", file)


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

When using a git repo version of `capa-rules`, `capa` iterates through `.git` looking for rules (which obviously doesn't have any) and emits some warnings that bloat the log. This PR filters out `/.git` when crawling the fs looking for rules.

```
WARNING:capa.ida.plugin.form:skipping non-.yml file: description
WARNING:capa.ida.plugin.form:skipping non-.yml file: config
WARNING:capa.ida.plugin.form:skipping non-.yml file: index
WARNING:capa.ida.plugin.form:skipping non-.yml file: HEAD
WARNING:capa.ida.plugin.form:skipping non-.yml file: packed-refs
WARNING:capa.ida.plugin.form:skipping non-.yml file: HEAD
WARNING:capa.ida.plugin.form:skipping non-.yml file: master
WARNING:capa.ida.plugin.form:skipping non-.yml file: HEAD
WARNING:capa.ida.plugin.form:skipping non-.yml file: fsmonitor-watchman.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-commit.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-merge-commit.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-applypatch.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: applypatch-msg.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-rebase.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: prepare-commit-msg.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-push.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: post-update.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: update.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: commit-msg.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pre-receive.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: push-to-checkout.sample
WARNING:capa.ida.plugin.form:skipping non-.yml file: pack-3d7585a4ba30f1662b7dd2f7a3dae8f86c61fd21.pack
WARNING:capa.ida.plugin.form:skipping non-.yml file: pack-3d7585a4ba30f1662b7dd2f7a3dae8f86c61fd21.idx
WARNING:capa.ida.plugin.form:skipping non-.yml file: master
WARNING:capa.ida.plugin.form:skipping non-.yml file: HEAD
WARNING:capa.ida.plugin.form:skipping non-.yml file: exclude
```

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [X] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [X] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
