### PR TITLE
fix import-to-ida due to changes in the result document format in v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Add logging and print redirect to tqdm for capa main [#749](https://github.com/mandiant/capa/issues/749) [@Aayush-Goel-04](https://github.com/aayush-goel-04)
 - extractor: fix binja installation path detection does not work with Python 3.11
 - tests: refine the IDA test runner script #1513 @williballenthin
+- import-to-ida: fix bug introduced with JSON report changes in v5 #1584 @williballenthin
 
 ### capa explorer IDA Pro plugin
 

--- a/scripts/import-to-ida.py
+++ b/scripts/import-to-ida.py
@@ -28,8 +28,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
-import binascii
 import logging
+import binascii
 
 import ida_nalt
 import ida_funcs
@@ -76,7 +76,7 @@ def main():
     # found: b'84882C9D43E23D63B82004FAE74EBB6\x00'
     #
     # see: https://github.com/idapython/bin/issues/11
-    a = meta["sample"]["md5"].lower()
+    a = meta.sample.md5.lower()
     b = binascii.hexlify(ida_nalt.retrieve_input_file_md5()).decode("ascii").lower()
     if not a.startswith(b):
         logger.error("sample mismatch")

--- a/scripts/import-to-ida.py
+++ b/scripts/import-to-ida.py
@@ -94,8 +94,11 @@ def main():
 
         name = rule["meta"]["name"]
         ns = rule["meta"].get("namespace", "")
-        for va in rule["matches"].keys():
-            va = int(va)
+        for address, match in rule["matches"]:
+            if address["type"] != "absolute":
+                continue
+
+            va = address["value"]
             rows.append((ns, name, va))
 
     # order by (namespace, name) so that like things show up together

--- a/scripts/import-to-ida.py
+++ b/scripts/import-to-ida.py
@@ -28,6 +28,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
+import binascii
 import json
 import logging
 
@@ -77,7 +78,7 @@ def main():
     #
     # see: https://github.com/idapython/bin/issues/11
     a = doc["meta"]["sample"]["md5"].lower()
-    b = ida_nalt.retrieve_input_file_md5().lower()
+    b = binascii.hexlify(ida_nalt.retrieve_input_file_md5()).decode("ascii").lower()
     if not a.startswith(b):
         logger.error("sample mismatch")
         return -2


### PR DESCRIPTION
closes #1584 

these changes will work with JSON reports created from master/v6 but not backwards on v5. there's a script that works on v5 here: https://github.com/mandiant/capa/blob/19a5ef8/scripts/import-to-ida.py


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
