### PR TITLE
Add Optional attribute to argv property in Metadata model. 

### DIFF
--- a/capa/render/result_document.py
+++ b/capa/render/result_document.py
@@ -75,7 +75,7 @@ class Analysis(FrozenModel):
 class Metadata(FrozenModel):
     timestamp: datetime.datetime
     version: str
-    argv: Tuple[str, ...]
+    argv: Optional[Tuple[str, ...]]
     sample: Sample
     analysis: Analysis
 


### PR DESCRIPTION
This fixes an issue where a ValidationError is raised when `argv` is not in the passed metadata and set to None in the function from_capa.

Example Exception 
```
...
  File "../capa/render/result_document.py", line 88, in from_capa
    return cls(
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Metadata
argv
  none is not an allowed value (type=type_error.none.not_allowed)
```

Current definition expects a Tuple
https://github.com/mandiant/capa/blob/master/capa/render/result_document.py#L78

When `argv` is not within the passed fields, the function will set the value to None 
https://github.com/mandiant/capa/blob/master/capa/render/result_document.py#L87

[x] No CHANGELOG update needed
