### PR TITLE
explorer: improve exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - doc: improve error messaging and documentation related to capa rule set #1249 @mike-hunhoff
 - fix: assume 32-bit displacement for offsets #1250 @mike-hunhoff
 - generator: refactor caching and matching #1251 @mike-hunhoff
+- fix: improve exception handling to prevent IDA from locking up when errors occur #1262 @mike-hunhoff
 
 ### Development
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -821,7 +821,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             logger.info("User cancelled analysis.")
             return False
 
-        update_wait_box("initializing feature extractor")
+        update_wait_box("Initializing feature extractor")
 
         try:
             # must use extractor to get function, as capa analysis requires casted object

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -656,7 +656,7 @@ class CapaExplorerForm(idaapi.PluginForm):
                 update_wait_box("%s (%d of %d)" % (text, self.process_count, self.process_total))
                 self.process_count += 1
 
-            update_wait_box("initializing feature extractor")
+            update_wait_box("Initializing feature extractor")
 
             try:
                 extractor = CapaExplorerFeatureExtractor()

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -827,7 +827,7 @@ class CapaExplorerForm(idaapi.PluginForm):
             # must use extractor to get function, as capa analysis requires casted object
             extractor = CapaExplorerFeatureExtractor()
         except Exception as e:
-            logger.error("Failed to init feature extractor (error: %s)", e, exc_info=True)
+            logger.error("Failed to initialize feature extractor (error: %s)", e, exc_info=True)
             return False
 
         if ida_kernwin.user_cancelled():

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -662,7 +662,7 @@ class CapaExplorerForm(idaapi.PluginForm):
                 extractor = CapaExplorerFeatureExtractor()
                 extractor.indicator.progress.connect(slot_progress_feature_extraction)
             except Exception as e:
-                logger.error("Failed to init feature extractor (error: %s).", e, exc_info=True)
+                logger.error("Failed to initialize feature extractor (error: %s).", e, exc_info=True)
                 return False
 
             if ida_kernwin.user_cancelled():


### PR DESCRIPTION
Closes #1261

Improved exception handling to prevent IDA from locking up if certain errors occur during execution. User is presented with a dialog indicating an error occurred and they should see the output window for more details.

![Screen Shot 2023-01-04 at 10 28 21 AM](https://user-images.githubusercontent.com/42192796/210615658-a8f7c099-e4b8-4a47-afc6-95c99826b2eb.png)
