### PR TITLE
Fix BN installation path detection does not work with Python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- extractor: fix binja installation path detection does not work with Python 3.11
+
 ### capa explorer IDA Pro plugin
 
 ### Development

--- a/capa/features/extractors/binja/find_binja_api.py
+++ b/capa/features/extractors/binja/find_binja_api.py
@@ -15,8 +15,8 @@ import subprocess
 # binaryninja module is extracted by the PyInstaller.
 code = r"""
 from pathlib import Path
-import importlib
-spec = importlib.util.find_spec('binaryninja')
+from importlib import util
+spec = util.find_spec('binaryninja')
 if spec is not None:
     if len(spec.submodule_search_locations) > 0:
             path = Path(spec.submodule_search_locations[0])


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
-->

This fixes a minor issue that the binja installation path detection does not work with Python 3.11. Close https://github.com/mandiant/capa/issues/1430

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
