### PR TITLE
fix: display instruction items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 -  render: convert feature attributes to aliased dictionary for vverbose #1152 @mike-hunhoff
 
 ### capa explorer IDA Pro plugin
+- fix: display instruction items #1154 @mr-tz
 
 ### Development
 

--- a/capa/ida/plugin/item.py
+++ b/capa/ida/plugin/item.py
@@ -274,6 +274,12 @@ class CapaExplorerBlockItem(CapaExplorerDataItem):
         super(CapaExplorerBlockItem, self).__init__(parent, [self.fmt % ea, ea_to_hex(ea), ""])
 
 
+class CapaExplorerInstructionItem(CapaExplorerBlockItem):
+    """store data for instruction match"""
+
+    fmt = "instruction(loc_%08X)"
+
+
 class CapaExplorerDefaultItem(CapaExplorerDataItem):
     """store data for default match e.g. statement (and, or)"""
 

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -31,6 +31,7 @@ from capa.ida.plugin.item import (
     CapaExplorerSubscopeItem,
     CapaExplorerRuleMatchItem,
     CapaExplorerStringViewItem,
+    CapaExplorerInstructionItem,
     CapaExplorerInstructionViewItem,
 )
 from capa.features.address import Address, AbsoluteVirtualAddress
@@ -493,6 +494,8 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                     parent2 = CapaExplorerFunctionItem(parent, location)
                 elif rule.meta.scope == capa.rules.BASIC_BLOCK_SCOPE:
                     parent2 = CapaExplorerBlockItem(parent, location)
+                elif rule.meta.scope == capa.rules.INSTRUCTION_SCOPE:
+                    parent2 = CapaExplorerInstructionItem(parent, location)
                 else:
                     raise RuntimeError("unexpected rule scope: " + str(rule.meta.scope))
 

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -143,6 +143,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                     CapaExplorerFunctionItem,
                     CapaExplorerFeatureItem,
                     CapaExplorerSubscopeItem,
+                    CapaExplorerInstructionItem,
                 ),
             )
             and column == CapaExplorerDataModel.COLUMN_INDEX_RULE_INFORMATION


### PR DESCRIPTION
closes #1154

result:
![2022-08-23_16-04-26](https://user-images.githubusercontent.com/17606537/186179042-f2ba6b9e-028b-44cc-bad3-006003637427.png)

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
