### PR TITLE
render: display number zero vverbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Deprecation notice: as described in [#937](https://github.com/mandiant/capa/issu
 ### Bug Fixes
 - improve handling _ prefix compile/link artifact #924 @mike-hunhoff
 - better detect OS in ELF samples #988 @williballenthin
+- display number feature zero in vverbose #1097 @mike-hunhoff
 
 ### capa explorer IDA Pro plugin
 - improve file format extraction #918 @mike-hunhoff

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -145,7 +145,7 @@ def render_feature(ostream, match: rd.Match, feature: frzf.Feature, indent=0):
         ostream.write(key)
         ostream.write(": ")
 
-        if value:
+        if value or key == "number":
             ostream.write(rutils.bold2(value))
 
             if feature.description:

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -143,6 +143,7 @@ def render_feature(ostream, match: rd.Match, feature: frzf.Feature, indent=0):
             value = render_string_value(value)
 
         if key == "number":
+            assert isinstance(value, int)
             value = hex(value)
 
         ostream.write(key)

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -142,10 +142,13 @@ def render_feature(ostream, match: rd.Match, feature: frzf.Feature, indent=0):
         if key == "string":
             value = render_string_value(value)
 
+        if key == "number":
+            value = hex(value)
+
         ostream.write(key)
         ostream.write(": ")
 
-        if value or key == "number":
+        if value:
             ostream.write(rutils.bold2(value))
 
             if feature.description:


### PR DESCRIPTION
also, display `number` features as hex.


<img width="1228" alt="Screen Shot 2022-07-07 at 3 31 22 PM" src="https://user-images.githubusercontent.com/42192796/177875035-a8ecd367-0677-4a65-ad6e-f05a02d0b4ac.png">

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [X] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
