### PR TITLE
Update the stack string detection with BN's builtin outlining of constant expressionss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 -
 
 ### Bug Fixes
+- extractor: add a Binary Ninja test that asserts its version #1487 @xusheng6
 - extractor: update Binary Ninja stack string detection after the new constant outlining feature #1473 @xusheng6
 - extractor: update vivisect Arch extraction #1334 @mr-tz
 - extractor: avoid Binary Ninja exception when analyzing certain files #1441 @xusheng6 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 -
 
 ### Bug Fixes
+- extractor: update Binary Ninja stack string detection after the new constant outlining feature #1473 @xusheng6
 - extractor: update vivisect Arch extraction #1334 @mr-tz
 - extractor: avoid Binary Ninja exception when analyzing certain files #1441 @xusheng6 
 - symtab: fix struct.unpack() format for 64-bit ELF files @yelhamer

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -55,3 +55,9 @@ def test_standalone_binja_backend():
     CD = os.path.dirname(__file__)
     test_path = os.path.join(CD, "..", "tests", "data", "Practical Malware Analysis Lab 01-01.exe_")
     assert capa.main.main([test_path, "-b", capa.main.BACKEND_BINJA]) == 0
+
+
+@pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
+def test_binja_version():
+    version = binaryninja.core_version_info()
+    assert version.major == 3 and version.minor == 4


### PR DESCRIPTION
This PR updates the BN stack string detection code, leveraging the constant outlining feature introduced in BN 3.5. 

The constant outlining, in short, detects memory writes to the stack and convert them into a more readable `strcpy`, e.g., 

```
  13 @ 00455755  __builtin_strncpy(dest: &var_10c_112, src: "AAAA", n: 4)
```

instead of 

```
00455755  mov     dword [ebp-0x108 {var_10c}], 0x41414141
0045575f  mov     dword [ebp-0x104 {var_108}], ebx  {0x0}
```

The constant outlining feature was previously causing the capa CI to fail, since the old extractor code is unaware of the new pattern. 

This PR keeps the old way of doing stack string detection and falls back to it if the new feature is unavailable. This ensures capa works properly on an older version of BN. 

This PR fixes https://github.com/mandiant/capa/issues/1473 https://github.com/mandiant/capa/issues/1487

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #1473
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
