### PR TITLE
Add a call scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add ProcessesAddress and ThreadAddress #1612 @yelhamer
 - Add dynamic capability extraction @yelhamer
 - Add support for mixed-scopes rules @yelhamer
+- Add a call scope @yelhamer
 
 ### Breaking Changes
 

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -93,7 +93,7 @@ class ThreadAddress(Address):
         return (self.process, self.tid) < (other.process, other.tid)
 
 
-class CallAddress(Address):
+class DynamicCallAddress(Address):
     """addesses a call in a dynamic execution trace"""
 
     def __init__(self, thread: ThreadAddress, id: int):
@@ -108,18 +108,18 @@ class CallAddress(Address):
         return hash((self.thread, self.id))
 
     def __eq__(self, other):
-        assert isinstance(other, CallAddress)
+        assert isinstance(other, DynamicCallAddress)
         return (self.thread, self.id) == (other.thread, other.id)
 
     def __lt__(self, other):
-        assert isinstance(other, CallAddress)
+        assert isinstance(other, DynamicCallAddress)
         return (self.thread, self.id) < (other.thread, other.id)
 
 
 class DynamicReturnAddress(Address):
     """an address from a dynamic analysis trace"""
 
-    def __init__(self, call: CallAddress, return_address: int):
+    def __init__(self, call: DynamicCallAddress, return_address: int):
         assert return_address >= 0
         self.call = call
         self.return_address = return_address

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -66,6 +66,7 @@ class ProcessAddress(Address):
         return (self.ppid, self.pid) == (other.ppid, other.pid)
 
     def __lt__(self, other):
+        assert isinstance(other, ProcessAddress)
         return (self.ppid, self.pid) < (other.ppid, other.pid)
 
 
@@ -85,11 +86,11 @@ class ThreadAddress(Address):
 
     def __eq__(self, other):
         assert isinstance(other, ThreadAddress)
-        return self.tid == other.tid
+        return (self.process, self.tid) == (other.process, other.tid)
 
     def __lt__(self, other):
         assert isinstance(other, ThreadAddress)
-        return self.tid < other.tid
+        return (self.process, self.tid) < (other.process, other.tid)
 
 
 class CallAddress(Address):
@@ -108,11 +109,11 @@ class CallAddress(Address):
 
     def __eq__(self, other):
         assert isinstance(other, CallAddress)
-        return self.id == other.id
+        return (self.thread, self.id) == (other.thread, other.id)
 
     def __lt__(self, other):
         assert isinstance(other, CallAddress)
-        return self.id < other.id
+        return (self.thread, self.id) < (other.thread, other.id)
 
 
 class DynamicReturnAddress(Address):
@@ -131,11 +132,11 @@ class DynamicReturnAddress(Address):
 
     def __eq__(self, other):
         assert isinstance(other, DynamicReturnAddress)
-        return self.return_address == other.return_address
+        return (self.call, self.return_address) == other.call, other.return_address)
 
     def __lt__(self, other):
         assert isinstance(other, DynamicReturnAddress)
-        return self.return_address < other.return_address
+        return (self.call, self.return_address) < (other.call, other.return_address)
 
 
 class RelativeVirtualAddress(int, Address):

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -132,7 +132,7 @@ class DynamicReturnAddress(Address):
 
     def __eq__(self, other):
         assert isinstance(other, DynamicReturnAddress)
-        return (self.call, self.return_address) == other.call, other.return_address)
+        return (self.call, self.return_address) == (other.call, other.return_address)
 
     def __lt__(self, other):
         assert isinstance(other, DynamicReturnAddress)

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -78,39 +78,64 @@ class ThreadAddress(Address):
         self.tid = tid
 
     def __repr__(self):
-        return f"thread(tid: {self.tid})"
+        return f"{self.process}, thread(tid: {self.tid})"
 
     def __hash__(self):
         return hash((self.process, self.tid))
 
     def __eq__(self, other):
         assert isinstance(other, ThreadAddress)
-        return (self.process, self.tid) == (other.process, other.tid)
+        return self.tid == other.tid
 
     def __lt__(self, other):
-        return (self.process, self.tid) < (other.process, other.tid)
+        assert isinstance(other, ThreadAddress)
+        return self.tid < other.tid
 
 
-class DynamicAddress(Address):
+class CallAddress(Address):
+    """addesses a call in a dynamic execution trace"""
+
+    def __init__(self, thread: ThreadAddress, id: int):
+        assert id >= 0
+        self.thread = thread
+        self.id = id
+
+    def __repr__(self):
+        return f"{self.thread}, call(id: {self.id})"
+
+    def __hash__(self):
+        return hash((self.thread, self.id))
+
+    def __eq__(self, other):
+        assert isinstance(other, CallAddress)
+        return self.id == other.id
+
+    def __lt__(self, other):
+        assert isinstance(other, CallAddress)
+        return self.id < other.id
+
+
+class DynamicReturnAddress(Address):
     """an address from a dynamic analysis trace"""
 
-    def __init__(self, id_: int, return_address: int):
-        assert id_ >= 0
+    def __init__(self, call: CallAddress, return_address: int):
         assert return_address >= 0
-        self.id = id_
+        self.call = call
         self.return_address = return_address
 
     def __repr__(self):
-        return f"dynamic(event: {self.id}, returnaddress: 0x{self.return_address:x})"
+        return f"{self.call}, dynamic-call(return-address: 0x{self.return_address:x})"
 
     def __hash__(self):
-        return hash((self.id, self.return_address))
+        return hash((self.call, self.return_address))
 
     def __eq__(self, other):
-        return (self.id, self.return_address) == (other.id, other.return_address)
+        assert isinstance(other, DynamicReturnAddress)
+        return self.return_address == other.return_address
 
     def __lt__(self, other):
-        return (self.id, self.return_address) < (other.id, other.return_address)
+        assert isinstance(other, DynamicReturnAddress)
+        return self.return_address < other.return_address
 
 
 class RelativeVirtualAddress(int, Address):

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -16,7 +16,7 @@ from typing_extensions import TypeAlias
 
 import capa.features.address
 from capa.features.common import Feature
-from capa.features.address import Address, ThreadAddress, ProcessAddress, AbsoluteVirtualAddress
+from capa.features.address import Address, CallAddress, ThreadAddress, ProcessAddress, AbsoluteVirtualAddress
 
 # feature extractors may reference functions, BBs, insns by opaque handle values.
 # you can use the `.address` property to get and render the address of the feature.
@@ -300,7 +300,7 @@ class ProcessHandle:
     reference to a process extracted by the sandbox.
 
     Attributes:
-        pid: process id
+        address: process' address (pid and pid)
         inner: sandbox-specific data
     """
 
@@ -314,11 +314,25 @@ class ThreadHandle:
     reference to a thread extracted by the sandbox.
 
     Attributes:
-        tid: thread id
+        address: thread's address (tid)
         inner: sandbox-specific data
     """
 
     address: ThreadAddress
+    inner: Any
+
+
+@dataclass
+class CallHandle:
+    """
+    reference to an api call extracted by the sandbox.
+
+    Attributes:
+        address: call's id address
+        inner: sandbox-specific data
+    """
+
+    address: CallAddress
     inner: Any
 
 
@@ -415,6 +429,24 @@ class DynamicFeatureExtractor:
         - sequenced api traces
         - file/registry interactions
         - network activity
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_calls(self, ph: ProcessHandle, th: ThreadHandle) -> Iterator[CallHandle]:
+        """
+        Enumerate calls in the given thread
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def extract_call_features(
+        self, ph: ProcessHandle, th: ThreadHandle, ch: CallHandle
+    ) -> Iterator[Tuple[Feature, Address]]:
+        """
+        Yields all features of a call. These include:
+        - api's
+        - arguments
         """
         raise NotImplementedError()
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -16,7 +16,7 @@ from typing_extensions import TypeAlias
 
 import capa.features.address
 from capa.features.common import Feature
-from capa.features.address import Address, CallAddress, ThreadAddress, ProcessAddress, AbsoluteVirtualAddress
+from capa.features.address import Address, ThreadAddress, ProcessAddress, DynamicCallAddress, AbsoluteVirtualAddress
 
 # feature extractors may reference functions, BBs, insns by opaque handle values.
 # you can use the `.address` property to get and render the address of the feature.
@@ -332,7 +332,7 @@ class CallHandle:
         inner: sandbox-specific data
     """
 
-    address: CallAddress
+    address: DynamicCallAddress
     inner: Any
 
 

--- a/capa/features/extractors/base_extractor.py
+++ b/capa/features/extractors/base_extractor.py
@@ -300,7 +300,7 @@ class ProcessHandle:
     reference to a process extracted by the sandbox.
 
     Attributes:
-        address: process' address (pid and pid)
+        address: process's address (pid)
         inner: sandbox-specific data
     """
 

--- a/capa/features/extractors/cape/call.py
+++ b/capa/features/extractors/cape/call.py
@@ -25,13 +25,14 @@ def extract_call_features(
     behavior: Dict, ph: ProcessHandle, th: ThreadHandle, ch: CallHandle
 ) -> Iterator[Tuple[Feature, Address]]:
     """
-    this method goes through the specified thread's call trace, and extracts all possible
-    features such as: API, Number (for arguments), String (for arguments).
+    this method extrcts the given call's features (api name and arguments),
+    and returns them as API, Number, and String features.
 
     args:
       behavior: a dictionary of behavioral artifacts extracted by the sandbox
       ph: process handle (for defining the extraction scope)
       th: thread handle (for defining the extraction scope)
+      ch: call handle (for defining the extraction scope)
 
     yields:
       Feature, address; where Feature is either: API, Number, or String.

--- a/capa/features/extractors/cape/call.py
+++ b/capa/features/extractors/cape/call.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2023 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import logging
+from typing import Any, Dict, List, Tuple, Iterator
+
+import capa.features.extractors.cape.file
+import capa.features.extractors.cape.thread
+import capa.features.extractors.cape.global_
+import capa.features.extractors.cape.process
+from capa.features.insn import API, Number
+from capa.features.common import String, Feature
+from capa.features.address import Address, DynamicReturnAddress
+from capa.features.extractors.base_extractor import CallHandle, ThreadHandle, ProcessHandle
+
+logger = logging.getLogger(__name__)
+
+
+def extract_call_features(
+    behavior: Dict, ph: ProcessHandle, th: ThreadHandle, ch: CallHandle
+) -> Iterator[Tuple[Feature, Address]]:
+    """
+    this method goes through the specified thread's call trace, and extracts all possible
+    features such as: API, Number (for arguments), String (for arguments).
+
+    args:
+      behavior: a dictionary of behavioral artifacts extracted by the sandbox
+      ph: process handle (for defining the extraction scope)
+      th: thread handle (for defining the extraction scope)
+
+    yields:
+      Feature, address; where Feature is either: API, Number, or String.
+    """
+    # TODO(yelhamer): find correct base address used at runtime.
+    # this address may vary from the PE header, may read actual base from procdump.pe.imagebase or similar.
+    # https://github.com/mandiant/capa/issues/1618
+    process = capa.features.extractors.cape.helpers.find_process(behavior["processes"], ph)
+    calls: List[Dict[str, Any]] = process["calls"]
+    call = calls[ch.address.id]
+    assert call["thread_id"] == str(th.address.tid)
+    caller = DynamicReturnAddress(call=ch.address, return_address=int(call["caller"], 16))
+    # list similar to disassembly: arguments right-to-left, call
+    for arg in call["arguments"][::-1]:
+        try:
+            yield Number(int(arg["value"], 16), description=f"{arg['name']}"), caller
+        except ValueError:
+            yield String(arg["value"], description=f"{arg['name']}"), caller
+    yield API(call["api"]), caller
+
+
+def extract_features(
+    behavior: Dict, ph: ProcessHandle, th: ThreadHandle, ch: CallHandle
+) -> Iterator[Tuple[Feature, Address]]:
+    for handler in CALL_HANDLERS:
+        for feature, addr in handler(behavior, ph, th, ch):
+            yield feature, addr
+
+
+CALL_HANDLERS = (extract_call_features,)

--- a/capa/features/extractors/cape/call.py
+++ b/capa/features/extractors/cape/call.py
@@ -48,9 +48,9 @@ def extract_call_features(
     # list similar to disassembly: arguments right-to-left, call
     for arg in call["arguments"][::-1]:
         try:
-            yield Number(int(arg["value"], 16), description=f"{arg['name']}"), caller
+            yield Number(int(arg["value"], 16)), caller
         except ValueError:
-            yield String(arg["value"], description=f"{arg['name']}"), caller
+            yield String(arg["value"]), caller
     yield API(call["api"]), caller
 
 

--- a/capa/features/extractors/cape/extractor.py
+++ b/capa/features/extractors/cape/extractor.py
@@ -9,13 +9,20 @@
 import logging
 from typing import Dict, Tuple, Union, Iterator
 
+import capa.features.extractors.cape.call
 import capa.features.extractors.cape.file
 import capa.features.extractors.cape.thread
 import capa.features.extractors.cape.global_
 import capa.features.extractors.cape.process
 from capa.features.common import Feature
 from capa.features.address import Address, AbsoluteVirtualAddress, _NoAddress
-from capa.features.extractors.base_extractor import SampleHashes, ThreadHandle, ProcessHandle, DynamicFeatureExtractor
+from capa.features.extractors.base_extractor import (
+    CallHandle,
+    SampleHashes,
+    ThreadHandle,
+    ProcessHandle,
+    DynamicFeatureExtractor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +67,14 @@ class CapeExtractor(DynamicFeatureExtractor):
 
     def extract_thread_features(self, ph: ProcessHandle, th: ThreadHandle) -> Iterator[Tuple[Feature, Address]]:
         yield from capa.features.extractors.cape.thread.extract_features(self.behavior, ph, th)
+
+    def get_calls(self, ph: ProcessHandle, th: ThreadHandle) -> Iterator[CallHandle]:
+        yield from capa.features.extractors.cape.thread.get_calls(self.behavior, ph, th)
+
+    def extract_call_features(
+        self, ph: ProcessHandle, th: ThreadHandle, ch: CallHandle
+    ) -> Iterator[Tuple[Feature, Address]]:
+        yield from capa.features.extractors.cape.call.extract_features(self.behavior, ph, th, ch)
 
     @classmethod
     def from_report(cls, report: Dict) -> "CapeExtractor":

--- a/capa/features/extractors/cape/thread.py
+++ b/capa/features/extractors/cape/thread.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Tuple, Iterator
 
 import capa.features.extractors.cape.helpers
 from capa.features.common import Feature
-from capa.features.address import NO_ADDRESS, Address, CallAddress
+from capa.features.address import NO_ADDRESS, Address, DynamicCallAddress
 from capa.features.extractors.base_extractor import CallHandle, ThreadHandle, ProcessHandle
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def get_calls(behavior: Dict, ph: ProcessHandle, th: ThreadHandle) -> Iterator[C
         if call["thread_id"] != tid:
             continue
 
-        addr = CallAddress(thread=th.address, id=call["id"])
+        addr = DynamicCallAddress(thread=th.address, id=call["id"])
         ch = CallHandle(address=addr, inner={})
         yield ch
 

--- a/capa/features/extractors/null.py
+++ b/capa/features/extractors/null.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing_extensions import TypeAlias
 
 from capa.features.common import Feature
-from capa.features.address import NO_ADDRESS, Address, CallAddress, ThreadAddress, ProcessAddress
+from capa.features.address import NO_ADDRESS, Address, ThreadAddress, ProcessAddress, DynamicCallAddress
 from capa.features.extractors.base_extractor import (
     BBHandle,
     CallHandle,
@@ -151,7 +151,7 @@ class NullDynamicFeatureExtractor(DynamicFeatureExtractor):
 
     def get_calls(self, p, t):
         for address in sorted(self.processes[p.address].threads[t.address].calls.keys()):
-            assert isinstance(address, CallAddress)
+            assert isinstance(address, DynamicCallAddress)
             yield CallHandle(address=address, inner={})
 
     def extract_call_features(self, p, t, call):

--- a/capa/features/freeze/__init__.py
+++ b/capa/features/freeze/__init__.py
@@ -82,7 +82,7 @@ class Address(HashableModel):
         elif isinstance(a, capa.features.address.ThreadAddress):
             return cls(type=AddressType.THREAD, value=(a.process.ppid, a.process.pid, a.tid))
 
-        elif isinstance(a, capa.features.address.CallAddress):
+        elif isinstance(a, capa.features.address.DynamicCallAddress):
             return cls(type=AddressType.CALL, value=(a.thread.process.ppid, a.thread.process.pid, a.thread.tid, a.id))
 
         elif isinstance(a, capa.features.address.DynamicReturnAddress):
@@ -153,7 +153,7 @@ class Address(HashableModel):
         elif self.type is AddressType.CALL:
             assert isinstance(self.value, tuple)
             ppid, pid, tid, id_ = self.value
-            return capa.features.address.CallAddress(
+            return capa.features.address.DynamicCallAddress(
                 thread=capa.features.address.ThreadAddress(
                     process=capa.features.address.ProcessAddress(ppid=ppid, pid=pid), tid=tid
                 ),
@@ -164,7 +164,7 @@ class Address(HashableModel):
             assert isinstance(self.value, tuple)
             ppid, pid, tid, id_, return_address = self.value
             return capa.features.address.DynamicReturnAddress(
-                call=capa.features.address.CallAddress(
+                call=capa.features.address.DynamicCallAddress(
                     thread=capa.features.address.ThreadAddress(
                         process=capa.features.address.ProcessAddress(ppid=ppid, pid=pid), tid=tid
                     ),

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -67,12 +67,10 @@ def format_address(address: frz.Address) -> str:
         assert isinstance(pid, int)
         return f"process ppid: {ppid}, process pid: {pid}"
     elif address.type == frz.AddressType.THREAD:
-        assert isinstance(address.value, tuple)
-        ppid, pid, tid = address.value
-        assert isinstance(ppid, int)
-        assert isinstance(pid, int)
+        assert isinstance(address.value, int)
+        tid = address.value
         assert isinstance(tid, int)
-        return f"process ppid: {ppid}, process pid: {pid}, thread id: {tid}"
+        return f"thread id: {tid}"
     elif address.type == frz.AddressType.NO_ADDRESS:
         return "global"
     else:

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -124,7 +124,7 @@ class Scopes:
 
     def __repr__(self) -> str:
         if self.static and self.dynamic:
-            return f"static-scope: {self.static}, dyanamic-scope: {self.dynamic}"
+            return f"static-scope: {self.static}, dynamic-scope: {self.dynamic}"
         elif self.static:
             return f"static-scope: {self.static}"
         elif self.dynamic:
@@ -1267,6 +1267,7 @@ class RuleSet:
         self.file_rules = self._get_rules_for_scope(rules, FILE_SCOPE)
         self.process_rules = self._get_rules_for_scope(rules, PROCESS_SCOPE)
         self.thread_rules = self._get_rules_for_scope(rules, THREAD_SCOPE)
+        self.call_rules = self._get_rules_for_scope(rules, CALL_SCOPE)
         self.function_rules = self._get_rules_for_scope(rules, FUNCTION_SCOPE)
         self.basic_block_rules = self._get_rules_for_scope(rules, BASIC_BLOCK_SCOPE)
         self.instruction_rules = self._get_rules_for_scope(rules, INSTRUCTION_SCOPE)
@@ -1279,6 +1280,7 @@ class RuleSet:
             self.process_rules
         )
         (self._easy_thread_rules_by_feature, self._hard_thread_rules) = self._index_rules_by_feature(self.thread_rules)
+        (self._easy_call_rules_by_feature, self._hard_call_rules) = self._index_rules_by_feature(self.call_rules)
         (self._easy_function_rules_by_feature, self._hard_function_rules) = self._index_rules_by_feature(
             self.function_rules
         )
@@ -1533,6 +1535,9 @@ class RuleSet:
         elif scope == Scope.THREAD:
             easy_rules_by_feature = self._easy_thread_rules_by_feature
             hard_rule_names = self._hard_thread_rules
+        elif scope == Scope.CALL:
+            easy_rules_by_feature = self._easy_call_rules_by_feature
+            hard_rule_names = self._hard_call_rules
         elif scope == Scope.FUNCTION:
             easy_rules_by_feature = self._easy_function_rules_by_feature
             hard_rule_names = self._hard_function_rules

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -189,13 +189,12 @@ SUPPORTED_FEATURES: Dict[str, Set] = {
         capa.features.common.Regex,
         capa.features.common.Characteristic("embedded pe"),
     },
-    THREAD_SCOPE: {
-        capa.features.common.MatchedRule,
-        capa.features.common.Substring,
-        capa.features.common.Regex,
-    },
+    THREAD_SCOPE: set(),
     CALL_SCOPE: {
+        capa.features.common.MatchedRule,
+        capa.features.common.Regex,
         capa.features.common.String,
+        capa.features.common.Substring,
         capa.features.insn.API,
         capa.features.insn.Number,
     },

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -571,7 +571,7 @@ def build_statements(d, scopes: Scopes):
 
     elif key == "call":
         if all(s not in scopes for s in (FILE_SCOPE, PROCESS_SCOPE, THREAD_SCOPE)):
-            raise InvalidRule("thread subscope supported only for the process scope")
+            raise InvalidRule("call subscope supported only for the process and thread scopes")
 
         if len(d[key]) != 1:
             raise InvalidRule("subscope must have exactly one child statement")

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -257,7 +257,7 @@ def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
             print(f" proc: {p.inner['name']}: {feature}")
 
             for t in extractor.get_threads(p):
-                print(f"  {t.address}")
+                print(f"  thread: {t.address.tid}")
                 for feature, addr in extractor.extract_thread_features(p, t):
                     if is_global_feature(feature):
                         continue
@@ -273,7 +273,8 @@ def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
                             continue
 
                         if isinstance(feature, API):
-                            apis.append(str(feature.value))
+                            assert isinstance(addr, capa.features.address.DynamicReturnAddress)
+                            apis.append((addr.call.id, str(feature.value)))
 
                         if isinstance(feature, (Number, String)):
                             arguments.append(str(feature.value))
@@ -281,8 +282,8 @@ def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
                     if not apis:
                         print(f"    arguments=[{', '.join(arguments)}]")
 
-                    for api in apis:
-                        print(f"{api}({', '.join(arguments)})")
+                    for cid, api in apis:
+                        print(f"call {cid}: {api}({', '.join(arguments)})")
 
 
 def ida_main():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -165,13 +165,55 @@ def test_ruleset():
                         """
                 )
             ),
+            capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    """
+                    rule:
+                        meta:
+                            name: test call subscope
+                            scopes:
+                                static: basic block
+                                dynamic: thread
+                        features:
+                          - and:
+                            - string: "explorer.exe"
+                            - call:
+                              - api: HttpOpenRequestW
+                    """
+                )
+            ),
+            capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    """
+                    rule:
+                        meta:
+                            name: test rule
+                            scopes:
+                                static: instruction
+                                dynamic: call
+                        features:
+                          - and:
+                            - or:
+                              - api: socket
+                              - and:
+                                - os: linux
+                                - mnemonic: syscall
+                                - number: 41 = socket()
+                            - number: 6 = IPPROTO_TCP
+                            - number: 1 = SOCK_STREAM
+                            - number: 2 = AF_INET
+                    """
+                )
+            ),
         ]
     )
     assert len(rules.file_rules) == 2
     assert len(rules.function_rules) == 2
-    assert len(rules.basic_block_rules) == 1
+    assert len(rules.basic_block_rules) == 2
+    assert len(rules.instruction_rules) == 1
     assert len(rules.process_rules) == 4
-    assert len(rules.thread_rules) == 1
+    assert len(rules.thread_rules) == 2
+    assert len(rules.call_rules) == 2
 
 
 def test_match_across_scopes_file_function(z9324d_extractor):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -517,16 +517,16 @@ def test_subscope_rules():
                 textwrap.dedent(
                     """
                     rule:
-                        meta:
-                            name: test call subscope
-                            scopes:
-                                static: basic block
-                                dynamic: thread
-                        features:
-                            - and:
-                                 - string: "explorer.exe"
-                                 - call:
-                                    - api: HttpOpenRequestW
+                      meta:
+                        name: test call subscope
+                        scopes:
+                          static: basic block
+                          dynamic: thread
+                      features:
+                        - and:
+                          - string: "explorer.exe"
+                          - call:
+                            - api: HttpOpenRequestW
                     """
                 )
             ),

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -363,10 +363,10 @@ def test_multi_scope_rules_features():
                         static: instruction
                         dynamic: call
                 features:
-                    - and:
+                  - and:
                     - or:
-                        - api: socket
-                        - and:
+                      - api: socket
+                      - and:
                         - os: linux
                         - mnemonic: syscall
                         - number: 41 = socket()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -357,22 +357,22 @@ def test_multi_scope_rules_features():
         textwrap.dedent(
             """
             rule:
-                meta:
-                    name: test rule
-                    scopes:
-                        static: instruction
-                        dynamic: call
-                features:
-                  - and:
-                    - or:
-                      - api: socket
-                      - and:
-                        - os: linux
-                        - mnemonic: syscall
-                        - number: 41 = socket()
-                    - number: 6 = IPPROTO_TCP
-                    - number: 1 = SOCK_STREAM
-                    - number: 2 = AF_INET
+              meta:
+                name: test rule
+                scopes:
+                  static: instruction
+                  dynamic: call
+              features:
+                - and:
+                  - or:
+                    - api: socket
+                    - and:
+                      - os: linux
+                      - mnemonic: syscall
+                      - number: 41 = socket()
+                  - number: 6 = IPPROTO_TCP
+                  - number: 1 = SOCK_STREAM
+                  - number: 2 = AF_INET
             """
         )
     )

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -353,6 +353,30 @@ def test_multi_scope_rules_features():
         )
     )
 
+    _ = capa.rules.Rule.from_yaml(
+        textwrap.dedent(
+            """
+            rule:
+                meta:
+                    name: test rule
+                    scopes:
+                        static: instruction
+                        dynamic: call
+                features:
+                    - and:
+                    - or:
+                        - api: socket
+                        - and:
+                        - os: linux
+                        - mnemonic: syscall
+                        - number: 41 = socket()
+                    - number: 6 = IPPROTO_TCP
+                    - number: 1 = SOCK_STREAM
+                    - number: 2 = AF_INET
+            """
+        )
+    )
+
 
 def test_rules_flavor_filtering():
     rules = [
@@ -489,12 +513,30 @@ def test_subscope_rules():
                     """
                 )
             ),
+            capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    """
+                    rule:
+                        meta:
+                            name: test call subscope
+                            scopes:
+                                static: basic block
+                                dynamic: thread
+                        features:
+                            - and:
+                                 - string: "explorer.exe"
+                                 - call:
+                                    - api: HttpOpenRequestW
+                    """
+                )
+            ),
         ]
     )
-    # the file rule scope will have two rules:
-    #  - `test function subscope` and `test process subscope`
-    # plus the dynamic flavor of all rules
-    # assert len(rules.file_rules) == 4
+    # the file rule scope will have four rules:
+    # - `test function subscope`, `test process subscope` and
+    # `test thread subscope` for the static scope
+    # - and `test process subscope` for both scopes
+    assert len(rules.file_rules) == 3
 
     # the function rule scope have two rule:
     # - the rule on which `test function subscope` depends
@@ -504,9 +546,14 @@ def test_subscope_rules():
     # - the rule on which `test process subscope` depends,
     assert len(rules.process_rules) == 3
 
-    # the thread rule scope has one rule:
+    # the thread rule scope has two rule:
     # - the rule on which `test thread subscope` depends
-    assert len(rules.thread_rules) == 1
+    # - the `test call subscope` rule
+    assert len(rules.thread_rules) == 2
+
+    # the call rule scope has one rule:
+    # - the rule on which `test call subcsope` depends
+    assert len(rules.call_rules) == 1
 
 
 def test_duplicate_rules():


### PR DESCRIPTION
This PR is for adding the call scope.

For the time being, the call scope supports only the features: `API`, `Number`, and `String`.

Also, I have also modified the dynamic-related addresses to include a reference to each one's parent scope/address. This is in order to avoid the mixing of extracted features. For example, two api calls with the same id's, two threads with the same ids, and two processes with the same pid.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
