### PR TITLE
main: don't show spinner when debug messages are emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - tests: refine the IDA test runner script #1513 @williballenthin
 - output: don't leave behind traces of progress bar @williballenthin
 - import-to-ida: fix bug introduced with JSON report changes in v5 #1584 @williballenthin
+- main: don't show spinner when emitting debug messages #1636 @williballenthin
 
 ### capa explorer IDA Pro plugin
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -1250,7 +1250,7 @@ def main(argv: Optional[List[str]] = None):
                     args.backend,
                     sig_paths,
                     should_save_workspace,
-                    disable_progress=args.quiet,
+                    disable_progress=args.quiet or args.debug,
                 )
             except UnsupportedFormatError:
                 log_unsupported_format_error()


### PR DESCRIPTION
closes #1636

<img width="521" alt="image" src="https://github.com/mandiant/capa/assets/156560/33f9468a-f661-4125-9c7f-b7fa9b8b2dee">


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
