### PR TITLE
remove dynamic return address concept

### DIFF
--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -116,29 +116,6 @@ class DynamicCallAddress(Address):
         return (self.thread, self.id) < (other.thread, other.id)
 
 
-class DynamicReturnAddress(Address):
-    """an address from a dynamic analysis trace"""
-
-    def __init__(self, call: DynamicCallAddress, return_address: int):
-        assert return_address >= 0
-        self.call = call
-        self.return_address = return_address
-
-    def __repr__(self):
-        return f"{self.call}, dynamic-call(return-address: 0x{self.return_address:x})"
-
-    def __hash__(self):
-        return hash((self.call, self.return_address))
-
-    def __eq__(self, other):
-        assert isinstance(other, DynamicReturnAddress)
-        return (self.call, self.return_address) == (other.call, other.return_address)
-
-    def __lt__(self, other):
-        assert isinstance(other, DynamicReturnAddress)
-        return (self.call, self.return_address) < (other.call, other.return_address)
-
-
 class RelativeVirtualAddress(int, Address):
     """a memory address relative to a base address"""
 

--- a/capa/features/extractors/cape/call.py
+++ b/capa/features/extractors/cape/call.py
@@ -15,7 +15,7 @@ import capa.features.extractors.cape.global_
 import capa.features.extractors.cape.process
 from capa.features.insn import API, Number
 from capa.features.common import String, Feature
-from capa.features.address import Address, DynamicReturnAddress
+from capa.features.address import Address
 from capa.features.extractors.base_extractor import CallHandle, ThreadHandle, ProcessHandle
 
 logger = logging.getLogger(__name__)
@@ -44,14 +44,13 @@ def extract_call_features(
     calls: List[Dict[str, Any]] = process["calls"]
     call = calls[ch.address.id]
     assert call["thread_id"] == str(th.address.tid)
-    caller = DynamicReturnAddress(call=ch.address, return_address=int(call["caller"], 16))
     # list similar to disassembly: arguments right-to-left, call
     for arg in call["arguments"][::-1]:
         try:
-            yield Number(int(arg["value"], 16)), caller
+            yield Number(int(arg["value"], 16)), ch.address
         except ValueError:
-            yield String(arg["value"]), caller
-    yield API(call["api"]), caller
+            yield String(arg["value"]), ch.address
+    yield API(call["api"]), ch.address
 
 
 def extract_features(

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -56,10 +56,8 @@ def format_address(address: frz.Address) -> str:
         return f"token({capa.helpers.hex(token)})+{capa.helpers.hex(offset)}"
     elif address.type == frz.AddressType.DYNAMIC:
         assert isinstance(address.value, tuple)
-        id_, return_address = address.value
-        assert isinstance(id_, int)
-        assert isinstance(return_address, int)
-        return f"event: {id_}, retaddr: 0x{return_address:x}"
+        ppid, pid, tid, id_, return_address = address.value
+        return f"process ppid: {ppid}, process pid: {pid}, thread id: {tid}, call: {id_}, return address: {capa.helpers.hex(return_address)}"
     elif address.type == frz.AddressType.PROCESS:
         assert isinstance(address.value, tuple)
         ppid, pid = address.value

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -71,6 +71,10 @@ def format_address(address: frz.Address) -> str:
         tid = address.value
         assert isinstance(tid, int)
         return f"thread id: {tid}"
+    elif address.type == frz.AddressType.CALL:
+        assert isinstance(address.value, tuple)
+        ppid, pid, tid, id_ = address.value
+        return f"process ppid: {ppid}, process pid: {pid}, thread id: {tid}, call: {id_}"
     elif address.type == frz.AddressType.NO_ADDRESS:
         return "global"
     else:

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -273,8 +273,8 @@ def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
                             continue
 
                         if isinstance(feature, API):
-                            assert isinstance(addr, capa.features.address.DynamicReturnAddress)
-                            apis.append((addr.call.id, str(feature.value)))
+                            assert isinstance(addr, capa.features.address.DynamicCallAddress)
+                            apis.append((addr.id, str(feature.value)))
 
                         if isinstance(feature, (Number, String)):
                             arguments.append(str(feature.value))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -363,7 +363,17 @@ def get_data_path_by_name(name) -> Path:
             / "data"
             / "dynamic"
             / "cape"
+            / "v2.2"
             / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+        )
+    elif name.startswith("d46900"):
+        return (
+            CD
+            / "data"
+            / "dynamic"
+            / "cape"
+            / "v2.2"
+            / "d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz"
         )
     elif name.startswith("ea2876"):
         return CD / "data" / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -42,7 +42,6 @@ from capa.features.extractors.base_extractor import (
     BBHandle,
     CallHandle,
     InsnHandle,
-    SampleHashes,
     ThreadHandle,
     ProcessHandle,
     FunctionHandle,
@@ -652,54 +651,6 @@ def parametrize(params, values, **kwargs):
     ids = list(map(make_test_id, values))
     return pytest.mark.parametrize(params, values, ids=ids, **kwargs)
 
-
-EXTRACTOR_HASHING_TESTS = [
-    # viv extractor
-    (
-        get_viv_extractor(get_data_path_by_name("mimikatz")),
-        SampleHashes(
-            md5="5f66b82558ca92e54e77f216ef4c066c",
-            sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
-            sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
-        ),
-    ),
-    # PE extractor
-    (
-        get_pefile_extractor(get_data_path_by_name("mimikatz")),
-        SampleHashes(
-            md5="5f66b82558ca92e54e77f216ef4c066c",
-            sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
-            sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
-        ),
-    ),
-    # dnFile extractor
-    (
-        get_dnfile_extractor(get_data_path_by_name("b9f5b")),
-        SampleHashes(
-            md5="b9f5bd514485fb06da39beff051b9fdc",
-            sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
-            sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
-        ),
-    ),
-    # dotnet File
-    (
-        get_dotnetfile_extractor(get_data_path_by_name("b9f5b")),
-        SampleHashes(
-            md5="b9f5bd514485fb06da39beff051b9fdc",
-            sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
-            sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
-        ),
-    ),
-    # cape extractor
-    (
-        get_cape_extractor(get_data_path_by_name("0000a657")),
-        SampleHashes(
-            md5="e2147b5333879f98d515cd9aa905d489",
-            sha1="ad4d520fb7792b4a5701df973d6bd8a6cbfbb57f",
-            sha256="0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82",
-        ),
-    ),
-]
 
 DYNAMIC_FEATURE_PRESENCE_TESTS = sorted(
     [

--- a/tests/test_extractor_hashing.py
+++ b/tests/test_extractor_hashing.py
@@ -16,12 +16,48 @@ from capa.features.extractors.base_extractor import SampleHashes
 logger = logging.getLogger(__name__)
 
 
-@fixtures.parametrize(
-    "extractor,hashes",
-    fixtures.EXTRACTOR_HASHING_TESTS,
-)
-def test_hash_extraction(extractor, hashes):
-    assert extractor.get_sample_hashes() == hashes
+def test_viv_hash_extraction():
+    assert fixtures.get_viv_extractor(fixtures.get_data_path_by_name("mimikatz")).get_sample_hashes() == SampleHashes(
+        md5="5f66b82558ca92e54e77f216ef4c066c",
+        sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
+        sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
+    )
+
+
+def test_pefile_hash_extraction():
+    assert fixtures.get_pefile_extractor(
+        fixtures.get_data_path_by_name("mimikatz")
+    ).get_sample_hashes() == SampleHashes(
+        md5="5f66b82558ca92e54e77f216ef4c066c",
+        sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
+        sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
+    )
+
+
+def test_dnfile_hash_extraction():
+    assert fixtures.get_dnfile_extractor(fixtures.get_data_path_by_name("b9f5b")).get_sample_hashes() == SampleHashes(
+        md5="b9f5bd514485fb06da39beff051b9fdc",
+        sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
+        sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
+    )
+
+
+def test_dotnetfile_hash_extraction():
+    assert fixtures.get_dotnetfile_extractor(
+        fixtures.get_data_path_by_name("b9f5b")
+    ).get_sample_hashes() == SampleHashes(
+        md5="b9f5bd514485fb06da39beff051b9fdc",
+        sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
+        sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
+    )
+
+
+def test_cape_hash_extraction():
+    assert fixtures.get_cape_extractor(fixtures.get_data_path_by_name("0000a657")).get_sample_hashes() == SampleHashes(
+        md5="e2147b5333879f98d515cd9aa905d489",
+        sha1="ad4d520fb7792b4a5701df973d6bd8a6cbfbb57f",
+        sha256="0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82",
+    )
 
 
 # We need to skip the binja test if we cannot import binaryninja, e.g., in GitHub CI.


### PR DESCRIPTION
please review and merge #1709 first

remove the return address concept, since it wasn't really used by any scripts or capa analysis. this reduces the amount of code to maintain.

i think the intent was to potentially assist analysts that encounter an interesting API call in mapping that back to the input binary. we can do this by recording more details, including return address, about API calls in the "layout", and then referencing this during rendering. 



### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
