### PR TITLE
ci: set top level permissions to satisfy code scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: build
 
-permissions:
-  contents: write
-
 on:
   pull_request:
     branches: [ master ]
   release:
     types: [edited, published]
+
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,8 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+permissions: read-all
+
 jobs:
   check_changelog:
     # no need to check for dependency updates via dependabot

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,12 @@
 # https://blog.trailofbits.com/2023/05/23/trusted-publishing-a-new-benchmark-for-packaging-security/
 name: publish to pypi
 
-permissions:
-  contents: write
-
 on:
   release:
     types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   pypi-publish:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   tag:
     name: Tag capa rules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 # save workspaces to speed up testing
 env:
   CAPA_SAVE_WORKSPACE: "True"


### PR DESCRIPTION
https://github.com/mandiant/capa/security/code-scanning/30
https://github.com/mandiant/capa/security/code-scanning/29
https://github.com/mandiant/capa/security/code-scanning/27

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
