### PR TITLE
SymTab _parse(): Bugfixes for the struct unpacking and for handling symtabs with a null entry size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 ### Bug Fixes
 
 - extractor: avoid Binary Ninja exception when analyzing certain files #1441 @xusheng6 
+- symtab: fix struct.unpack() format for 64-bit ELF files @yelhamer
+- symtab: safeguard against ZeroDivisionError for files containing a symtab with a null entry size @yelhamer
 
 
 ### capa explorer IDA Pro plugin

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -661,7 +661,7 @@ class SymTab:
                 )
             elif bitness == 64:
                 name_offset, info, other, shndx, value, size = struct.unpack_from(
-                    endian + "IBBhQQ", symtab_buf, i * self.symtab.entsize
+                    endian + "IBBHQQ", symtab_buf, i * self.symtab.entsize
                 )
 
             self.symbols.append(Symbol(name_offset, value, size, info, other, shndx))

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -658,7 +658,7 @@ class SymTab:
                 )
             elif bitness == 64:
                 name_offset, info, other, shndx, value, size = struct.unpack_from(
-                    endian + "IBBBQQ", symtab_buf, i * self.symtab.entsize
+                    endian + "IBBhQQ", symtab_buf, i * self.symtab.entsize
                 )
 
             self.symbols.append(Symbol(name_offset, value, size, info, other, shndx))

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -651,6 +651,9 @@ class SymTab:
         return the symbol's information in
         the order specified by sys/elf32.h
         """
+        if self.symtab.entsize == 0:
+            return
+
         for i in range(int(len(self.symtab.buf) / self.symtab.entsize)):
             if bitness == 32:
                 name_offset, value, size, info, other, shndx = struct.unpack_from(


### PR DESCRIPTION
This fixes symtab's struct.unpack() format for 64-bit ELF binaries. The previous unpacking was off by one byte for the fields: shndx, value and size.

This also adds a safeguard against binaries that — for some reason — might have symtab with a null entry size.

### Checklist

- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
