### PR TITLE
ci: tests: run binja after code style/linter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
   binja-tests:
     name: Binary Ninja tests for ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ubuntu-20.04
+    needs: [code_style, rule_linter]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
only run binja tests if code style/linter succeed, reducing resource consumption when there are obvious code style fixes needed.

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
