### PR TITLE
dotnet: emit features from newobj instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 - verify rule metadata format on load #1160 @mr-tz
 - extract property features from .NET PE files #1168 @anushkavirgaonkar
+- emit features for .NET newobj instruction #1186 @mike-hunhoff
 
 ### Breaking Changes
 

--- a/capa/features/extractors/dnfile/helpers.py
+++ b/capa/features/extractors/dnfile/helpers.py
@@ -52,6 +52,8 @@ class DnType(object):
         self.class_ = class_
         if member == ".ctor":
             member = "ctor"
+        if member == ".cctor":
+            member = "cctor"
         self.member = member
 
     def __hash__(self):

--- a/capa/features/extractors/dnfile/helpers.py
+++ b/capa/features/extractors/dnfile/helpers.py
@@ -50,6 +50,8 @@ class DnType(object):
         self.access = access
         self.namespace = namespace
         self.class_ = class_
+        if member == ".ctor":
+            member = "ctor"
         self.member = member
 
     def __hash__(self):

--- a/capa/features/extractors/dnfile/insn.py
+++ b/capa/features/extractors/dnfile/insn.py
@@ -94,7 +94,7 @@ def extract_insn_api_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Iterato
     """parse instruction API features"""
     insn: Instruction = ih.inner
 
-    if insn.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli):
+    if insn.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli, OpCodes.Newobj):
         return
 
     callee: Union[DnType, DnUnmanagedMethod, None] = get_callee(fh.ctx, insn.operand.value)
@@ -188,6 +188,7 @@ def extract_insn_class_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Itera
         OpCodes.Ldsflda,
         OpCodes.Stfld,
         OpCodes.Stsfld,
+        OpCodes.Newobj,
     ):
         return
 
@@ -220,6 +221,7 @@ def extract_insn_namespace_features(fh: FunctionHandle, bh, ih: InsnHandle) -> I
         OpCodes.Ldsflda,
         OpCodes.Stfld,
         OpCodes.Stsfld,
+        OpCodes.Newobj,
     ):
         return
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -725,7 +725,7 @@ FEATURE_PRESENCE_TESTS_DOTNET = sorted(
         ("b9f5b", "file", OS(OS_ANY), True),
         ("b9f5b", "file", Format(FORMAT_DOTNET), True),
         ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::Main"), True),
-        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::.ctor"), True),
+        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::ctor"), True),
         ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::.cctor"), False),
         ("hello-world", "file", capa.features.common.String("Hello World!"), True),
         ("hello-world", "file", capa.features.common.Class("HelloWorld"), True),

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -726,7 +726,7 @@ FEATURE_PRESENCE_TESTS_DOTNET = sorted(
         ("b9f5b", "file", Format(FORMAT_DOTNET), True),
         ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::Main"), True),
         ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::ctor"), True),
-        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::.cctor"), False),
+        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::cctor"), False),
         ("hello-world", "file", capa.features.common.String("Hello World!"), True),
         ("hello-world", "file", capa.features.common.Class("HelloWorld"), True),
         ("hello-world", "file", capa.features.common.Class("System.Console"), True),


### PR DESCRIPTION
Objects created via the `newobj` instruction are emitted as `api` features using the hard-coded method name `ctor` e.g. `System.Threading.Mutex::ctor`. This addition enables users to write rules specific to objects created at runtime in .NET.

see https://github.com/mandiant/capa-rules/pull/626 for example rules.

closes #1150 