### PR TITLE
fix: Warning user to install signatures

### DIFF
--- a/capa/main.py
+++ b/capa/main.py
@@ -698,6 +698,9 @@ def get_rules(
 
 
 def get_signatures(sigs_path):
+    if not os.path.exists(sigs_path):
+        raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
+
     paths = []
     if os.path.isfile(sigs_path):
         paths.append(sigs_path)
@@ -1044,8 +1047,6 @@ def handle_common_args(args):
                 raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
         else:
             sigs_path = args.signatures
-            if not os.path.exists(sigs_path):
-                raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
             logger.debug("using signatures path: %s", sigs_path)
 
         args.signatures = sigs_path

--- a/capa/main.py
+++ b/capa/main.py
@@ -1036,10 +1036,12 @@ def handle_common_args(args):
 
             sigs_path = os.path.join(get_default_root(), "sigs")
             if not os.path.exists(sigs_path):
-                raise IOError(
+                logger.error(
+                    "Using default signature path, but it doesn't exist. "
                     "Please install the signatures first: "
                     "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
                 )
+                raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
         else:
             sigs_path = args.signatures
             logger.debug("using signatures path: %s", sigs_path)

--- a/capa/main.py
+++ b/capa/main.py
@@ -698,15 +698,6 @@ def get_rules(
 
 
 def get_signatures(sigs_path):
-    if not os.path.exists(sigs_path):
-        # Check if Capa installed via PIP
-        if "/site-packages/capa/" in sigs_path:
-            raise IOError(
-                "Please install the signatures first: "
-                "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
-            )
-        raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
-
     paths = []
     if os.path.isfile(sigs_path):
         paths.append(sigs_path)
@@ -1044,6 +1035,11 @@ def handle_common_args(args):
             logger.debug("-" * 80)
 
             sigs_path = os.path.join(get_default_root(), "sigs")
+            if not os.path.exists(sigs_path):
+                raise IOError(
+                    "Please install the signatures first: "
+                    "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
+                )
         else:
             sigs_path = args.signatures
             logger.debug("using signatures path: %s", sigs_path)

--- a/capa/main.py
+++ b/capa/main.py
@@ -699,6 +699,12 @@ def get_rules(
 
 def get_signatures(sigs_path):
     if not os.path.exists(sigs_path):
+        # Check if Capa installed via PIP
+        if "/site-packages/capa/" in sigs_path:
+            raise IOError(
+                "Please install the signatures first: "
+                "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
+            )
         raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
 
     paths = []

--- a/capa/main.py
+++ b/capa/main.py
@@ -1044,6 +1044,8 @@ def handle_common_args(args):
                 raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
         else:
             sigs_path = args.signatures
+            if not os.path.exists(sigs_path):
+                raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
             logger.debug("using signatures path: %s", sigs_path)
 
         args.signatures = sigs_path


### PR DESCRIPTION
Give the user an instruction link to install signatures if they installed Capa via pip
related #682


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
