### PR TITLE
feat: verify rule metadata format on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### New Features
+- verify rule metadata format on load #1160 @mr-tz
 
 ### Breaking Changes
 

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -27,6 +27,7 @@ except ImportError:
 from typing import Any, Set, Dict, List, Tuple, Union, Iterator
 
 import yaml
+import pydantic
 import ruamel.yaml
 
 import capa.perf
@@ -800,8 +801,16 @@ class Rule:
     def from_yaml_file(cls, path, use_ruamel=False):
         with open(path, "rb") as f:
             try:
-                return cls.from_yaml(f.read().decode("utf-8"), use_ruamel=use_ruamel)
+                rule = cls.from_yaml(f.read().decode("utf-8"), use_ruamel=use_ruamel)
+                # import here to avoid circular dependency
+                from capa.render.result_document import RuleMetadata
+
+                # validate meta data fields
+                _ = RuleMetadata.from_capa(rule)
+                return rule
             except InvalidRule as e:
+                raise InvalidRuleWithPath(path, str(e))
+            except pydantic.ValidationError as e:
                 raise InvalidRuleWithPath(path, str(e))
 
     def to_yaml(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,8 @@ def test_main_single_rule(z9324d_extractor, tmpdir):
             meta:
                 name: test rule
                 scope: file
+                authors:
+                  - test
             features:
               - string: test
         """


### PR DESCRIPTION
Avoid to load and match to then fail on invalid rule meta when rendering.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
