### PR TITLE
add format to global features and code refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - render: fix verbose rendering of scopes #1263 @williballenthin
 - rules: better detect invalid rules #1282 @williballenthin
 - show-features: better render strings with embedded whitespace #1267 @williballenthin
+- extractor: add format to global features #1258 @mr-tz
 
 ### capa explorer IDA Pro plugin
 - fix: display instruction items #1154 @mr-tz

--- a/capa/features/extractors/dnfile/extractor.py
+++ b/capa/features/extractors/dnfile/extractor.py
@@ -8,13 +8,13 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from typing import Dict, List, Tuple, Union, Iterator, Optional
 
 import dnfile
 from dncil.cil.opcode import OpCodes
 
 import capa.features.extractors
+import capa.features.extractors.dotnetfile
 import capa.features.extractors.dnfile.file
 import capa.features.extractors.dnfile.insn
 import capa.features.extractors.dnfile.function
@@ -78,6 +78,7 @@ class DnfileFeatureExtractor(FeatureExtractor):
 
         # pre-compute these because we'll yield them at *every* scope.
         self.global_features: List[Tuple[Feature, Address]] = []
+        self.global_features.extend(capa.features.extractors.dotnetfile.extract_file_format())
         self.global_features.extend(capa.features.extractors.dotnetfile.extract_file_os(pe=self.pe))
         self.global_features.extend(capa.features.extractors.dotnetfile.extract_file_arch(pe=self.pe))
 

--- a/capa/features/extractors/ida/extractor.py
+++ b/capa/features/extractors/ida/extractor.py
@@ -25,6 +25,7 @@ class IdaFeatureExtractor(FeatureExtractor):
     def __init__(self):
         super().__init__()
         self.global_features: List[Tuple[Feature, Address]] = []
+        self.global_features.extend(capa.features.extractors.ida.file.extract_file_format())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_os())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_arch())
 

--- a/capa/features/extractors/viv/extractor.py
+++ b/capa/features/extractors/viv/extractor.py
@@ -34,6 +34,7 @@ class VivisectFeatureExtractor(FeatureExtractor):
 
         # pre-compute these because we'll yield them at *every* scope.
         self.global_features: List[Tuple[Feature, Address]] = []
+        self.global_features.extend(capa.features.extractors.viv.file.extract_file_format(self.buf))
         self.global_features.extend(capa.features.extractors.common.extract_os(self.buf))
         self.global_features.extend(capa.features.extractors.viv.global_.extract_arch(self.vw))
 

--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -10,7 +10,7 @@ import logging
 from typing import NoReturn
 
 from capa.exceptions import UnsupportedFormatError
-from capa.features.common import FORMAT_SC32, FORMAT_SC64, FORMAT_UNKNOWN
+from capa.features.common import FORMAT_PE, FORMAT_SC32, FORMAT_SC64, FORMAT_DOTNET, FORMAT_UNKNOWN, Format
 
 EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
 EXTENSIONS_SHELLCODE_64 = ("sc64", "raw64")
@@ -68,11 +68,17 @@ def get_auto_format(path: str) -> str:
 def get_format(sample: str) -> str:
     # imported locally to avoid import cycle
     from capa.features.extractors.common import extract_format
+    from capa.features.extractors.dnfile_ import DnfileFeatureExtractor
 
     with open(sample, "rb") as f:
         buf = f.read()
 
     for feature, _ in extract_format(buf):
+        if feature == Format(FORMAT_PE):
+            dnfile_extractor = DnfileFeatureExtractor(sample)
+            if dnfile_extractor.is_dotnet_file():
+                feature = Format(FORMAT_DOTNET)
+
         assert isinstance(feature.value, str)
         return feature.value
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -307,11 +307,7 @@ def get_sample_capabilities(ctx: Context, path: Path) -> Set[str]:
     elif nice_path.endswith(capa.helpers.EXTENSIONS_SHELLCODE_64):
         format_ = "sc64"
     else:
-        format_ = "auto"
-        if not nice_path.endswith(capa.helpers.EXTENSIONS_ELF):
-            dnfile_extractor = capa.features.extractors.dnfile_.DnfileFeatureExtractor(nice_path)
-            if dnfile_extractor.is_dotnet_file():
-                format_ = FORMAT_DOTNET
+        format_ = capa.main.get_auto_format(nice_path)
 
     logger.debug("analyzing sample: %s", nice_path)
     extractor = capa.main.get_extractor(nice_path, format_, "", DEFAULT_SIGNATURES, False, disable_progress=True)

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -175,7 +175,7 @@ def main(argv=None):
             capa.helpers.log_unsupported_runtime_error()
             return -1
 
-    meta = capa.main.collect_metadata(argv, args.sample, args.rules, extractor, format_=format_)
+    meta = capa.main.collect_metadata(argv, args.sample, args.rules, extractor)
     capabilities, counts = capa.main.find_capabilities(rules, extractor)
     meta["analysis"].update(counts)
     meta["analysis"]["layout"] = capa.main.compute_layout(rules, extractor, capabilities)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -682,14 +682,22 @@ FEATURE_PRESENCE_TESTS = sorted(
         # os & format & arch
         ("pma16-01", "file", OS(OS_WINDOWS), True),
         ("pma16-01", "file", OS(OS_LINUX), False),
+        ("mimikatz", "file", OS(OS_WINDOWS), True),
         ("pma16-01", "function=0x404356", OS(OS_WINDOWS), True),
         ("pma16-01", "function=0x404356,bb=0x4043B9", OS(OS_WINDOWS), True),
+        ("mimikatz", "function=0x40105D", OS(OS_WINDOWS), True),
         ("pma16-01", "file", Arch(ARCH_I386), True),
         ("pma16-01", "file", Arch(ARCH_AMD64), False),
+        ("mimikatz", "file", Arch(ARCH_I386), True),
         ("pma16-01", "function=0x404356", Arch(ARCH_I386), True),
         ("pma16-01", "function=0x404356,bb=0x4043B9", Arch(ARCH_I386), True),
+        ("mimikatz", "function=0x40105D", Arch(ARCH_I386), True),
         ("pma16-01", "file", Format(FORMAT_PE), True),
         ("pma16-01", "file", Format(FORMAT_ELF), False),
+        ("mimikatz", "file", Format(FORMAT_PE), True),
+        # format is also a global feature
+        ("pma16-01", "function=0x404356", Format(FORMAT_PE), True),
+        ("mimikatz", "function=0x456BB9", Format(FORMAT_PE), True),
         # elf support
         ("7351f.elf", "file", OS(OS_LINUX), True),
         ("7351f.elf", "file", OS(OS_WINDOWS), False),


### PR DESCRIPTION
closes #1258 

related to #1187 

tests succeed in IDA
```
--------------------------------------------------------------------------------
OK   mimikatz-function=0x40E5C2-basic block-7
OK   mimikatz-function=0x4702FD-characteristic(calls from)-0
OK   mimikatz-function=0x40E5C2-characteristic(calls from)-3
OK   mimikatz-function=0x4556E5-characteristic(calls to)-0
OK   mimikatz-function=0x40B1F1-characteristic(calls to)-3
...
OK   mimikatz-file-string(SCardControl)-True
OK   mimikatz-file-string(SCardTransmit)-True
OK   mimikatz-file-string(ACR  > )-True
OK   mimikatz-file-string(nope)-False
OK   mimikatz-file-section(.text)-True
OK   mimikatz-file-section(.nope)-False
OK   mimikatz-file-import(advapi32.CryptSetHashParam)-True
OK   mimikatz-file-import(CryptSetHashParam)-True
OK   mimikatz-file-import(kernel32.IsWow64Process)-True
OK   mimikatz-file-import(msvcrt.exit)-True
OK   mimikatz-file-import(cabinet.#11)-True
OK   mimikatz-file-import(#11)-False
OK   mimikatz-file-import(#nope)-False
OK   mimikatz-file-import(nope)-False
OK   mimikatz-file-import(advapi32.CryptAcquireContextW)-True
OK   mimikatz-file-import(advapi32.CryptAcquireContext)-True
OK   mimikatz-file-import(CryptAcquireContextW)-True
OK   mimikatz-file-import(CryptAcquireContext)-True
OK   mimikatz-file-os(windows)-True
OK   mimikatz-file-arch(i386)-True
OK   mimikatz-file-format(pe)-True
OK   mimikatz-function=0x401000-characteristic(loop)-False
OK   mimikatz-function=0x401000-characteristic(tight loop)-False
OK   mimikatz-function=0x401000-characteristic(stack string)-False
OK   mimikatz-function=0x401000-number(0x0)-True
OK   mimikatz-function=0x401000,bb=0x401000-characteristic(tight loop)-False
OK   mimikatz-function=0x40105D-mnemonic(push)-True
OK   mimikatz-function=0x40105D-mnemonic(movzx)-True
OK   mimikatz-function=0x40105D-mnemonic(xor)-True
OK   mimikatz-function=0x40105D-mnemonic(in)-False
OK   mimikatz-function=0x40105D-mnemonic(out)-False
OK   mimikatz-function=0x40105D-number(0xFF)-True
OK   mimikatz-function=0x40105D-number(0x3136B0)-True
OK   mimikatz-function=0x40105D-number(0xC)-False
OK   mimikatz-function=0x40105D-number(0x10)-False
OK   mimikatz-function=0x40105D-offset(0x0)-True
OK   mimikatz-function=0x40105D-offset(0x4)-True
OK   mimikatz-function=0x40105D-offset(0xC)-True
OK   mimikatz-function=0x40105D-offset(0x8)-False
OK   mimikatz-function=0x40105D-offset(0x10)-False
OK   mimikatz-function=0x40105D-string(SCardControl)-True
OK   mimikatz-function=0x40105D-string(SCardTransmit)-True
OK   mimikatz-function=0x40105D-string(ACR  > )-True
OK   mimikatz-function=0x40105D-string(nope)-False
OK   mimikatz-function=0x40105D-bytes(53 00 43 00 61 00 72 00 64 00 43 00 6F 00 6E 00 74 00 72 00 6F 00 6C 00)-True
OK   mimikatz-function=0x40105D-bytes(53 00 43 00 61 00 72 00 64 00 54 00 72 00 61 00 6E 00 73 00 6D 00 69 00 74 00)-True
OK   mimikatz-function=0x40105D-bytes(41 00 43 00 52 00 20 00 20 00 3E 00 20 00)-True
OK   mimikatz-function=0x40105D-bytes(6E 6F 70 65)-False
OK   mimikatz-function=0x40105D-characteristic(nzxor)-False
OK   mimikatz-function=0x40105D-characteristic(calls to)-True
OK   mimikatz-function=0x40105D-os(windows)-True
OK   mimikatz-function=0x40105D-arch(i386)-True
OK   mimikatz-function=0x40105D,bb=0x401073-operand[1].number(0xFF)-True
OK   mimikatz-function=0x40105D,bb=0x401073-operand[0].number(0xFF)-False
OK   mimikatz-function=0x40105D,bb=0x4010B0-operand[0].offset(0x4)-True
OK   mimikatz-function=0x40105D,bb=0x4010B0-operand[1].offset(0x4)-False
OK   mimikatz-function=0x4011FB-offset(-0x1)-True
OK   mimikatz-function=0x4011FB-offset(-0x2)-True
OK   mimikatz-function=0x401517-characteristic(loop)-True
OK   mimikatz-function=0x401553-number(0xFFFFFFFF)-True
OK   mimikatz-function=0x401873,bb=0x4018B2,insn=0x4018C0-number(0x2)-True
OK   mimikatz-function=0x401CC7,bb=0x401CDE,insn=0x401CF6-offset(0x10)-False
OK   mimikatz-function=0x401D64,bb=0x401D73,insn=0x401D85-offset(0x80000000)-False
OK   mimikatz-function=0x402203,bb=0x402221,insn=0x40223C-offset(0x4)-True
OK   mimikatz-function=0x402EC4-characteristic(tight loop)-True
OK   mimikatz-function=0x402EC4,bb=0x402F8E-characteristic(tight loop)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptAcquireContextW)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptAcquireContext)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptGenKey)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptImportKey)-True
OK   mimikatz-function=0x403BAC-api(advapi32.CryptDestroyKey)-True
OK   mimikatz-function=0x403BAC-api(CryptAcquireContextW)-True
OK   mimikatz-function=0x403BAC-api(CryptAcquireContext)-True
OK   mimikatz-function=0x403BAC-api(CryptGenKey)-True
OK   mimikatz-function=0x403BAC-api(CryptImportKey)-True
OK   mimikatz-function=0x403BAC-api(CryptDestroyKey)-True
OK   mimikatz-function=0x403BAC-api(Nope)-False
OK   mimikatz-function=0x403BAC-api(advapi32.Nope)-False
OK   mimikatz-function=0x40640e-characteristic(recursive call)-True
OK   mimikatz-function=0x40B3C6-api(LocalFree)-True
OK   mimikatz-function=0x410DFC-characteristic(nzxor)-True
OK   mimikatz-function=0x4175FF-characteristic(recursive call)-False
OK   mimikatz-function=0x4175FF-characteristic(indirect call)-True
OK   mimikatz-function=0x43e543-number(0xFFFFFFF0)-True
OK   mimikatz-function=0x44570F-bytes(FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF)-False
OK   mimikatz-function=0x44EDEF-string(INPUTEVENT)-True
OK   mimikatz-function=0x44EDEF-bytes(49 00 4E 00 50 00 55 00 54 00 45 00 56 00 45 00 4E 00 54 00)-True
OK   mimikatz-function=0x4556E5-characteristic(stack string)-True
OK   mimikatz-function=0x4556E5-api(advapi32.LsaQueryInformationPolicy)-True
OK   mimikatz-function=0x4556E5-api(LsaQueryInformationPolicy)-True
OK   mimikatz-function=0x4556E5-characteristic(peb access)-False
OK   mimikatz-function=0x4556E5-characteristic(gs access)-False
OK   mimikatz-function=0x4556E5-characteristic(cross section flow)-False
OK   mimikatz-function=0x4556E5-characteristic(indirect call)-False
OK   mimikatz-function=0x4556E5-characteristic(calls from)-True
OK   mimikatz-function=0x456BB9-characteristic(calls to)-False
OK   mimikatz-function=0x456BB9-format(pe)-True
OK   mimikatz-function=0x46D534-characteristic(nzxor)-False
OK   mimikatz-function=0x46D6CE-string((null))-True
OK   mimikatz-function=0x4702FD-characteristic(calls from)-False
OK   mimikatz-function=0x47153B,bb=0x4717AB,insn=0x4717B1-number(-0x30)-False
OK   mimikatz-function=0x471EAB,bb=0x471ED8,insn=0x471EE6-number(0x4)-False
...
OK   mimikatz-file-import(cabinet.FCIAddFile)-True
DONE
```

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
