### PR TITLE
properly set bounds for find_byte_sequence

### DIFF
--- a/capa/features/extractors/ghidra/helpers.py
+++ b/capa/features/extractors/ghidra/helpers.py
@@ -8,6 +8,7 @@
 from typing import Dict, List, Iterator
 
 import ghidra
+import java.lang
 from ghidra.program.model.lang import OperandType
 from ghidra.program.model.block import BasicBlockModel, SimpleBlockIterator
 from ghidra.program.model.symbol import SourceType, SymbolType
@@ -36,7 +37,7 @@ def find_byte_sequence(seq: bytes) -> Iterator[int]:
     """
     seqstr = "".join([f"\\x{b:02x}" for b in seq])
     # .add(1) to avoid false positives on regular PE files
-    eas = findBytes(currentProgram().getMinAddress().add(1), seqstr, 1, 1)  # type: ignore [name-defined] # noqa: F821
+    eas = findBytes(currentProgram().getMinAddress().add(1), seqstr, java.lang.Integer.MAX_VALUE, 1)  # type: ignore [name-defined] # noqa: F821
     yield from eas
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [X] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed

# Fix 1756: Ghidra: find_byte_sequence incorrectly bounded
Fixes #1756 
