### PR TITLE
rules: use Scope enum instead of constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+- remove the `SCOPE_*` constants in favor of the `Scope` enum #1764 @williballenthin
+
 ### New Rules (0)
 
 -

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -500,13 +500,13 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                 location = location_.to_capa()
 
                 parent2: CapaExplorerDataItem
-                if capa.rules.FILE_SCOPE in rule.meta.scopes:
+                if capa.rules.Scope.FILE in rule.meta.scopes:
                     parent2 = parent
-                elif capa.rules.FUNCTION_SCOPE in rule.meta.scopes:
+                elif capa.rules.Scope.FUNCTION in rule.meta.scopes:
                     parent2 = CapaExplorerFunctionItem(parent, location)
-                elif capa.rules.BASIC_BLOCK_SCOPE in rule.meta.scopes:
+                elif capa.rules.Scope.BASIC_BLOCK in rule.meta.scopes:
                     parent2 = CapaExplorerBlockItem(parent, location)
-                elif capa.rules.INSTRUCTION_SCOPE in rule.meta.scopes:
+                elif capa.rules.Scope.INSTRUCTION in rule.meta.scopes:
                     parent2 = CapaExplorerInstructionItem(parent, location)
                 else:
                     raise RuntimeError("unexpected rule scope: " + str(rule.meta.scopes.static))

--- a/capa/main.py
+++ b/capa/main.py
@@ -1056,7 +1056,7 @@ def compute_dynamic_layout(rules, extractor: DynamicFeatureExtractor, capabiliti
     matched_threads = set()
     for rule_name, matches in capabilities.items():
         rule = rules[rule_name]
-        if capa.rules.THREAD_SCOPE in rule.scopes:
+        if capa.rules.Scope.THREAD in rule.scopes:
             for addr, _ in matches:
                 assert addr in processes_by_thread
                 matched_threads.add(addr)
@@ -1099,7 +1099,7 @@ def compute_static_layout(rules, extractor: StaticFeatureExtractor, capabilities
     matched_bbs = set()
     for rule_name, matches in capabilities.items():
         rule = rules[rule_name]
-        if capa.rules.BASIC_BLOCK_SCOPE in rule.scopes:
+        if capa.rules.Scope.BASIC_BLOCK in rule.scopes:
             for addr, _ in matches:
                 assert addr in functions_by_bb
                 matched_bbs.add(addr)

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -214,7 +214,7 @@ def render_rules(ostream, doc: rd.ResultDocument):
 
             rows.append((key, v))
 
-        if capa.rules.FILE_SCOPE not in rule.meta.scopes:
+        if capa.rules.Scope.FILE not in rule.meta.scopes:
             locations = [m[0] for m in doc.rules[rule.meta.name].matches]
             rows.append(("matches", "\n".join(map(format_address, locations))))
 

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -357,7 +357,7 @@ def render_rules(ostream, doc: rd.ResultDocument):
 
         ostream.writeln(tabulate.tabulate(rows, tablefmt="plain"))
 
-        if capa.rules.FILE_SCOPE in rule.meta.scopes:
+        if capa.rules.Scope.FILE in rule.meta.scopes:
             matches = doc.rules[rule.meta.name].matches
             if len(matches) != 1:
                 # i think there should only ever be one match per file-scope rule,
@@ -379,13 +379,13 @@ def render_rules(ostream, doc: rd.ResultDocument):
                 ostream.write(" @ ")
                 ostream.write(capa.render.verbose.format_address(location))
 
-                if capa.rules.BASIC_BLOCK_SCOPE in rule.meta.scopes:
+                if capa.rules.Scope.BASIC_BLOCK in rule.meta.scopes:
                     ostream.write(
                         " in function "
                         + capa.render.verbose.format_address(frz.Address.from_capa(functions_by_bb[location.to_capa()]))
                     )
 
-                if capa.rules.THREAD_SCOPE in rule.meta.scopes:
+                if capa.rules.Scope.THREAD in rule.meta.scopes:
                     ostream.write(
                         " in process "
                         + capa.render.verbose.format_address(

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -164,7 +164,10 @@ class Scopes:
         if scopes_["dynamic"] and scopes_["dynamic"] not in DYNAMIC_SCOPES:
             raise InvalidRule(f"{scopes_['dynamic']} is not a valid dynamic scope")
 
-        return Scopes(static=Scope(scopes_["static"]), dynamic=Scope(scopes_["dynamic"]))
+        return Scopes(
+            static=Scope(scopes_["static"]) if scopes_["static"] else None,
+            dynamic=Scope(scopes_["dynamic"]) if scopes_["dynamic"] else None,
+        )
 
 
 SUPPORTED_FEATURES: Dict[str, Set] = {

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -115,10 +115,10 @@ def render_matches_by_function(doc: rd.ResultDocument):
 
     matches_by_function = collections.defaultdict(set)
     for rule in rutils.capability_rules(doc):
-        if capa.rules.FUNCTION_SCOPE in rule.meta.scopes:
+        if capa.rules.Scope.FUNCTION in rule.meta.scopes:
             for addr, _ in rule.matches:
                 matches_by_function[addr].add(rule.meta.name)
-        elif capa.rules.BASIC_BLOCK_SCOPE in rule.meta.scopes:
+        elif capa.rules.Scope.BASIC_BLOCK in rule.meta.scopes:
             for addr, _ in rule.matches:
                 function = functions_by_bb[addr]
                 matches_by_function[function].add(rule.meta.name)

--- a/tests/_test_proto.py
+++ b/tests/_test_proto.py
@@ -116,10 +116,10 @@ def test_addr_to_pb2():
 
 
 def test_scope_to_pb2():
-    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.FILE_SCOPE)) == capa_pb2.SCOPE_FILE
-    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.FUNCTION_SCOPE)) == capa_pb2.SCOPE_FUNCTION
-    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.BASIC_BLOCK_SCOPE)) == capa_pb2.SCOPE_BASIC_BLOCK
-    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.INSTRUCTION_SCOPE)) == capa_pb2.SCOPE_INSTRUCTION
+    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.Scope.FILE)) == capa_pb2.SCOPE_FILE
+    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.Scope.FUNCTION)) == capa_pb2.SCOPE_FUNCTION
+    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.Scope.BASIC_BLOCK)) == capa_pb2.SCOPE_BASIC_BLOCK
+    assert capa.render.proto.scope_to_pb2(capa.rules.Scope(capa.rules.Scope.INSTRUCTION)) == capa_pb2.SCOPE_INSTRUCTION
 
 
 def cmp_optional(a: Any, b: Any) -> bool:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -40,7 +40,7 @@ ADDR4 = capa.features.address.AbsoluteVirtualAddress(0x401004)
 
 def test_rule_ctor():
     r = capa.rules.Rule(
-        "test rule", capa.rules.Scopes(capa.rules.FUNCTION_SCOPE, capa.rules.FILE_SCOPE), Or([Number(1)]), {}
+        "test rule", capa.rules.Scopes(capa.rules.Scope.FUNCTION, capa.rules.Scope.FILE), Or([Number(1)]), {}
     )
     assert bool(r.evaluate({Number(0): {ADDR1}})) is False
     assert bool(r.evaluate({Number(1): {ADDR2}})) is True


### PR DESCRIPTION
this PR updates code across capa to prefer to use `Scope.FOO` instead of `FOO_SCOPE`. before, we had two ways of doing things. now we have one. preferring to use the enum is better because it lets type checkers reason about the set of values, rather than arbitrary strings.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
