### PR TITLE
ci: use macos-11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - os: windows-2022
             artifact_name: capa.exe
             asset_name: windows
-          - os: macos-10.15
+          - os: macos-11
             artifact_name: capa
             asset_name: macos
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
           - os: windows-2022
             artifact_name: capa.exe
             asset_name: windows
-          - os: macos-11
+          - os: macos-10.15
+            # use older macOS for assumed better portability
             artifact_name: capa
             asset_name: macos
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         # across all operating systems
         python-version: ["3.7", "3.10"]
         include:


### PR DESCRIPTION
Not sure if this breaks things for older macOS versions. In that case we can revert to `macos-10.15` which will still be supported.

closes #793

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
