### PR TITLE
only show first lib match to reduce vverbose output noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - dotnet: emit namespace/class features for ldvirtftn/ldftn instructions #1241 @mike-hunhoff
 - dotnet: emit namespace/class features for type references #1242 @mike-hunhoff
 - dotnet: extract dotnet and pe format #1187 @mr-tz
+- don't render all library rule matches in vverbose output #1174 @mr-tz
 
 ### Breaking Changes
 - remove SMDA backend #1062 @williballenthin 

--- a/capa/render/utils.py
+++ b/capa/render/utils.py
@@ -24,6 +24,10 @@ def bold2(s: str) -> str:
     return termcolor.colored(s, "green")
 
 
+def warn(s: str) -> str:
+    return termcolor.colored(s, "yellow")
+
+
 def format_parts_id(data: Union[rd.AttackSpec, rd.MBCSpec]):
     """
     format canonical representation of ATT&CK/MBC parts and ID

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -285,17 +285,24 @@ def render_rules(ostream, doc: rd.ResultDocument):
         if rule.meta.is_subscope_rule:
             continue
 
+        lib_info = ""
         count = len(rule.matches)
         if count == 1:
-            capability = rutils.bold(rule.meta.name)
+            if rule.meta.lib:
+                lib_info = " (library rule)"
+            capability = "%s%s" % (rutils.bold(rule.meta.name), lib_info)
         else:
-            capability = "%s (%d matches)" % (rutils.bold(rule.meta.name), count)
+            if rule.meta.lib:
+                lib_info = ", only showing first match of library rule"
+            capability = "%s (%d matches%s)" % (rutils.bold(rule.meta.name), count, lib_info)
 
         ostream.writeln(capability)
         had_match = True
 
         rows = []
-        rows.append(("namespace", rule.meta.namespace))
+        if not rule.meta.lib:
+            # library rules should not have a namespace
+            rows.append(("namespace", rule.meta.namespace))
 
         if rule.meta.maec.analysis_conclusion or rule.meta.maec.analysis_conclusion_ov:
             rows.append(
@@ -314,10 +321,6 @@ def render_rules(ostream, doc: rd.ResultDocument):
             )
 
         rows.append(("author", ", ".join(rule.meta.authors)))
-
-        # indicate this is a library rule
-        if rule.meta.lib:
-            rows.append(("lib", rutils.warn("true, only showing first match")))
 
         rows.append(("scope", rule.meta.scope.value))
 

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -315,6 +315,10 @@ def render_rules(ostream, doc: rd.ResultDocument):
 
         rows.append(("author", ", ".join(rule.meta.authors)))
 
+        # indicate this is a library rule
+        if rule.meta.lib:
+            rows.append(("lib", rutils.warn("true, only showing first match")))
+
         rows.append(("scope", rule.meta.scope.value))
 
         if rule.meta.attack:
@@ -355,6 +359,10 @@ def render_rules(ostream, doc: rd.ResultDocument):
 
                 ostream.write("\n")
                 render_match(ostream, match, indent=1)
+                if rule.meta.lib:
+                    # only show first match
+                    break
+
         ostream.write("\n")
 
     if not had_match:


### PR DESCRIPTION
closes #1174

results in
![WindowsTerminal_I7o39CRQF2](https://user-images.githubusercontent.com/17606537/210804370-60047bae-47eb-4c35-a625-4d588721ac81.png)


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
