### PR TITLE
add flavored scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a CAPE file format and CAPE-based dynamic feature extraction to scripts/show-features.py #1566 @yelhamer
 - Add a new process scope for the dynamic analysis flavor #1517 @yelhamer
 - Add a new thread scope for the dynamic analysis flavor #1517 @yelhamer
+- Add support for flavor-based rule scopes @yelhamer
 
 ### Breaking Changes
 - Update Metadata type in capa main [#1411](https://github.com/mandiant/capa/issues/1411) [@Aayush-Goel-04](https://github.com/aayush-goel-04) @manasghandat

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -252,24 +252,28 @@ class InvalidRuleSet(ValueError):
 def ensure_feature_valid_for_scope(scope: Union[str, Flavor], feature: Union[Feature, Statement]):
     # if the given feature is a characteristic,
     # check that is a valid characteristic for the given scope.
+    supported_features = set()
     if isinstance(scope, Flavor):
         if scope.static:
-            ensure_feature_valid_for_scope(scope.static, feature)
+            supported_features.update(SUPPORTED_FEATURES[scope.static])
         if scope.dynamic:
-            ensure_feature_valid_for_scope(scope.dynamic, feature)
-        return
+            supported_features.update(SUPPORTED_FEATURES[scope.dynamic])
+    elif isinstance(scope, str):
+        supported_features.update(SUPPORTED_FEATURES[scope])
+    else:
+        raise InvalidRule(f"{scope} is not a valid scope")
 
     if (
         isinstance(feature, capa.features.common.Characteristic)
         and isinstance(feature.value, str)
-        and capa.features.common.Characteristic(feature.value) not in SUPPORTED_FEATURES[scope]
+        and capa.features.common.Characteristic(feature.value) not in supported_features
     ):
         raise InvalidRule(f"feature {feature} not supported for scope {scope}")
 
     if not isinstance(feature, capa.features.common.Characteristic):
         # features of this scope that are not Characteristics will be Type instances.
         # check that the given feature is one of these types.
-        types_for_scope = filter(lambda t: isinstance(t, type), SUPPORTED_FEATURES[scope])
+        types_for_scope = filter(lambda t: isinstance(t, type), supported_features)
         if not isinstance(feature, tuple(types_for_scope)):  # type: ignore
             raise InvalidRule(f"feature {feature} not supported for scope {scope}")
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -376,24 +376,46 @@ def test_subscope_rules():
                     """
                 )
             ),
+            capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    """
+                    rule:
+                        meta:
+                            name: test subscopes for scope flavors
+                            scope: 
+                                static: function
+                                dynamic: process
+                        features:
+                            - and:
+                                - string: yo
+                                - instruction:
+                                    - mnemonic: shr
+                                    - number: 5
+                    """
+                )
+            ),
         ]
     )
     # the file rule scope will have two rules:
     #  - `test function subscope` and `test process subscope`
     assert len(rules.file_rules) == 2
 
-    # the function rule scope have one rule:
-    #  - the rule on which `test function subscope` depends
-    assert len(rules.function_rules) == 1
+    # the function rule scope have two rule:
+    # - the rule on which `test function subscope` depends, and
+    # the `test subscopes for scope flavors` rule
+    assert len(rules.function_rules) == 2
 
-    # the process rule scope has one rule:
-    # - the rule on which `test process subscope` and depends
-    # as well as `test thread scope`
-    assert len(rules.process_rules) == 2
+    # the process rule scope has three rules:
+    # - the rule on which `test process subscope` depends,
+    # `test thread scope` , and `test subscopes for scope flavors`
+    assert len(rules.process_rules) == 3
 
     # the thread rule scope has one rule:
     # - the rule on which `test thread subscope` depends
     assert len(rules.thread_rules) == 1
+
+    # the rule on which `test subscopes for scope flavors` depends
+    assert len(rules.instruction_rules) == 1
 
 
 def test_duplicate_rules():
@@ -494,6 +516,66 @@ def test_invalid_rules():
                     meta:
                         name: test rule
                         mbc: Objective::Behavior::Method [Identifier]
+                    features:
+                        - number: 1
+                """
+            )
+        )
+    with pytest.raises(capa.rules.InvalidRule):
+        r = capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule
+                        scope:
+                            static: basic block
+                            behavior: process
+                    features:
+                        - number: 1
+                """
+            )
+        )
+    with pytest.raises(capa.rules.InvalidRule):
+        r = capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule
+                        scope:
+                            legacy: basic block
+                            dynamic: process
+                    features:
+                        - number: 1
+                """
+            )
+        )
+    with pytest.raises(capa.rules.InvalidRule):
+        r = capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule
+                        scope:
+                            static: process
+                            dynamic: process
+                    features:
+                        - number: 1
+                """
+            )
+        )
+    with pytest.raises(capa.rules.InvalidRule):
+        r = capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule
+                        scope:
+                            static: basic block
+                            dynamic: function
                     features:
                         - number: 1
                 """


### PR DESCRIPTION
This PR proposes an implementation for the concept of _flavors_ (as discussed in #1517 ).

In this PR, each rule is assumed to have two different interpretations depending on what type of extractor it is matching against (_Dynamic_ or _Static_). If the extractor is static, it will be looking to match against static scopes and will thus fetch the static interpretation of the rule form the _RuleSet_ class, and if it is a dynamic extractor, it will do the same by fetching the dynamic interpretation. A rule may lack one interpretation/flavor at most (either a static scope or a dynamic one must be specified).

One advantage of this design is we can have rules written for one analysis mode (static for example) be used in a dynamic analysis context. For example the following rule:
```yaml
rule:
  meta:
    name: create a socket
    scope:
      static: function
      dynamic: thread
  features:
    - or:
      - api: socket
      - and:
        - instruction:    # will become a `match` feature
          - mnemonic: syscall
          - number: 41
```
In this case, if the rule is being matched against features extracted by a dynamic extractor then the `API(socket)` feature would still match, and thereby the whole rule would still match and it won't be lost.

Disadvantages of this approach is the the `Flavor` class feels like a hack. I feel like it could be nice if we could rename that class into `Scope`, and find another way to represent the `Scope` enum class.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
