### PR TITLE
add a Dynamic extractor interface

### DIFF
--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -275,7 +275,6 @@ class ProcessHandle:
         inner: sandbox-specific data
     """
 
-    ppid: int
     pid: int
     inner: Any
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -327,7 +327,7 @@ class DynamicExtractor(FeatureExtractor):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_threads(self, ph: ProcessHandle) -> Iterator[ProcessHandle]:
+    def get_threads(self, ph: ProcessHandle) -> Iterator[ThreadHandle]:
         """
         Yields all the threads that a process created.
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -274,6 +274,7 @@ class ProcessHandle:
         inner: sandbox-specific data
     """
 
+    ppid: int
     pid: int
     inner: Any
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -8,7 +8,7 @@
 
 import abc
 import dataclasses
-from typing import Any, Dict, Tuple, Union, Iterator, TextIO, BinaryIO
+from typing import Any, Dict, Tuple, Union, Iterator
 from dataclasses import dataclass
 
 import capa.features.address

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -305,10 +305,7 @@ class DynamicExtractor(FeatureExtractor):
     @abc.abstractmethod
     def get_processes(self) -> Iterator[ProcessHandle]:
         """
-        Yields all the child-processes of a parent one.
-
-        Attributes:
-            ph: parent process
+        Enumerate processes in the trace.
         """
         raise NotImplementedError()
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -345,22 +345,3 @@ class DynamicExtractor(FeatureExtractor):
         - network activity
         """
         raise NotImplementedError()
-
-    @abc.abstractclassmethod
-    def from_trace(cls, trace: TextIO) -> "DynamicExtractor":
-        """
-        Most sandboxes provide reports in a serialized text format (i.e. JSON for Cuckoo and CAPE).
-        This routine takes a file descriptor of such report (analysis trace) and returns a corresponding DynamicExtractor object.
-        """
-        raise NotImplementedError()
-    
-    @abc.abstractclassmethod
-    def submit_sample(cls, sample: BinaryIO, api: Dict[str, str]) -> "DynamicExtractor":
-        """
-        This routine takes a sample and submits it for analysis to the provided api. The trace should then ideally be passed to the from_trace() method.
-
-        Attributes:
-            sample: file descriptor of the sample
-            api: contains information such as the uri, api key, etc.
-        """
-        raise NotImplementedError()

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -341,7 +341,7 @@ class DynamicExtractor(FeatureExtractor):
         """
         Yields all the features of a thread. These include:
         - sequenced api traces
-        - files/registris interacted with
+        - file/registry interactions
         - network activity
         """
         raise NotImplementedError()

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -270,6 +270,7 @@ class ProcessHandle:
     reference to a process extracted by the sandbox.
 
     Attributes:
+        ppid: parent process id
         pid: process id
         inner: sandbox-specific data
     """

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -270,7 +270,6 @@ class ProcessHandle:
     reference to a process extracted by the sandbox.
 
     Attributes:
-        ppid: parent process id
         pid: process id
         inner: sandbox-specific data
     """

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -303,10 +303,6 @@ class DynamicExtractor(FeatureExtractor):
 
     This class is not instantiated directly; it is the base class for other implementations.
     """
-
-    def __init__(self):
-        super().__init__()
-
     @abc.abstractmethod
     def get_processes(self) -> Iterator[ProcessHandle]:
         """

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -322,10 +322,7 @@ class DynamicExtractor(FeatureExtractor):
     @abc.abstractmethod
     def get_threads(self, ph: ProcessHandle) -> Iterator[ThreadHandle]:
         """
-        Yields all the threads that a process created.
-
-        Attributes:
-            ph: parent process
+        Enumerate threads in the given process.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This is the parent branch of the cape-dynamic-extractor and cuckoo-dynamic extractor; The two will ensue later on. It defined the interface that all dynamic sandbox-based feature extractors should implement.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
