### PR TITLE
Utility script to detect feature overlap between new and existing CAPA rules.

### DIFF
--- a/scripts/detect_duplicate_features.py
+++ b/scripts/detect_duplicate_features.py
@@ -1,0 +1,67 @@
+import os
+import yaml
+
+def findall_features(features):
+    feature_list = []
+    for feature in features:
+        if 'and' in feature:
+            and_list = findall_features(feature['and'])
+            for x in and_list:
+                feature_list.append(x)
+        elif 'or' in feature:
+            or_list = findall_features(feature['or'])
+            for y in or_list:
+                feature_list.append(y)
+        else:
+            feature_list.append(feature)
+    return feature_list
+
+def find_overlapping_rules(new_rule_path, rules_path):
+    if not new_rule_path.endswith('.yml'):
+        return 'ERROR ! New rule path file name incorrect'
+    
+    count = 0
+
+    with open(new_rule_path, 'r') as f:
+        new_rule = yaml.safe_load(f)
+    if 'rule' not in new_rule:
+        return "ERROR ! given new rule path isn't a rule"
+    
+    new_rule_features = findall_features(new_rule['rule']['features'])
+
+    overlapping_rules = []
+    
+    for dirpath, dirnames, filenames in os.walk(rules_path):
+        for filename in filenames:
+            if filename.endswith('.yml'):
+                rule_path = os.path.join(dirpath, filename)
+                with open(rule_path, 'r') as f:
+                    rule = yaml.safe_load(f)
+                    if 'rule' not in rule:
+                        continue
+                    rule_features = findall_features(rule['rule']['features'])
+                    count+=1
+                if any([feature in rule_features for feature in new_rule_features]):
+                    overlapping_rules.append(rule_path)
+    result = {'overlapping_rules': overlapping_rules,
+              'count': count}
+    
+    return result
+
+# usage
+base_dir = ''
+new_rule_path = base_dir + 'rules\\anti-analysis\\reference-analysis-tools-strings.yml'
+rules_path = base_dir + 'rules'
+
+try:
+    result = find_overlapping_rules(new_rule_path, rules_path)
+    print('New rule path : %s' % new_rule_path)
+    print('Number of rules checked : %s ' % result['count'])
+    print('Paths to overlapping rules : ', result['overlapping_rules'])
+    print('Number of rules containing same features : %s' % len(result['overlapping_rules']))
+except Exception as e:
+    print(e)
+    try:
+        print(result,'')
+    except:
+        pass


### PR DESCRIPTION
Python script to detect feature overlap between new and existing CAPA rules. Checks if the a feature in new rule exists in both the new rule and an existing rule, ignoring other logic like scopes, structural expressions, etc.

To run edit these variables in .py file as required **new_rules_path** / **rules_path**('Directory containing the rules') / **base_dir**.

closes #1451

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
