### PR TITLE
features: string: better __str__ embedded whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - dotnet: address unhandled exceptions with improved type checking #1230 @mike-hunhoff
 - fix import-to-ida script formatting #1208 @williballenthin
 - render: fix verbose rendering of scopes #1263 @williballenthin
+- show-features: better render strings with embedded whitespace #1267 @williballenthin
 
 ### capa explorer IDA Pro plugin
 - fix: display instruction items #1154 @mr-tz

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -180,6 +180,7 @@ class String(Feature):
         super().__init__(value, description=description)
 
     def get_value_str(self) -> str:
+        assert isinstance(self.value, str)
         return escape_string(self.value)
 
 
@@ -236,6 +237,7 @@ class Substring(String):
             return Result(False, _MatchedSubstring(self, {}), [])
 
     def get_value_str(self) -> str:
+        assert isinstance(self.value, str)
         return escape_string(self.value)
 
     def __str__(self):

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -179,6 +179,9 @@ class String(Feature):
     def __init__(self, value: str, description=None):
         super().__init__(value, description=description)
 
+    def get_value_str(self) -> str:
+        return escape_string(self.value)
+
 
 class Class(Feature):
     def __init__(self, value: str, description=None):
@@ -232,9 +235,12 @@ class Substring(String):
         else:
             return Result(False, _MatchedSubstring(self, {}), [])
 
+    def get_value_str(self) -> str:
+        return escape_string(self.value)
+
     def __str__(self):
         assert isinstance(self.value, str)
-        return "substring(%s)" % self.value
+        return "substring(%s)" % escape_string(self.value)
 
 
 class _MatchedSubstring(Substring):

--- a/capa/features/extractors/common.py
+++ b/capa/features/extractors/common.py
@@ -9,6 +9,7 @@ import pefile
 import capa.features
 import capa.features.extractors.elf
 import capa.features.extractors.pefile
+import capa.features.extractors.strings
 from capa.features.common import OS, FORMAT_PE, FORMAT_ELF, OS_WINDOWS, FORMAT_FREEZE, Arch, Format, String, Feature
 from capa.features.freeze import is_freeze
 from capa.features.address import NO_ADDRESS, Address, FileOffsetAddress


### PR DESCRIPTION
closes #1267 

i wasnt able to reproduce the issue as described, but i can see in the code how this would happen, so @mr-tz please confirm this fix


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
