### PR TITLE
linter: use pydantic to validate rule metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 
 
 ### Bug Fixes
+- linter: use pydantic to validate rule metadata #1141 @mike-hunhoff
 
 ### capa explorer IDA Pro plugin
 


### PR DESCRIPTION
addresses #1138

- [x] linter: update scripts/lint.py to validate rule metadata using pydantic
- [x] linter: fix rule count

see https://github.com/mandiant/capa-rules/issues/606 for affected rules (41)