### PR TITLE
dotnet: emit namespace/class features for ldvirtftn/ldftn instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - dotnet: emit API features for generic methods #1231 @mike-hunhoff
 - Python 3.11 support #1192 @williballenthin
 - dotnet: emit calls to/from MethodDef methods #1236 @mike-hunhoff
+- dotnet: emit namespace/class features for ldvirtftn/ldftn instructions #1241 @mike-hunhoff
 
 ### Breaking Changes
 

--- a/capa/features/extractors/dnfile/extractor.py
+++ b/capa/features/extractors/dnfile/extractor.py
@@ -57,17 +57,24 @@ class DnfileFeatureExtractor(FeatureExtractor):
         # calculate unique calls to/from each method
         for fh in methods.values():
             for insn in fh.inner.instructions:
-                if insn.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli, OpCodes.Newobj):
+                if insn.opcode not in (
+                    OpCodes.Call,
+                    OpCodes.Callvirt,
+                    OpCodes.Jmp,
+                    OpCodes.Newobj,
+                ):
                     continue
 
+                address: DNTokenAddress = DNTokenAddress(insn.operand.value)
+
                 # record call to destination method; note: we only consider MethodDef methods for destinations
-                dest: Optional[FunctionHandle] = methods.get(DNTokenAddress(insn.operand.value), None)
+                dest: Optional[FunctionHandle] = methods.get(address, None)
                 if dest is not None:
                     dest.ctx["calls_to"].add(fh.address)
 
                 # record call from source method; note: we record all unique calls from a MethodDef method, not just
                 # those calls to other MethodDef methods e.g. calls to imported MemberRef methods
-                fh.ctx["calls_from"].add(DNTokenAddress(insn.operand.value))
+                fh.ctx["calls_from"].add(address)
 
         yield from methods.values()
 

--- a/capa/features/extractors/dnfile/insn.py
+++ b/capa/features/extractors/dnfile/insn.py
@@ -96,7 +96,12 @@ def get_callee(ctx: Dict, token: Token) -> Union[DnType, DnUnmanagedMethod, None
 
 def extract_insn_api_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Iterator[Tuple[Feature, Address]]:
     """parse instruction API features"""
-    if ih.inner.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli, OpCodes.Newobj):
+    if ih.inner.opcode not in (
+        OpCodes.Call,
+        OpCodes.Callvirt,
+        OpCodes.Jmp,
+        OpCodes.Newobj,
+    ):
         return
 
     callee: Union[DnType, DnUnmanagedMethod, None] = get_callee(fh.ctx, ih.inner.operand)
@@ -116,7 +121,7 @@ def extract_insn_property_features(fh: FunctionHandle, bh, ih: InsnHandle) -> It
     name: Optional[str] = None
     access: Optional[str] = None
 
-    if ih.inner.opcode in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli):
+    if ih.inner.opcode in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp):
         # property access via MethodDef or MemberRef
         callee: Union[DnType, DnUnmanagedMethod, None] = get_callee(fh.ctx, ih.inner.operand)
         if isinstance(callee, DnType):
@@ -150,7 +155,8 @@ def extract_insn_class_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Itera
         OpCodes.Call,
         OpCodes.Callvirt,
         OpCodes.Jmp,
-        OpCodes.Calli,
+        OpCodes.Ldvirtftn,
+        OpCodes.Ldftn,
         OpCodes.Newobj,
     ):
         # method call - includes managed methods (MethodDef, TypeRef) and properties (MethodSemantics, TypeRef)
@@ -178,7 +184,8 @@ def extract_insn_namespace_features(fh: FunctionHandle, bh, ih: InsnHandle) -> I
         OpCodes.Call,
         OpCodes.Callvirt,
         OpCodes.Jmp,
-        OpCodes.Calli,
+        OpCodes.Ldvirtftn,
+        OpCodes.Ldftn,
         OpCodes.Newobj,
     ):
         # method call - includes managed methods (MethodDef, TypeRef) and properties (MethodSemantics, TypeRef)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -762,6 +762,8 @@ FEATURE_PRESENCE_TESTS_DOTNET = sorted(
         ("_692f", "token=0x6000004", capa.features.insn.API("System.Linq.Enumerable::First"), True),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Namespace("System.Linq"), True),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Class("System.Linq.Enumerable"), True),  # generic method
+        ("_1c444", "token=0x6000020", capa.features.common.Namespace("Reqss"), True),  # ldftn
+        ("_1c444", "token=0x6000020", capa.features.common.Class("Reqss.Reqss"), True),  # ldftn
         (
             "_1c444",
             "function=0x1F59, bb=0x1F59, insn=0x1F5B",


### PR DESCRIPTION
closes #1117 