### PR TITLE
dotnet: emit namespace/class features for type references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Python 3.11 support #1192 @williballenthin
 - dotnet: emit calls to/from MethodDef methods #1236 @mike-hunhoff
 - dotnet: emit namespace/class features for ldvirtftn/ldftn instructions #1241 @mike-hunhoff
+- dotnet: emit namespace/class features for type references #1242 @mike-hunhoff
 
 ### Breaking Changes
 

--- a/capa/features/extractors/dnfile/extractor.py
+++ b/capa/features/extractors/dnfile/extractor.py
@@ -20,7 +20,7 @@ import capa.features.extractors.dnfile.insn
 import capa.features.extractors.dnfile.function
 from capa.features.common import Feature
 from capa.features.address import NO_ADDRESS, Address, DNTokenAddress, DNTokenOffsetAddress
-from capa.features.extractors.dnfile.types import DnfileFeatureCache, DnfileFeatureExtractorType
+from capa.features.extractors.dnfile.types import DnType, DnUnmanagedMethod
 from capa.features.extractors.base_extractor import BBHandle, InsnHandle, FunctionHandle, FeatureExtractor
 from capa.features.extractors.dnfile.helpers import (
     get_dotnet_types,
@@ -32,31 +32,49 @@ from capa.features.extractors.dnfile.helpers import (
 )
 
 
+class DnFileFeatureExtractorCache:
+    def __init__(self, pe: dnfile.dnPE):
+        self.imports: Dict[int, Union[DnType, DnUnmanagedMethod]] = {}
+        self.native_imports: Dict[int, Union[DnType, DnUnmanagedMethod]] = {}
+        self.methods: Dict[int, Union[DnType, DnUnmanagedMethod]] = {}
+        self.fields: Dict[int, Union[DnType, DnUnmanagedMethod]] = {}
+        self.types: Dict[int, Union[DnType, DnUnmanagedMethod]] = {}
+
+        for import_ in get_dotnet_managed_imports(pe):
+            self.imports[import_.token] = import_
+        for native_import in get_dotnet_unmanaged_imports(pe):
+            self.native_imports[native_import.token] = native_import
+        for method in get_dotnet_managed_methods(pe):
+            self.methods[method.token] = method
+        for field in get_dotnet_fields(pe):
+            self.fields[field.token] = field
+        for type_ in get_dotnet_types(pe):
+            self.types[type_.token] = type_
+
+    def get_import(self, token: int) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+        return self.imports.get(token, None)
+
+    def get_native_import(self, token: int) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+        return self.native_imports.get(token, None)
+
+    def get_method(self, token: int) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+        return self.methods.get(token, None)
+
+    def get_field(self, token: int) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+        return self.fields.get(token, None)
+
+    def get_type(self, token: int) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+        return self.types.get(token, None)
+
+
 class DnfileFeatureExtractor(FeatureExtractor):
     def __init__(self, path: str):
         super().__init__()
         self.pe: dnfile.dnPE = dnfile.dnPE(path)
 
-        # cached .NET token lookup tables
-        self.tokens: Dict[DnfileFeatureCache, Dict[int, DnfileFeatureExtractorType]] = {}
-        for value in DnfileFeatureCache:
-            self.tokens[value] = {}
-
-        # pre-compute .NET token lookup tables
-        for import_ in get_dotnet_managed_imports(self.pe):
-            self.tokens[DnfileFeatureCache.Imports][import_.token] = import_
-
-        for native_import in get_dotnet_unmanaged_imports(self.pe):
-            self.tokens[DnfileFeatureCache.NativeImports][native_import.token] = native_import
-
-        for method in get_dotnet_managed_methods(self.pe):
-            self.tokens[DnfileFeatureCache.Methods][method.token] = method
-
-        for field in get_dotnet_fields(self.pe):
-            self.tokens[DnfileFeatureCache.Fields][field.token] = field
-
-        for type_ in get_dotnet_types(self.pe):
-            self.tokens[DnfileFeatureCache.Types][type_.token] = type_
+        # pre-compute .NET token lookup tables; each .NET method has access to this cache for feature extraction
+        # most relevant at instruction scope
+        self.token_cache: DnFileFeatureExtractorCache = DnFileFeatureExtractorCache(self.pe)
 
         # pre-compute these because we'll yield them at *every* scope.
         self.global_features: List[Tuple[Feature, Address]] = []
@@ -79,7 +97,7 @@ class DnfileFeatureExtractor(FeatureExtractor):
             fh: FunctionHandle = FunctionHandle(
                 address=DNTokenAddress(token),
                 inner=method,
-                ctx={"pe": self.pe, "calls_from": set(), "calls_to": set(), "tokens": self.tokens},
+                ctx={"pe": self.pe, "calls_from": set(), "calls_to": set(), "cache": self.token_cache},
             )
 
             # method tokens should be unique

--- a/capa/features/extractors/dnfile/helpers.py
+++ b/capa/features/extractors/dnfile/helpers.py
@@ -306,20 +306,12 @@ def get_dotnet_unmanaged_imports(pe: dnfile.dnPE) -> Iterator[DnUnmanagedMethod]
 
 
 def get_dotnet_types(pe: dnfile.dnPE) -> Iterator[DnType]:
-    """ """
+    """get .NET types from TypeDef and TypeRef tables"""
     for (rid, typedef) in iter_dotnet_table(pe, dnfile.mdtable.TypeDef.number):
         assert isinstance(typedef, dnfile.mdtable.TypeDefRow)
 
         typedef_token: int = calculate_dotnet_token_value(dnfile.mdtable.TypeDef.number, rid)
         yield DnType(typedef_token, typedef.TypeName, namespace=typedef.TypeNamespace)
-
-        if isinstance(typedef.Extends, dnfile.mdtable.TypeSpecRow):
-            if typedef.Extends.table is None:
-                logger.debug("TypeDef[0x%X] Extends table is None", rid)
-                continue
-
-            typespec_token: int = calculate_dotnet_token_value(typedef.Extends.table.number, typedef.Extends.row_index)
-            yield DnType(typespec_token, typedef.TypeName, namespace=typedef.TypeNamespace)
 
     for (rid, typeref) in iter_dotnet_table(pe, dnfile.mdtable.TypeRef.number):
         assert isinstance(typeref, dnfile.mdtable.TypeRefRow)

--- a/capa/features/extractors/dnfile/helpers.py
+++ b/capa/features/extractors/dnfile/helpers.py
@@ -18,12 +18,7 @@ from dncil.clr.token import Token, StringToken, InvalidToken
 from dncil.cil.body.reader import CilMethodBodyReaderBase
 
 from capa.features.common import FeatureAccess
-from capa.features.extractors.dnfile.types import (
-    DnType,
-    DnUnmanagedMethod,
-    DnfileFeatureCache,
-    DnfileFeatureExtractorType,
-)
+from capa.features.extractors.dnfile.types import DnType, DnUnmanagedMethod
 
 logger = logging.getLogger(__name__)
 
@@ -338,10 +333,3 @@ def iter_dotnet_table(pe: dnfile.dnPE, table_index: int) -> Iterator[Tuple[int, 
     for (rid, row) in enumerate(pe.net.mdtables.tables.get(table_index, [])):
         # .NET tables are 1-indexed
         yield rid + 1, row
-
-
-def get_cached_token(
-    caches: Dict[DnfileFeatureCache, Dict[int, DnfileFeatureExtractorType]], token: int, cache: DnfileFeatureCache
-) -> Optional[DnfileFeatureExtractorType]:
-    assert cache in DnfileFeatureCache
-    return caches[cache].get(token, None)

--- a/capa/features/extractors/dnfile/insn.py
+++ b/capa/features/extractors/dnfile/insn.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Tuple, Union, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Dict, Tuple, Union, Iterator, Optional
 
 if TYPE_CHECKING:
     from capa.features.extractors.dnfile.extractor import DnFileFeatureExtractorCache
@@ -33,14 +33,12 @@ from capa.features.extractors.dnfile.helpers import (
 logger = logging.getLogger(__name__)
 
 
-def get_callee(
-    pe: dnfile.dnPE, cache: DnFileFeatureExtractorCache, token: Token
-) -> Optional[Union[DnType, DnUnmanagedMethod]]:
+def get_callee(ctx: Dict[str, Any], token: Token) -> Optional[Union[DnType, DnUnmanagedMethod]]:
     """map .NET token to un/managed (generic) method"""
     token_: int
     if token.table == dnfile.mdtable.MethodSpec.number:
         # map MethodSpec to MethodDef or MemberRef
-        row: Union[dnfile.base.MDTableRow, InvalidToken, str] = resolve_dotnet_token(pe, token)
+        row: Union[dnfile.base.MDTableRow, InvalidToken, str] = resolve_dotnet_token(ctx["pe"], token)
         assert isinstance(row, dnfile.mdtable.MethodSpecRow)
 
         if row.Method.table is None:
@@ -51,13 +49,13 @@ def get_callee(
     else:
         token_ = token.value
 
-    callee: Optional[Union[DnType, DnUnmanagedMethod]] = cache.get_import(token_)
+    callee: Optional[Union[DnType, DnUnmanagedMethod]] = ctx["cache"].get_import(token_)
     if callee is None:
         # we must check unmanaged imports before managed methods because we map forwarded managed methods
         # to their unmanaged imports; we prefer a forwarded managed method be mapped to its unmanaged import for analysis
-        callee = cache.get_native_import(token_)
+        callee = ctx["cache"].get_native_import(token_)
         if callee is None:
-            callee = cache.get_method(token_)
+            callee = ctx["cache"].get_method(token_)
     return callee
 
 
@@ -71,7 +69,7 @@ def extract_insn_api_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Iterato
     ):
         return
 
-    callee: Optional[Union[DnType, DnUnmanagedMethod]] = get_callee(fh.ctx["pe"], fh.ctx["cache"], ih.inner.operand)
+    callee: Optional[Union[DnType, DnUnmanagedMethod]] = get_callee(fh.ctx, ih.inner.operand)
     if isinstance(callee, DnType):
         # ignore methods used to access properties
         if callee.access is None:
@@ -90,7 +88,7 @@ def extract_insn_property_features(fh: FunctionHandle, bh, ih: InsnHandle) -> It
 
     if ih.inner.opcode in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp):
         # property access via MethodDef or MemberRef
-        callee: Optional[Union[DnType, DnUnmanagedMethod]] = get_callee(fh.ctx["pe"], fh.ctx["cache"], ih.inner.operand)
+        callee: Optional[Union[DnType, DnUnmanagedMethod]] = get_callee(fh.ctx, ih.inner.operand)
         if isinstance(callee, DnType):
             if callee.access is not None:
                 name = str(callee)
@@ -131,7 +129,7 @@ def extract_insn_namespace_class_features(
         OpCodes.Newobj,
     ):
         # method call - includes managed methods (MethodDef, TypeRef) and properties (MethodSemantics, TypeRef)
-        type_ = get_callee(fh.ctx["pe"], fh.ctx["cache"], ih.inner.operand)
+        type_ = get_callee(fh.ctx, ih.inner.operand)
 
     elif ih.inner.opcode in (
         OpCodes.Ldfld,

--- a/capa/features/extractors/dnfile/insn.py
+++ b/capa/features/extractors/dnfile/insn.py
@@ -126,7 +126,7 @@ def extract_insn_property_features(fh: FunctionHandle, bh, ih: InsnHandle) -> It
 def extract_insn_namespace_class_features(
     fh: FunctionHandle, bh, ih: InsnHandle
 ) -> Iterator[Tuple[Union[Namespace, Class], Address]]:
-    """parse instruction class features"""
+    """parse instruction namespace and class features"""
     type_: Optional[DnfileFeatureExtractorType] = None
 
     if ih.inner.opcode in (
@@ -204,7 +204,7 @@ def extract_insn_string_features(fh: FunctionHandle, bh, ih: InsnHandle) -> Iter
 def extract_unmanaged_call_characteristic_features(
     fh: FunctionHandle, bb: BBHandle, ih: InsnHandle
 ) -> Iterator[Tuple[Characteristic, Address]]:
-    if ih.inner.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp, OpCodes.Calli):
+    if ih.inner.opcode not in (OpCodes.Call, OpCodes.Callvirt, OpCodes.Jmp):
         return
 
     row: Union[str, InvalidToken, dnfile.base.MDTableRow] = resolve_dotnet_token(fh.ctx["pe"], ih.inner.operand)

--- a/capa/features/extractors/dnfile/types.py
+++ b/capa/features/extractors/dnfile/types.py
@@ -73,14 +73,3 @@ class DnUnmanagedMethod:
     @staticmethod
     def format_name(module, method):
         return f"{module}.{method}"
-
-
-class DnfileFeatureCache(Enum):
-    Imports = 1
-    Methods = 2
-    Fields = 3
-    Types = 4
-    NativeImports = 5
-
-
-DnfileFeatureExtractorType = Union[DnType, DnUnmanagedMethod]

--- a/capa/features/extractors/dnfile/types.py
+++ b/capa/features/extractors/dnfile/types.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2020 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from enum import Enum
+from typing import Union, Optional
+
+
+class DnType(object):
+    def __init__(self, token: int, class_: str, namespace: str = "", member: str = "", access: Optional[str] = None):
+        self.token: int = token
+        self.access: Optional[str] = access
+        self.namespace: str = namespace
+        self.class_: str = class_
+
+        if member == ".ctor":
+            member = "ctor"
+        if member == ".cctor":
+            member = "cctor"
+
+        self.member: str = member
+
+    def __hash__(self):
+        return hash((self.token, self.access, self.namespace, self.class_, self.member))
+
+    def __eq__(self, other):
+        return (
+            self.token == other.token
+            and self.access == other.access
+            and self.namespace == other.namespace
+            and self.class_ == other.class_
+            and self.member == other.member
+        )
+
+    def __str__(self):
+        return DnType.format_name(self.class_, namespace=self.namespace, member=self.member)
+
+    def __repr__(self):
+        return str(self)
+
+    @staticmethod
+    def format_name(class_: str, namespace: str = "", member: str = ""):
+        # like File::OpenRead
+        name: str = f"{class_}::{member}" if member else class_
+        if namespace:
+            # like System.IO.File::OpenRead
+            name = f"{namespace}.{name}"
+        return name
+
+
+class DnUnmanagedMethod:
+    def __init__(self, token: int, module: str, method: str):
+        self.token: int = token
+        self.module: str = module
+        self.method: str = method
+
+    def __hash__(self):
+        return hash((self.token, self.module, self.method))
+
+    def __eq__(self, other):
+        return self.token == other.token and self.module == other.module and self.method == other.method
+
+    def __str__(self):
+        return DnUnmanagedMethod.format_name(self.module, self.method)
+
+    def __repr__(self):
+        return str(self)
+
+    @staticmethod
+    def format_name(module, method):
+        return f"{module}.{method}"
+
+
+class DnfileFeatureCache(Enum):
+    Imports = 1
+    Methods = 2
+    Fields = 3
+    Types = 4
+    NativeImports = 5
+
+
+DnfileFeatureExtractorType = Union[DnType, DnUnmanagedMethod]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -760,7 +760,12 @@ FEATURE_PRESENCE_TESTS_DOTNET = sorted(
         ("_1c444", "function=0x1F68", capa.features.insn.Number(0x0), True),
         ("_1c444", "function=0x1F68", capa.features.insn.Number(0x1), False),
         ("_692f", "token=0x6000004", capa.features.insn.API("System.Linq.Enumerable::First"), True),  # generic method
-        ("_692f", "token=0x6000004", capa.features.insn.Property("System.Linq.Enumerable::First"), False),  # generic method
+        (
+            "_692f",
+            "token=0x6000004",
+            capa.features.insn.Property("System.Linq.Enumerable::First"),
+            False,
+        ),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Namespace("System.Linq"), True),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Class("System.Linq.Enumerable"), True),  # generic method
         ("_1c444", "token=0x6000020", capa.features.common.Namespace("Reqss"), True),  # ldftn

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -760,6 +760,7 @@ FEATURE_PRESENCE_TESTS_DOTNET = sorted(
         ("_1c444", "function=0x1F68", capa.features.insn.Number(0x0), True),
         ("_1c444", "function=0x1F68", capa.features.insn.Number(0x1), False),
         ("_692f", "token=0x6000004", capa.features.insn.API("System.Linq.Enumerable::First"), True),  # generic method
+        ("_692f", "token=0x6000004", capa.features.insn.Property("System.Linq.Enumerable::First"), False),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Namespace("System.Linq"), True),  # generic method
         ("_692f", "token=0x6000004", capa.features.common.Class("System.Linq.Enumerable"), True),  # generic method
         ("_1c444", "token=0x6000020", capa.features.common.Namespace("Reqss"), True),  # ldftn


### PR DESCRIPTION
closes #982 

cache .NET token lookup tables per extractor instead of per .NET method.
