### PR TITLE
explorer: improve ruleset error messaging and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - fix: accept only plaintext pasted content #1194 @williballenthin
 - fix: UnboundLocalError #1217 @williballenthin
 - extractor: add support for COFF files and extern functions #1223 @mike-hunhoff
+- doc: improve error messaging and documentation related to capa ruleset #1249 @mike-hunhoff
 
 ### Development
 

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -64,7 +64,7 @@ capa explorer is limited to the file types supported by capa, which include:
 4. Click the `Analyze` button
 
 The first time you run capa explorer you will be asked to specify a local directory containing capa rules to use for analysis. We recommend downloading and extracting the [official capa rules](https://github.com/mandiant/capa-rules/releases) that match 
-the version of capa you have installed (see installation instructions above for more details). capa explorer remembers you selection for future analysis which you
+the version of capa you have installed (see installation instructions above for more details). capa explorer remembers your selection for future analysis which you
 can update using the `Settings` button.
 
 #### Tips for Program Analysis

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -40,7 +40,7 @@ You can install capa explorer using the following steps:
     ```
     $ pip install flare-capa
     ```
-2. Download and extract the [official capa rule set](https://github.com/mandiant/capa-rules/releases) that matches the version of capa you have installed
+2. Download and extract the [official capa rules](https://github.com/mandiant/capa-rules/releases) that match the version of capa you have installed
    1. Use the following command to view the version of capa you have installed:
    ```commandline
     $ pip show flare-capa
@@ -63,7 +63,7 @@ capa explorer is limited to the file types supported by capa, which include:
 3. Select the `Program Analysis` tab
 4. Click the `Analyze` button
 
-The first time you run capa explorer you will be asked to specify a local capa rule set to use for analysis. We recommend downloading and extracting the [official capa rule set](https://github.com/mandiant/capa-rules/releases) that matches 
+The first time you run capa explorer you will be asked to specify a local directory containing capa rules to use for analysis. We recommend downloading and extracting the [official capa rules](https://github.com/mandiant/capa-rules/releases) that match 
 the version of capa you have installed (see installation instructions above for more details). capa explorer remembers you selection for future analysis which you
 can update using the `Settings` button.
 
@@ -71,7 +71,7 @@ can update using the `Settings` button.
 
 * Start analysis by clicking the `Analyze` button
 * Reset the plugin user interface and remove highlighting from your Disassembly view by clicking the `Reset` button
-* Change your capa rule set and other default settings by clicking the `Settings` button
+* Change your local capa rules directory and other default settings by clicking the `Settings` button
 * Hover your cursor over a rule match to view the source content of the rule
 * Double-click the `Address` column to navigate your Disassembly view to the address of the associated feature
 * Double-click a result in the `Rule Information` column to expand its children

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -40,7 +40,7 @@ You can install capa explorer using the following steps:
     ```
     $ pip install flare-capa
     ```
-2. Download and extract the [official capa ruleset](https://github.com/mandiant/capa-rules/releases) that matches the version of capa you have installed
+2. Download and extract the [official capa rule set](https://github.com/mandiant/capa-rules/releases) that matches the version of capa you have installed
    1. Use the following command to view the version of capa you have installed:
    ```commandline
     $ pip show flare-capa
@@ -63,7 +63,7 @@ capa explorer is limited to the file types supported by capa, which include:
 3. Select the `Program Analysis` tab
 4. Click the `Analyze` button
 
-The first time you run capa explorer you will be asked to specify a local capa ruleset to use for analysis. We recommend downloading and extracting the [official capa ruleset](https://github.com/mandiant/capa-rules/releases) that matches 
+The first time you run capa explorer you will be asked to specify a local capa rule set to use for analysis. We recommend downloading and extracting the [official capa rule set](https://github.com/mandiant/capa-rules/releases) that matches 
 the version of capa you have installed (see installation instructions above for more details). capa explorer remembers you selection for future analysis which you
 can update using the `Settings` button.
 
@@ -71,7 +71,7 @@ can update using the `Settings` button.
 
 * Start analysis by clicking the `Analyze` button
 * Reset the plugin user interface and remove highlighting from your Disassembly view by clicking the `Reset` button
-* Change your capa ruleset and other default settings by clicking the `Settings` button
+* Change your capa rule set and other default settings by clicking the `Settings` button
 * Hover your cursor over a rule match to view the source content of the rule
 * Double-click the `Address` column to navigate your Disassembly view to the address of the associated feature
 * Double-click a result in the `Rule Information` column to expand its children

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -1,8 +1,8 @@
 ![capa explorer](../../../.github/capa-explorer-logo.png)
 
 capa explorer is an IDAPython plugin that integrates the FLARE team's open-source framework, capa, with IDA Pro. capa is a framework that uses a well-defined collection of rules to 
-identify capabilities in a program. You can run capa against a PE file or shellcode and it tells you what it thinks the program can do. For example, it might suggest that 
-the program is a backdoor, can install services, or relies on HTTP to communicate. capa explorer runs capa directly against your IDA Pro database (IDB) without requiring access
+identify capabilities in a program. You can run capa against a PE file, ELF file, or shellcode and it tells you what it thinks the program can do. For example, it might suggest that 
+the program is a backdoor, can install services, or relies on HTTP to communicate. capa explorer runs capa analysis on your IDA Pro database (IDB) without needing access
 to the original binary file. Once a database has been analyzed, capa explorer helps you identify interesting areas of a program and build new capa rules using features extracted from your IDB.
 
 We love using capa explorer during malware analysis because it teaches us what parts of a program suggest a behavior. As we click on rows, capa explorer jumps directly 
@@ -21,10 +21,10 @@ We can use capa explorer to navigate our Disassembly view directly to the suspec
 Using the `Rule Information` and `Details` columns capa explorer shows us that the suspect function matched `self delete via COMSPEC environment variable` because it contains capa rule matches for `create process`, `get COMSPEC environment variable`,
 and `query environment variable`, references to the strings `COMSPEC`, ` > nul`, and `/c del `, and calls to the Windows API functions `GetEnvironmentVariableA` and `ShellExecuteEx`.
 
-capa explorer also helps you build new capa rules. To start select the `Rule Generator` tab, navigate to a function in your Disassembly view,
+capa explorer also helps you build and test new capa rules. To start, select the `Rule Generator` tab, navigate to a function in your Disassembly view,
 and click `Analyze`. capa explorer will extract features from the function and display them in the `Features` pane. You can add features listed in this pane to the `Editor` pane
 by either double-clicking a feature or using multi-select + right-click to add multiple features at once. The `Preview` and `Editor` panes help edit your rule. Use the `Preview` pane
-to modify the rule text directly and the `Editor` pane to construct and rearrange your hierarchy of statements and features. When you finish a rule you can save it directly to a file by clicking `Save`.
+to modify rule text directly and the `Editor` pane to construct and rearrange your hierarchy of statements and features. When you finish a rule you can save it directly to a file by clicking `Save`.
 
 ![](../../../doc/img/rulegen_expanded.png)
 
@@ -36,11 +36,15 @@ For more information on the FLARE team's open-source framework, capa, check out 
 
 You can install capa explorer using the following steps:
 
-1. Install capa and its dependencies from PyPI for the Python interpreter used by your IDA installation:
+1. Install capa and its dependencies from PyPI using the Python interpreter configured for your IDA installation:
     ```
     $ pip install flare-capa
     ```
-2. Download the [standard collection of capa rules](https://github.com/mandiant/capa-rules) (capa explorer needs capa rules to analyze a database)
+2. Download and extract the [official capa ruleset](https://github.com/mandiant/capa-rules/releases) that matches the version of capa you have installed
+   1. Use the following command to view the version of capa you have installed:
+   ```commandline
+    $ pip show flare-capa
+    ```
 3. Copy [capa_explorer.py](https://raw.githubusercontent.com/mandiant/capa/master/capa/ida/plugin/capa_explorer.py) to your IDA plugins directory
 
 ### Supported File Types
@@ -59,15 +63,15 @@ capa explorer is limited to the file types supported by capa, which include:
 3. Select the `Program Analysis` tab
 4. Click the `Analyze` button
 
-When running capa explorer for the first time you are prompted to select a file directory containing capa rules. The plugin conveniently
-remembers your selection for future runs; you can change this selection and other default settings by clicking `Settings`. We recommend 
-downloading and using the [standard collection of capa rules](https://github.com/mandiant/capa-rules) when getting started with the plugin.
+The first time you run capa explorer you will be asked to specify a local capa ruleset to use for analysis. We recommend downloading and extracting the [official capa ruleset](https://github.com/mandiant/capa-rules/releases) that matches 
+the version of capa you have installed (see installation instructions above for more details). capa explorer remembers you selection for future analysis which you
+can update using the `Settings` button.
 
 #### Tips for Program Analysis
 
 * Start analysis by clicking the `Analyze` button
 * Reset the plugin user interface and remove highlighting from your Disassembly view by clicking the `Reset` button
-* Change your capa rules directory and other default settings by clicking `Settings`
+* Change your capa ruleset and other default settings by clicking the `Settings` button
 * Hover your cursor over a rule match to view the source content of the rule
 * Double-click the `Address` column to navigate your Disassembly view to the address of the associated feature
 * Double-click a result in the `Rule Information` column to expand its children

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -222,7 +222,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         self.edit_rules_link = QtWidgets.QLabel()
 
         self.edit_rules_link.setText(
-            f'<a href="{CAPA_OFFICIAL_RULESET_URL}">Download and extract official capa ruleset</a>'
+            f'<a href="{CAPA_OFFICIAL_RULESET_URL}">Download and extract official capa rule set</a>'
         )
         self.edit_rules_link.setOpenExternalLinks(True)
 
@@ -234,7 +234,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self)
 
         layout = QtWidgets.QFormLayout(self)
-        layout.addRow("capa ruleset", self.edit_rule_path)
+        layout.addRow("capa rule set", self.edit_rule_path)
         layout.addRow("", self.edit_rules_link)
         layout.addRow("Default rule author", self.edit_rule_author)
         layout.addRow("Default rule scope", self.edit_rule_scope)
@@ -641,19 +641,19 @@ class CapaExplorerForm(idaapi.PluginForm):
         try:
             # resolve rules directory - check self and settings first, then ask user
             if not os.path.exists(settings.user.get(CAPA_SETTINGS_RULE_PATH, "")):
-                # configure ruleset selection messagebox
+                # configure rule set selection messagebox
                 rules_message = QtWidgets.QMessageBox()
                 rules_message.setIcon(QtWidgets.QMessageBox.Information)
                 rules_message.setWindowTitle("capa explorer")
-                rules_message.setText("You must specify a capa ruleset before running analysis.")
+                rules_message.setText("You must specify a capa rule set before running analysis.")
                 rules_message.setInformativeText(
-                    "Click 'Ok' to specify a local ruleset or you can download and extract the official "
-                    f"ruleset from the URL listed in the details."
+                    "Click 'Ok' to specify a local rule set or you can download and extract the official "
+                    f"rule set from the URL listed in the details."
                 )
                 rules_message.setDetailedText(f"{CAPA_OFFICIAL_RULESET_URL}")
                 rules_message.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
 
-                # display ruleset selection messagebox, check user button selection
+                # display rule set selection messagebox, check user button selection
                 pressed = rules_message.exec_()
                 if pressed == QtWidgets.QMessageBox.Cancel:
                     raise UserCancelledError()
@@ -664,14 +664,14 @@ class CapaExplorerForm(idaapi.PluginForm):
 
                 settings.user[CAPA_SETTINGS_RULE_PATH] = path
         except UserCancelledError as e:
-            capa.ida.helpers.inform_user_ida_ui("Analysis requires a capa ruleset")
+            capa.ida.helpers.inform_user_ida_ui("Analysis requires a capa rule set")
             logger.warning(
-                f"You must specify a capa ruleset before running analysis. Download and extract the official ruleset from {CAPA_OFFICIAL_RULESET_URL} (recommended)."
+                f"You must specify a capa rule set before running analysis. Download and extract the official rule set from {CAPA_OFFICIAL_RULESET_URL} (recommended)."
             )
             return False
         except Exception as e:
-            capa.ida.helpers.inform_user_ida_ui("Failed to load capa ruleset")
-            logger.error("Failed to load capa ruleset (error: %s).", e)
+            capa.ida.helpers.inform_user_ida_ui("Failed to load capa rule set")
+            logger.error("Failed to load capa rule set (error: %s).", e)
             return False
 
         if ida_kernwin.user_cancelled():
@@ -731,14 +731,14 @@ class CapaExplorerForm(idaapi.PluginForm):
             return False
         except Exception as e:
             capa.ida.helpers.inform_user_ida_ui(
-                "Failed to load capa ruleset from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
+                "Failed to load capa rule set from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
             )
 
-            logger.error("Failed to load capa ruleset from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
+            logger.error("Failed to load capa rule set from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
             logger.error(
                 "Make sure your file directory contains properly "
-                "formatted capa rules. You can download and extract the official ruleset from %s. "
-                "Or, for more details, see the ruleset documentation here: %s",
+                "formatted capa rules. You can download and extract the official rule set from %s. "
+                "Or, for more details, see the rule set documentation here: %s",
                 CAPA_OFFICIAL_RULESET_URL,
                 CAPA_RULESET_DOC_URL,
             )
@@ -861,7 +861,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
             self.model_data.render_capa_doc(self.doc, self.view_show_results_by_function.isChecked())
             self.set_view_status_label(
-                "capa ruleset: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
+                "capa rule set: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
             )
         except Exception as e:
             logger.error("Failed to render results (error: %s)", e, exc_info=True)
@@ -906,7 +906,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             if not self.load_capa_rules():
                 return False
         else:
-            logger.info('Using cached capa ruleset, click "Reset" to load ruleset from disk.')
+            logger.info('Using cached capa rule set, click "Reset" to load rule set from disk.')
 
         assert self.rules_cache is not None
         assert self.ruleset_cache is not None
@@ -1064,7 +1064,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         self.view_rulegen_status_label.clear()
 
         if not is_analyze:
-            # clear rules and ruleset cache only if user clicked "Reset"
+            # clear rules and rule set cache only if user clicked "Reset"
             self.rules_cache = None
             self.ruleset_cache = None
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -222,7 +222,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         self.edit_rules_link = QtWidgets.QLabel()
 
         self.edit_rules_link.setText(
-            f'<a href="{CAPA_OFFICIAL_RULESET_URL}">Download and extract official capa rule set</a>'
+            f'<a href="{CAPA_OFFICIAL_RULESET_URL}">Download and extract official capa rules</a>'
         )
         self.edit_rules_link.setOpenExternalLinks(True)
 
@@ -234,7 +234,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self)
 
         layout = QtWidgets.QFormLayout(self)
-        layout.addRow("capa rule set", self.edit_rule_path)
+        layout.addRow("capa rules", self.edit_rule_path)
         layout.addRow("", self.edit_rules_link)
         layout.addRow("Default rule author", self.edit_rule_author)
         layout.addRow("Default rule scope", self.edit_rule_scope)
@@ -641,19 +641,19 @@ class CapaExplorerForm(idaapi.PluginForm):
         try:
             # resolve rules directory - check self and settings first, then ask user
             if not os.path.exists(settings.user.get(CAPA_SETTINGS_RULE_PATH, "")):
-                # configure rule set selection messagebox
+                # configure rules selection messagebox
                 rules_message = QtWidgets.QMessageBox()
                 rules_message.setIcon(QtWidgets.QMessageBox.Information)
                 rules_message.setWindowTitle("capa explorer")
-                rules_message.setText("You must specify a capa rule set before running analysis.")
+                rules_message.setText("You must specify a directory containing capa rules before running analysis.")
                 rules_message.setInformativeText(
-                    "Click 'Ok' to specify a local rule set or you can download and extract the official "
-                    f"rule set from the URL listed in the details."
+                    "Click 'Ok' to specify a local directory of rules or you can download and extract the official "
+                    f"rules from the URL listed in the details."
                 )
                 rules_message.setDetailedText(f"{CAPA_OFFICIAL_RULESET_URL}")
                 rules_message.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
 
-                # display rule set selection messagebox, check user button selection
+                # display rules selection messagebox, check user button selection
                 pressed = rules_message.exec_()
                 if pressed == QtWidgets.QMessageBox.Cancel:
                     raise UserCancelledError()
@@ -664,14 +664,14 @@ class CapaExplorerForm(idaapi.PluginForm):
 
                 settings.user[CAPA_SETTINGS_RULE_PATH] = path
         except UserCancelledError as e:
-            capa.ida.helpers.inform_user_ida_ui("Analysis requires a capa rule set")
+            capa.ida.helpers.inform_user_ida_ui("Analysis requires capa rules")
             logger.warning(
-                f"You must specify a capa rule set before running analysis. Download and extract the official rule set from {CAPA_OFFICIAL_RULESET_URL} (recommended)."
+                f"You must specify a directory containing capa rules before running analysis. Download and extract the official rules from {CAPA_OFFICIAL_RULESET_URL} (recommended)."
             )
             return False
         except Exception as e:
-            capa.ida.helpers.inform_user_ida_ui("Failed to load capa rule set")
-            logger.error("Failed to load capa rule set (error: %s).", e)
+            capa.ida.helpers.inform_user_ida_ui("Failed to load capa rules")
+            logger.error("Failed to load capa rules (error: %s).", e)
             return False
 
         if ida_kernwin.user_cancelled():
@@ -731,14 +731,14 @@ class CapaExplorerForm(idaapi.PluginForm):
             return False
         except Exception as e:
             capa.ida.helpers.inform_user_ida_ui(
-                "Failed to load capa rule set from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
+                "Failed to load capa rules from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
             )
 
-            logger.error("Failed to load capa rule set from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
+            logger.error("Failed to load capa rules from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
             logger.error(
                 "Make sure your file directory contains properly "
-                "formatted capa rules. You can download and extract the official rule set from %s. "
-                "Or, for more details, see the rule set documentation here: %s",
+                "formatted capa rules. You can download and extract the official rules from %s. "
+                "Or, for more details, see the rules documentation here: %s",
                 CAPA_OFFICIAL_RULESET_URL,
                 CAPA_RULESET_DOC_URL,
             )
@@ -861,7 +861,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
             self.model_data.render_capa_doc(self.doc, self.view_show_results_by_function.isChecked())
             self.set_view_status_label(
-                "capa rule set: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
+                "capa rules: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
             )
         except Exception as e:
             logger.error("Failed to render results (error: %s)", e, exc_info=True)
@@ -906,7 +906,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             if not self.load_capa_rules():
                 return False
         else:
-            logger.info('Using cached capa rule set, click "Reset" to load rule set from disk.')
+            logger.info('Using cached capa rules, click "Reset" to load rules from disk.')
 
         assert self.rules_cache is not None
         assert self.ruleset_cache is not None

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -21,6 +21,7 @@ from PyQt5 import QtGui, QtCore, QtWidgets
 import capa.main
 import capa.rules
 import capa.engine
+import capa.version
 import capa.ida.helpers
 import capa.render.json
 import capa.features.common
@@ -47,6 +48,11 @@ settings = ida_settings.IDASettings("capa")
 CAPA_SETTINGS_RULE_PATH = "rule_path"
 CAPA_SETTINGS_RULEGEN_AUTHOR = "rulegen_author"
 CAPA_SETTINGS_RULEGEN_SCOPE = "rulegen_scope"
+
+
+CAPA_OFFICIAL_RULESET_URL = f"https://github.com/mandiant/capa-rules/releases/tag/v{capa.version.__version__}"
+CAPA_RULESET_DOC_URL = "https://github.com/mandiant/capa/blob/master/doc/rules.md"
+
 
 from enum import IntFlag
 
@@ -213,6 +219,12 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         self.edit_rule_path = QLineEditClicked(settings.user.get(CAPA_SETTINGS_RULE_PATH, ""))
         self.edit_rule_author = QtWidgets.QLineEdit(settings.user.get(CAPA_SETTINGS_RULEGEN_AUTHOR, ""))
         self.edit_rule_scope = QtWidgets.QComboBox()
+        self.edit_rules_link = QtWidgets.QLabel()
+
+        self.edit_rules_link.setText(
+            f'<a href="{CAPA_OFFICIAL_RULESET_URL}">Download and extract official capa ruleset</a>'
+        )
+        self.edit_rules_link.setOpenExternalLinks(True)
 
         scopes = ("file", "function", "basic block")
 
@@ -222,7 +234,8 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self)
 
         layout = QtWidgets.QFormLayout(self)
-        layout.addRow("capa rules path", self.edit_rule_path)
+        layout.addRow("capa ruleset", self.edit_rule_path)
+        layout.addRow("", self.edit_rules_link)
         layout.addRow("Default rule author", self.edit_rule_author)
         layout.addRow("Default rule scope", self.edit_rule_scope)
 
@@ -613,7 +626,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         """
         if post:
             if idaapi.get_imagebase() != meta.get("prev_base", -1):
-                capa.ida.helpers.inform_user_ida_ui("Running capa analysis again after program rebase")
+                capa.ida.helpers.inform_user_ida_ui("Running capa analysis using new program base")
                 self.slot_analyze()
         else:
             meta["prev_base"] = idaapi.get_imagebase()
@@ -628,16 +641,36 @@ class CapaExplorerForm(idaapi.PluginForm):
         try:
             # resolve rules directory - check self and settings first, then ask user
             if not os.path.exists(settings.user.get(CAPA_SETTINGS_RULE_PATH, "")):
-                idaapi.info("Please select a file directory containing capa rules.")
+                # configure ruleset selection messagebox
+                rules_message = QtWidgets.QMessageBox()
+                rules_message.setIcon(QtWidgets.QMessageBox.Information)
+                rules_message.setWindowTitle("capa explorer")
+                rules_message.setText("You must specify a capa ruleset before running analysis.")
+                rules_message.setInformativeText(
+                    "Click 'Ok' to specify a local ruleset or you can download and extract the official "
+                    f"ruleset from {CAPA_OFFICIAL_RULESET_URL}."
+                )
+                rules_message.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
+
+                # display ruleset selection messagebox, check user button selection
+                pressed = rules_message.exec_()
+                if pressed == QtWidgets.QMessageBox.Cancel:
+                    raise UserCancelledError()
+
                 path = self.ask_user_directory()
                 if not path:
-                    logger.warning(
-                        "You must select a file directory containing capa rules before analysis can be run. The standard collection of capa rules can be downloaded from https://github.com/mandiant/capa-rules."
-                    )
-                    return False
+                    raise UserCancelledError()
+
                 settings.user[CAPA_SETTINGS_RULE_PATH] = path
+        except UserCancelledError as e:
+            capa.ida.helpers.inform_user_ida_ui("Analysis requires a capa ruleset")
+            logger.warning(
+                f"You must specify a capa ruleset before running analysis. Download and extract the official ruleset from {CAPA_OFFICIAL_RULESET_URL} (recommended)."
+            )
+            return False
         except Exception as e:
-            logger.error("Failed to load capa rules (error: %s).", e)
+            capa.ida.helpers.inform_user_ida_ui("Failed to load capa ruleset")
+            logger.error("Failed to load capa ruleset (error: %s).", e)
             return False
 
         if ida_kernwin.user_cancelled():
@@ -697,24 +730,19 @@ class CapaExplorerForm(idaapi.PluginForm):
             return False
         except Exception as e:
             capa.ida.helpers.inform_user_ida_ui(
-                "Failed to load capa rules from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
+                "Failed to load capa ruleset from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
             )
-            logger.error("Failed to load rules from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
+
             logger.error(
-                "Make sure your file directory contains properly formatted capa rules. You can download the standard collection of capa rules from https://github.com/mandiant/capa-rules."
+                "Failed to load capa ruleset from %s (error: %s). Make sure your file directory contains properly "
+                "formatted capa rules. You can download and extract the official ruleset from %s. "
+                "Or, for more details, see the ruleset documentation here: %s",
+                settings.user[CAPA_SETTINGS_RULE_PATH],
+                e,
+                CAPA_OFFICIAL_RULESET_URL,
+                CAPA_RULESET_DOC_URL,
             )
-            logger.error(
-                "Please ensure you're using the rules that correspond to your major version of capa (%s)",
-                capa.version.get_major_version(),
-            )
-            logger.error(
-                "You can check out these rules with the following command:\n    %s",
-                capa.version.get_rules_checkout_command(),
-            )
-            logger.error(
-                "Or, for more details, see the rule set documentation here: %s",
-                "https://github.com/mandiant/capa/blob/master/doc/rules.md",
-            )
+
             settings.user[CAPA_SETTINGS_RULE_PATH] = ""
             return False
 
@@ -833,7 +861,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
             self.model_data.render_capa_doc(self.doc, self.view_show_results_by_function.isChecked())
             self.set_view_status_label(
-                "capa rules directory: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
+                "capa ruleset: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.rules_cache))
             )
         except Exception as e:
             logger.error("Failed to render results (error: %s)", e, exc_info=True)
@@ -878,7 +906,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             if not self.load_capa_rules():
                 return False
         else:
-            logger.info('Using cached ruleset, click "Reset" to reload rules from disk.')
+            logger.info('Using cached capa ruleset, click "Reset" to load ruleset from disk.')
 
         assert self.rules_cache is not None
         assert self.ruleset_cache is not None

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -648,8 +648,9 @@ class CapaExplorerForm(idaapi.PluginForm):
                 rules_message.setText("You must specify a capa ruleset before running analysis.")
                 rules_message.setInformativeText(
                     "Click 'Ok' to specify a local ruleset or you can download and extract the official "
-                    f"ruleset from {CAPA_OFFICIAL_RULESET_URL}."
+                    f"ruleset from the URL listed in the details."
                 )
+                rules_message.setDetailedText(f"{CAPA_OFFICIAL_RULESET_URL}")
                 rules_message.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
 
                 # display ruleset selection messagebox, check user button selection
@@ -733,12 +734,11 @@ class CapaExplorerForm(idaapi.PluginForm):
                 "Failed to load capa ruleset from %s" % settings.user[CAPA_SETTINGS_RULE_PATH]
             )
 
+            logger.error("Failed to load capa ruleset from %s (error: %s).", settings.user[CAPA_SETTINGS_RULE_PATH], e)
             logger.error(
-                "Failed to load capa ruleset from %s (error: %s). Make sure your file directory contains properly "
+                "Make sure your file directory contains properly "
                 "formatted capa rules. You can download and extract the official ruleset from %s. "
                 "Or, for more details, see the ruleset documentation here: %s",
-                settings.user[CAPA_SETTINGS_RULE_PATH],
-                e,
                 CAPA_OFFICIAL_RULESET_URL,
                 CAPA_RULESET_DOC_URL,
             )


### PR DESCRIPTION
closes #1244 . Opted to generate ruleset URL using `capa.version.__version__` instead of including capa version in the explorer UI. I believe this will make it easier for users to locate the correct ruleset for their capa/explorer installation.

<img width="292" alt="Screen Shot 2022-12-28 at 9 55 38 AM" src="https://user-images.githubusercontent.com/42192796/209846220-04070f47-f0df-4a23-bb6c-d4965c534d24.png">

<img width="350" alt="Screen Shot 2022-12-28 at 9 55 30 AM" src="https://user-images.githubusercontent.com/42192796/209846224-74121f74-53e9-483f-9fc3-833ca3353da4.png">


