### PR TITLE
Fix maec.malware_category_ov typo in vverbose render

### DIFF
--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -289,7 +289,7 @@ def render_rules(ostream, doc: rd.ResultDocument):
         if rule.meta.maec.malware_family:
             rows.append(("maec/malware-family", rule.meta.maec.malware_family))
 
-        if rule.meta.maec.malware_category or rule.meta.maec.malware_category:
+        if rule.meta.maec.malware_category or rule.meta.maec.malware_category_ov:
             rows.append(
                 ("maec/malware-category", rule.meta.maec.malware_category or rule.meta.maec.malware_category_ov)
             )


### PR DESCRIPTION
Small fix to correct a typo in the vverbose render.

### Checklist
- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
