### PR TITLE
Revert "build(deps): bump networkx from 2.5.1 to 3.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     "ida-settings==2.1.0",
     "viv-utils[flirt]==0.7.7",
     "halo==0.0.31",
-    "networkx==3.0",
+    "networkx==2.5.1",
     "ruamel.yaml==0.17.21",
     "vivisect==1.0.8",
     "pefile==2022.5.30",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     "ida-settings==2.1.0",
     "viv-utils[flirt]==0.7.7",
     "halo==0.0.31",
-    "networkx==2.5.1",
+    "networkx==2.5.1",  # newer versions no longer support py3.7.
     "ruamel.yaml==0.17.21",
     "vivisect==1.0.8",
     "pefile==2022.5.30",


### PR DESCRIPTION
Reverts mandiant/capa#1275

networkx >2.5.1 does not support python 3.7 (which we do), so cannot upgrade now.

[x] No CHANGELOG update needed