### PR TITLE
Remove dynsym library name for ELF imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## master (unreleased)
+- removed '.dynsym' as the library name for ELF imports. get_file_imports now only returns the API name.
 
 ### New Features
 - add protobuf format for result documents #1219 @williballenthin @mr-tz 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
 ## master (unreleased)
-- removed '.dynsym' as the library name for ELF imports. get_file_imports now only returns the API name.
 
 ### New Features
 - add protobuf format for result documents #1219 @williballenthin @mr-tz 
@@ -38,9 +37,9 @@
 - nursery/enumerate-pe-sections-in-dotnet @mr-tz
 - nursery/destroy-software-breakpoint-capability echernofsky@google.com
 - nursery/send-data-to-internet michael.hunhoff@mandiant.com
--
 
 ### Bug Fixes
+- extractor: removed '.dynsym' as the library name for ELF imports. get_file_imports now only returns the API name.
 - extractor: fix vivisect loop detection corner case #1310 @mr-tz
 - match: extend OS characteristic to match OS_ANY to all supported OSes #1324 @mike-hunhoff
 - extractor: fix IDA and vivisect string and bytes features overlap and tests #1327 #1336 @xusheng6 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - nursery/enumerate-pe-sections-in-dotnet @mr-tz
 - nursery/destroy-software-breakpoint-capability echernofsky@google.com
 - nursery/send-data-to-internet michael.hunhoff@mandiant.com
+-
 
 ### Bug Fixes
 - extractor: removed '.dynsym' as the library name for ELF imports. get_file_imports now only returns the API name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 -
 
 ### Bug Fixes
-- extractor: removed '.dynsym' as the library name for ELF imports. get_file_imports now only returns the API name.
+- extractor: removed '.dynsym' as the library name for ELF imports #1318 @stevemk14ebr 
 - extractor: fix vivisect loop detection corner case #1310 @mr-tz
 - match: extend OS characteristic to match OS_ANY to all supported OSes #1324 @mike-hunhoff
 - extractor: fix IDA and vivisect string and bytes features overlap and tests #1327 #1336 @xusheng6 

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -90,8 +90,10 @@ def get_file_imports() -> Dict[int, Tuple[str, str, int]]:
         if not library:
             continue
 
-        # IDA uses section names for the library of ELF imports, like ".dynsym"
-        library = library.lstrip(".")
+        # IDA uses section names for the library of ELF imports, like ".dynsym".
+        # These are not useful to us, we may need to expand this list over time (TODO: exhaust this list)
+        if library == ".dynsym":
+            library = ""
 
         def inspect_import(ea, function, ordinal):
             if function and function.startswith("__imp_"):


### PR DESCRIPTION
ELF Imports including dynsym as a library name is not useful and may cause conflicts with rules or users of capa as a python library. This removes the library name for elf binaries.

This change was discussed with @mike-hunhoff 