### PR TITLE
explorer: overhaul rule generator caching and matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - extractor: add support for COFF files and extern functions #1223 @mike-hunhoff
 - doc: improve error messaging and documentation related to capa rule set #1249 @mike-hunhoff
 - fix: assume 32-bit displacement for offsets #1250 @mike-hunhoff
+- generator: updates and bug fixes #1251 @mike-hunhoff
 
 ### Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 - extractor: add support for COFF files and extern functions #1223 @mike-hunhoff
 - doc: improve error messaging and documentation related to capa rule set #1249 @mike-hunhoff
 - fix: assume 32-bit displacement for offsets #1250 @mike-hunhoff
-- generator: updates and bug fixes #1251 @mike-hunhoff
+- generator: refactor caching and matching #1251 @mike-hunhoff
 
 ### Development
 

--- a/capa/ida/plugin/cache.py
+++ b/capa/ida/plugin/cache.py
@@ -11,20 +11,19 @@ from __future__ import annotations
 import copy
 import itertools
 import collections
-from typing import List, Dict, Optional, Set, Tuple, Union
+from typing import Set, Dict, List, Tuple, Union, Optional
 
 import capa.engine
-from capa.rules import Rule, RuleSet, Scope
+from capa.rules import Rule, Scope, RuleSet
 from capa.engine import FeatureSet, MatchResults
 from capa.features.address import NO_ADDRESS, Address
 from capa.ida.plugin.extractor import CapaExplorerFeatureExtractor
-from capa.features.extractors.base_extractor import FunctionHandle, BBHandle, InsnHandle
+from capa.features.extractors.base_extractor import BBHandle, InsnHandle, FunctionHandle
 
 
 class CapaExplorerRuleSetCache:
     def __init__(self, rules: List[Rule]):
-        # capa.rules.Ruleset modifies rules, so we use deepcopy to preserve the original list of rules and our
-        # cached list of rules
+        # capa.rules.Ruleset modifies rules, so we use deepcopy to preserve the original list of rules and our cached list of rules
         self.rules: List[Rule] = copy.deepcopy(rules)
         self.ruleset: RuleSet = RuleSet(copy.deepcopy(self.rules))
 

--- a/capa/ida/plugin/cache.py
+++ b/capa/ida/plugin/cache.py
@@ -45,12 +45,14 @@ class CapaRuleGenFeatureCacheNode:
         self.children: Set[CapaRuleGenFeatureCacheNode] = set()
 
     def __hash__(self):
+        # TODO: unique enough?
         return hash((self.address,))
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             return NotImplemented
-        return self.address == other.address and self.features == other.features and self.children == other.children
+        # TODO: unique enough?
+        return self.address == other.address
 
 
 class CapaRuleGenFeatureCache:

--- a/capa/ida/plugin/cache.py
+++ b/capa/ida/plugin/cache.py
@@ -94,7 +94,7 @@ class CapaRuleGenFeatureCache:
         for fh in fh_list:
             f_node: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(fh, self.file_node)
 
-            # extract basic block features
+            # extract basic block and below features
             for bbh in extractor.get_basic_blocks(fh):
                 bb_node: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(bbh, f_node)
 

--- a/capa/ida/plugin/cache.py
+++ b/capa/ida/plugin/cache.py
@@ -1,0 +1,227 @@
+# Copyright (C) 2020 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import itertools
+import collections
+from typing import List, Dict, Optional, Set, Tuple, Union
+
+import capa.engine
+from capa.rules import Rule, RuleSet, Scope
+from capa.engine import FeatureSet, MatchResults
+from capa.features.address import NO_ADDRESS, Address
+from capa.ida.plugin.extractor import CapaExplorerFeatureExtractor
+from capa.features.extractors.base_extractor import FunctionHandle, BBHandle, InsnHandle
+
+
+class CapaExplorerRuleSetCache:
+    def __init__(self, rules: List[Rule]):
+        # capa.rules.Ruleset modifies rules, so we use deepcopy to preserve the original list of rules and our
+        # cached list of rules
+        self.rules: List[Rule] = copy.deepcopy(rules)
+        self.ruleset: RuleSet = RuleSet(copy.deepcopy(self.rules))
+
+
+class CapaRuleGenFeatureCacheNode:
+    def __init__(
+        self,
+        inner: Optional[Union[FunctionHandle, BBHandle, InsnHandle]],
+        parent: Optional[CapaRuleGenFeatureCacheNode],
+    ):
+        self.inner: Optional[Union[FunctionHandle, BBHandle, InsnHandle]] = inner
+        self.address = NO_ADDRESS if self.inner is None else self.inner.address
+        self.parent: Optional[CapaRuleGenFeatureCacheNode] = parent
+
+        if self.parent is not None:
+            self.parent.children.add(self)
+
+        self.features: FeatureSet = collections.defaultdict(set)
+        self.children: Set[CapaRuleGenFeatureCacheNode] = set()
+
+    def __hash__(self):
+        return hash((self.address,))
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.address == other.address and self.features == other.features and self.children == other.children
+
+
+class CapaRuleGenFeatureCache:
+    def __init__(self, fh_list: List[FunctionHandle], extractor: CapaExplorerFeatureExtractor):
+        self.global_features: FeatureSet = collections.defaultdict(set)
+
+        self.file_node: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(None, None)
+        self.func_nodes: Dict[Address, CapaRuleGenFeatureCacheNode] = {}
+        self.bb_nodes: Dict[Address, CapaRuleGenFeatureCacheNode] = {}
+        self.insn_nodes: Dict[Address, CapaRuleGenFeatureCacheNode] = {}
+
+        self._find_global_features(extractor)
+        self._find_file_features(extractor)
+        self._find_function_and_below_features(fh_list, extractor)
+
+    def _find_global_features(self, extractor: CapaExplorerFeatureExtractor):
+        for (feature, addr) in extractor.extract_global_features():
+            # not all global features may have virtual addresses.
+            # if not, then at least ensure the feature shows up in the index.
+            # the set of addresses will still be empty.
+            if addr is not None:
+                self.global_features[feature].add(addr)
+            else:
+                if feature not in self.global_features:
+                    self.global_features[feature] = set()
+
+    def _find_file_features(self, extractor: CapaExplorerFeatureExtractor):
+        # not all file features may have virtual addresses.
+        # if not, then at least ensure the feature shows up in the index.
+        # the set of addresses will still be empty.
+        for (feature, addr) in extractor.extract_file_features():
+            if addr is not None:
+                self.file_node.features[feature].add(addr)
+            else:
+                if feature not in self.file_node.features:
+                    self.file_node.features[feature] = set()
+
+    def _find_function_and_below_features(self, fh_list: List[FunctionHandle], extractor: CapaExplorerFeatureExtractor):
+        for fh in fh_list:
+            f_node: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(fh, self.file_node)
+
+            # extract basic block features
+            for bbh in extractor.get_basic_blocks(fh):
+                bb_node: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(bbh, f_node)
+
+                # extract instruction features
+                for ih in extractor.get_instructions(fh, bbh):
+                    inode: CapaRuleGenFeatureCacheNode = CapaRuleGenFeatureCacheNode(ih, bb_node)
+
+                    for (feature, addr) in extractor.extract_insn_features(fh, bbh, ih):
+                        inode.features[feature].add(addr)
+
+                    self.insn_nodes[inode.address] = inode
+
+                # extract basic block features
+                for (feature, addr) in extractor.extract_basic_block_features(fh, bbh):
+                    bb_node.features[feature].add(addr)
+
+                # store basic block features in cache and function parent
+                self.bb_nodes[bb_node.address] = bb_node
+
+            # extract function features
+            for (feature, addr) in extractor.extract_function_features(fh):
+                f_node.features[feature].add(addr)
+
+            self.func_nodes[f_node.address] = f_node
+
+    def _find_instruction_capabilities(
+        self, ruleset: RuleSet, insn: CapaRuleGenFeatureCacheNode
+    ) -> Tuple[FeatureSet, MatchResults]:
+        features: FeatureSet = collections.defaultdict(set)
+
+        for (feature, locs) in itertools.chain(insn.features.items(), self.global_features.items()):
+            features[feature].update(locs)
+
+        _, matches = ruleset.match(Scope.INSTRUCTION, features, insn.address)
+        for (name, result) in matches.items():
+            rule = ruleset[name]
+            for (addr, _) in result:
+                capa.engine.index_rule_matches(features, rule, [addr])
+
+        return features, matches
+
+    def _find_basic_block_capabilities(
+        self, ruleset: RuleSet, bb: CapaRuleGenFeatureCacheNode
+    ) -> Tuple[FeatureSet, MatchResults, MatchResults]:
+        features: FeatureSet = collections.defaultdict(set)
+        insn_matches: MatchResults = collections.defaultdict(list)
+
+        for insn in bb.children:
+            ifeatures, imatches = self._find_instruction_capabilities(ruleset, insn)
+            for (feature, locs) in ifeatures.items():
+                features[feature].update(locs)
+            for (name, result) in imatches.items():
+                insn_matches[name].extend(result)
+
+        for (feature, locs) in itertools.chain(bb.features.items(), self.global_features.items()):
+            features[feature].update(locs)
+
+        _, matches = ruleset.match(Scope.BASIC_BLOCK, features, bb.address)
+        for (name, result) in matches.items():
+            rule = ruleset[name]
+            for (loc, _) in result:
+                capa.engine.index_rule_matches(features, rule, [loc])
+
+        return features, matches, insn_matches
+
+    def find_code_capabilities(
+        self, ruleset: RuleSet, fh: FunctionHandle
+    ) -> Tuple[FeatureSet, MatchResults, MatchResults, MatchResults]:
+        f_node: Optional[CapaRuleGenFeatureCacheNode] = self.func_nodes.get(fh.address, None)
+        if f_node is None:
+            return {}, {}, {}, {}
+
+        insn_matches: MatchResults = collections.defaultdict(list)
+        bb_matches: MatchResults = collections.defaultdict(list)
+        function_features: FeatureSet = collections.defaultdict(set)
+
+        for bb in f_node.children:
+            features, bmatches, imatches = self._find_basic_block_capabilities(ruleset, bb)
+            for (feature, locs) in features.items():
+                function_features[feature].update(locs)
+            for (name, result) in bmatches.items():
+                bb_matches[name].extend(result)
+            for (name, result) in imatches.items():
+                insn_matches[name].extend(result)
+
+        for (feature, locs) in itertools.chain(f_node.features.items(), self.global_features.items()):
+            function_features[feature].update(locs)
+
+        _, function_matches = ruleset.match(Scope.FUNCTION, function_features, f_node.address)
+        return function_features, function_matches, bb_matches, insn_matches
+
+    def find_file_capabilities(self, ruleset: RuleSet) -> Tuple[FeatureSet, MatchResults]:
+        features: FeatureSet = collections.defaultdict(set)
+
+        for func_node in self.file_node.children:
+            assert func_node.inner is not None
+            assert isinstance(func_node.inner, FunctionHandle)
+
+            func_features, _, _, _ = self.find_code_capabilities(ruleset, func_node.inner)
+            for (feature, locs) in func_features.items():
+                features[feature].update(locs)
+
+        for (feature, locs) in itertools.chain(self.file_node.features.items(), self.global_features.items()):
+            features[feature].update(locs)
+
+        _, matches = ruleset.match(Scope.FILE, features, NO_ADDRESS)
+        return features, matches
+
+    def get_all_function_features(self, fh: FunctionHandle) -> FeatureSet:
+        f_node: Optional[CapaRuleGenFeatureCacheNode] = self.func_nodes.get(fh.address, None)
+        if f_node is None:
+            return {}
+
+        all_function_features: FeatureSet = collections.defaultdict(set)
+        all_function_features.update(f_node.features)
+
+        for bb_node in f_node.children:
+            for i_node in bb_node.children:
+                for (feature, locs) in i_node.features.items():
+                    all_function_features[feature].update(locs)
+            for (feature, locs) in bb_node.features.items():
+                all_function_features[feature].update(locs)
+
+        # include global features just once
+        for (feature, locs) in self.global_features.items():
+            all_function_features[feature].update(locs)
+
+        return all_function_features
+
+    def get_all_file_features(self):
+        yield from itertools.chain(self.file_node.features.items(), self.global_features.items())

--- a/capa/ida/plugin/error.py
+++ b/capa/ida/plugin/error.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2020 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+class UserCancelledError(Exception):
+    """throw exception when user cancels action"""
+
+    pass

--- a/capa/ida/plugin/extractor.py
+++ b/capa/ida/plugin/extractor.py
@@ -19,10 +19,6 @@ class CapaExplorerProgressIndicator(QtCore.QObject):
 
     progress = QtCore.pyqtSignal(str)
 
-    def __init__(self):
-        """initialize signal object"""
-        super().__init__()
-
     def update(self, text):
         """emit progress update
 

--- a/capa/ida/plugin/extractor.py
+++ b/capa/ida/plugin/extractor.py
@@ -6,13 +6,12 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import ida_kernwin
 from PyQt5 import QtCore
 
-import ida_kernwin
-
 from capa.ida.plugin.error import UserCancelledError
-from capa.features.extractors.base_extractor import FunctionHandle
 from capa.features.extractors.ida.extractor import IdaFeatureExtractor
+from capa.features.extractors.base_extractor import FunctionHandle
 
 
 class CapaExplorerProgressIndicator(QtCore.QObject):

--- a/capa/ida/plugin/extractor.py
+++ b/capa/ida/plugin/extractor.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2020 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from PyQt5 import QtCore
+
+import ida_kernwin
+
+from capa.ida.plugin.error import UserCancelledError
+from capa.features.extractors.base_extractor import FunctionHandle
+from capa.features.extractors.ida.extractor import IdaFeatureExtractor
+
+
+class CapaExplorerProgressIndicator(QtCore.QObject):
+    """implement progress signal, used during feature extraction"""
+
+    progress = QtCore.pyqtSignal(str)
+
+    def __init__(self):
+        """initialize signal object"""
+        super().__init__()
+
+    def update(self, text):
+        """emit progress update
+
+        check if user cancelled action, raise exception for parent function to catch
+        """
+        if ida_kernwin.user_cancelled():
+            raise UserCancelledError("user cancelled")
+        self.progress.emit("extracting features from %s" % text)
+
+
+class CapaExplorerFeatureExtractor(IdaFeatureExtractor):
+    """subclass the IdaFeatureExtractor
+
+    track progress during feature extraction, also allow user to cancel feature extraction
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.indicator = CapaExplorerProgressIndicator()
+
+    def extract_function_features(self, fh: FunctionHandle):
+        self.indicator.update("function at 0x%X" % fh.inner.start_ea)
+        return super().extract_function_features(fh)

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -28,9 +28,6 @@ import capa.render.result_document
 import capa.features.extractors.ida.extractor
 from capa.rules import Rule
 from capa.engine import FeatureSet
-from capa.ida.plugin.cache import CapaExplorerRuleSetCache, CapaRuleGenFeatureCache
-from capa.ida.plugin.error import UserCancelledError
-from capa.ida.plugin.extractor import CapaExplorerFeatureExtractor
 from capa.ida.plugin.icon import QICON
 from capa.ida.plugin.view import (
     CapaExplorerQtreeView,
@@ -38,9 +35,12 @@ from capa.ida.plugin.view import (
     CapaExplorerRulegenPreview,
     CapaExplorerRulegenFeatures,
 )
+from capa.ida.plugin.cache import CapaRuleGenFeatureCache, CapaExplorerRuleSetCache
+from capa.ida.plugin.error import UserCancelledError
 from capa.ida.plugin.hooks import CapaExplorerIdaHooks
 from capa.ida.plugin.model import CapaExplorerDataModel
 from capa.ida.plugin.proxy import CapaExplorerRangeProxyModel, CapaExplorerSearchProxyModel
+from capa.ida.plugin.extractor import CapaExplorerFeatureExtractor
 from capa.features.extractors.base_extractor import FunctionHandle
 
 logger = logging.getLogger(__name__)

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -121,7 +121,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
         )
         self.edit_rules_link.setOpenExternalLinks(True)
 
-        scopes = ("file", "function", "basic block")
+        scopes = ("file", "function", "basic block", "instruction")
 
         self.edit_rule_scope.addItems(scopes)
         self.edit_rule_scope.setCurrentIndex(scopes.index(settings.user.get(CAPA_SETTINGS_RULEGEN_SCOPE, "function")))
@@ -753,8 +753,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
             self.model_data.render_capa_doc(self.resdoc_cache, self.view_show_results_by_function.isChecked())
             self.set_view_status_label(
-                "capa rules: %s (%d rules)"
-                % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.ruleset_cache.rules))
+                "capa rules: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.ruleset_cache.rules))
             )
         except Exception as e:
             logger.error("Failed to render results (error: %s)", e, exc_info=True)
@@ -919,7 +918,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             self.view_rulegen_features.load_features(all_file_features, all_function_features)
 
             self.set_view_status_label(
-                "capa rules directory: %s (%d rules)"
+                "capa rules: %s (%d rules)"
                 % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.ruleset_cache.rules))
             )
         except Exception as e:

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -1050,7 +1050,7 @@ class CapaExplorerForm(idaapi.PluginForm):
                     ruleset, self.rulegen_current_function
                 )
             except Exception as e:
-                self.set_rulegen_status(f"Failed to create function rule matches from ruleset ({e})")
+                self.set_rulegen_status(f"Failed to create function rule matches from rule set ({e})")
                 return
 
             if rule.scope == capa.rules.Scope.FUNCTION and rule.name in func_matches.keys():
@@ -1063,7 +1063,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             try:
                 _, file_matches = self.rulegen_feature_cache.find_file_capabilities(ruleset)
             except Exception as e:
-                self.set_rulegen_status(f"Failed to create file rule matches from ruleset ({e})")
+                self.set_rulegen_status(f"Failed to create file rule matches from rule set ({e})")
                 return
             if rule.name in file_matches.keys():
                 is_match = True

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -918,8 +918,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             self.view_rulegen_features.load_features(all_file_features, all_function_features)
 
             self.set_view_status_label(
-                "capa rules: %s (%d rules)"
-                % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.ruleset_cache.rules))
+                "capa rules: %s (%d rules)" % (settings.user[CAPA_SETTINGS_RULE_PATH], len(self.ruleset_cache.rules))
             )
         except Exception as e:
             logger.error("Failed to render views (error: %s)", e, exc_info=True)


### PR DESCRIPTION
- [x] fix #1246 
- [x] fix #1159 
- [x] fix rule generator `MatchedRule` matching
- [x] enable file scope matching
- [x] refactor form code to remove circular reference
- [x] fix scope matching
- [x] add "instruction" scope to UI nesting options

![Screen Shot 2023-01-03 at 10 18 26 AM](https://user-images.githubusercontent.com/42192796/210409543-20110243-13d4-48d8-8456-e5e682235dcd.png)