### PR TITLE
Fix binja backend stack string detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- Fix binja backend stack string detection. [#1473](https://github.com/mandiant/capa/issues/1473) [@xusheng6](https://github.com/xusheng6)
+
 ### capa explorer IDA Pro plugin
 
 ### Development

--- a/capa/features/extractors/binja/basicblock.py
+++ b/capa/features/extractors/binja/basicblock.py
@@ -75,10 +75,11 @@ def get_stack_string_len(f: Function, il: MediumLevelILInstruction) -> int:
         return 0
 
     dest = il.params[0]
-    if dest.operation != MediumLevelILOperation.MLIL_ADDRESS_OF:
+    if dest.operation in [MediumLevelILOperation.MLIL_ADDRESS_OF, MediumLevelILOperation.MLIL_VAR]:
+        var = dest.src
+    else:
         return 0
 
-    var = dest.src
     if var.source_type != VariableSourceType.StackVariableSourceType:
         return 0
 

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -40,9 +40,6 @@ except ImportError:
     indirect=["sample", "scope"],
 )
 def test_binja_features(sample, scope, feature, expected):
-    if feature == capa.features.common.Characteristic("stack string"):
-        pytest.xfail("skip failing Binja stack string detection temporarily, see #1473")
-
     if isinstance(feature, capa.features.file.Export) and "." in str(feature.value):
         pytest.xfail("skip Binja unsupported forwarded export feature, see #1646")
 


### PR DESCRIPTION
This fixes a bug in the binja stack string detection code. 

I was writing the code with a newer version of binja. It does not work with the stable headless used for the CI. 


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
