### PR TITLE
update freeze for dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - remove the `SCOPE_*` constants in favor of the `Scope` enum #1764 @williballenthin
 - protobuf: deprecate `RuleMetadata.scope` in favor of `RuleMetadata.scopes` @williballenthin
 - protobuf: deprecate `Metadata.analysis` in favor of `Metadata.analysis2` that is dynamic analysis aware @williballenthin
+- update freeze format to v3, adding support for dynamic analysis @williballenthin
 
 ### New Rules (19)
 

--- a/capa/features/extractors/null.py
+++ b/capa/features/extractors/null.py
@@ -136,26 +136,26 @@ class NullDynamicFeatureExtractor(DynamicFeatureExtractor):
             assert isinstance(address, ProcessAddress)
             yield ProcessHandle(address=address, inner={})
 
-    def extract_process_features(self, p):
-        for addr, feature in self.processes[p.address].features:
+    def extract_process_features(self, ph):
+        for addr, feature in self.processes[ph.address].features:
             yield feature, addr
 
-    def get_threads(self, p):
-        for address in sorted(self.processes[p].threads.keys()):
+    def get_threads(self, ph):
+        for address in sorted(self.processes[ph.address].threads.keys()):
             assert isinstance(address, ThreadAddress)
             yield ThreadHandle(address=address, inner={})
 
-    def extract_thread_features(self, p, t):
-        for addr, feature in self.processes[p.address].threads[t.address].features:
+    def extract_thread_features(self, ph, th):
+        for addr, feature in self.processes[ph.address].threads[th.address].features:
             yield feature, addr
 
-    def get_calls(self, p, t):
-        for address in sorted(self.processes[p.address].threads[t.address].calls.keys()):
+    def get_calls(self, ph, th):
+        for address in sorted(self.processes[ph.address].threads[th.address].calls.keys()):
             assert isinstance(address, DynamicCallAddress)
             yield CallHandle(address=address, inner={})
 
-    def extract_call_features(self, p, t, call):
-        for address, feature in self.processes[p.address].threads[t.address].calls[call.address].features:
+    def extract_call_features(self, ph, th, ch):
+        for address, feature in self.processes[ph.address].threads[th.address].calls[ch.address].features:
             yield feature, address
 
 

--- a/tests/test_freeze_dynamic.py
+++ b/tests/test_freeze_dynamic.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2023 Mandiant, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: [package root]/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import textwrap
+from typing import List
+from pathlib import Path
+
+import fixtures
+
+import capa.main
+import capa.rules
+import capa.helpers
+import capa.features.file
+import capa.features.insn
+import capa.features.common
+import capa.features.freeze
+import capa.features.basicblock
+import capa.features.extractors.null
+import capa.features.extractors.base_extractor
+from capa.features.address import Address, AbsoluteVirtualAddress
+from capa.features.extractors.base_extractor import (
+    SampleHashes,
+    ThreadHandle,
+    ProcessHandle,
+    ThreadAddress,
+    ProcessAddress,
+    DynamicCallAddress,
+    DynamicFeatureExtractor,
+)
+
+EXTRACTOR = capa.features.extractors.null.NullDynamicFeatureExtractor(
+    base_address=AbsoluteVirtualAddress(0x401000),
+    sample_hashes=SampleHashes(
+        md5="6eb7ee7babf913d75df3f86c229df9e7",
+        sha1="2a082494519acd5130d5120fa48786df7275fdd7",
+        sha256="0c7d1a34eb9fd55bedbf37ba16e3d5dd8c1dd1d002479cc4af27ef0f82bb4792",
+    ),
+    global_features=[],
+    file_features=[
+        (AbsoluteVirtualAddress(0x402345), capa.features.common.Characteristic("embedded pe")),
+    ],
+    processes={
+        ProcessAddress(pid=1): capa.features.extractors.null.ProcessFeatures(
+            features=[],
+            threads={
+                ThreadAddress(ProcessAddress(pid=1), tid=1): capa.features.extractors.null.ThreadFeatures(
+                    features=[],
+                    calls={
+                        DynamicCallAddress(
+                            thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=1
+                        ): capa.features.extractors.null.CallFeatures(
+                            features=[
+                                (
+                                    DynamicCallAddress(thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=1),
+                                    capa.features.insn.API("CreateFile"),
+                                ),
+                                (
+                                    DynamicCallAddress(thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=1),
+                                    capa.features.insn.Number(12),
+                                ),
+                            ],
+                        ),
+                        DynamicCallAddress(
+                            thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=2
+                        ): capa.features.extractors.null.CallFeatures(
+                            features=[
+                                (
+                                    DynamicCallAddress(thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=2),
+                                    capa.features.insn.API("WriteFile"),
+                                ),
+                            ],
+                        ),
+                    },
+                ),
+            },
+        ),
+    },
+)
+
+
+def addresses(s) -> List[Address]:
+    return sorted(i.address for i in s)
+
+
+def test_null_feature_extractor():
+    ph = ProcessHandle(ProcessAddress(pid=1), None)
+    th = ThreadHandle(ThreadAddress(ProcessAddress(pid=1), tid=1), None)
+
+    assert addresses(EXTRACTOR.get_processes()) == [ProcessAddress(pid=1)]
+    assert addresses(EXTRACTOR.get_threads(ph)) == [ThreadAddress(ProcessAddress(pid=1), tid=1)]
+    assert addresses(EXTRACTOR.get_calls(ph, th)) == [
+        DynamicCallAddress(thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=1),
+        DynamicCallAddress(thread=ThreadAddress(ProcessAddress(pid=1), tid=1), id=2),
+    ]
+
+    rules = capa.rules.RuleSet(
+        [
+            capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    """
+                    rule:
+                        meta:
+                            name: create file
+                            scopes:
+                                static: basic block
+                                dynamic: call
+                        features:
+                            - and:
+                                - api: CreateFile
+                    """
+                )
+            ),
+        ]
+    )
+    capabilities, _ = capa.main.find_capabilities(rules, EXTRACTOR)
+    assert "create file" in capabilities
+
+
+def compare_extractors(a: DynamicFeatureExtractor, b: DynamicFeatureExtractor):
+    assert list(a.extract_file_features()) == list(b.extract_file_features())
+
+    assert addresses(a.get_processes()) == addresses(b.get_processes())
+    for p in a.get_processes():
+        assert addresses(a.get_threads(p)) == addresses(b.get_threads(p))
+        assert sorted(set(a.extract_process_features(p))) == sorted(set(b.extract_process_features(p)))
+
+        for t in a.get_threads(p):
+            assert addresses(a.get_calls(p, t)) == addresses(b.get_calls(p, t))
+            assert sorted(set(a.extract_thread_features(p, t))) == sorted(set(b.extract_thread_features(p, t)))
+
+            for c in a.get_calls(p, t):
+                assert sorted(set(a.extract_call_features(p, t, c))) == sorted(set(b.extract_call_features(p, t, c)))
+
+
+def test_freeze_str_roundtrip():
+    load = capa.features.freeze.loads
+    dump = capa.features.freeze.dumps
+    reanimated = load(dump(EXTRACTOR))
+    compare_extractors(EXTRACTOR, reanimated)
+
+
+def test_freeze_bytes_roundtrip():
+    load = capa.features.freeze.load
+    dump = capa.features.freeze.dump
+    reanimated = load(dump(EXTRACTOR))
+    compare_extractors(EXTRACTOR, reanimated)
+
+
+def test_freeze_load_sample(tmpdir):
+    o = tmpdir.mkdir("capa").join("test.frz")
+
+    extractor = fixtures.get_cape_extractor(fixtures.get_data_path_by_name("d46900"))
+
+    Path(o.strpath).write_bytes(capa.features.freeze.dump(extractor))
+
+    null_extractor = capa.features.freeze.load(Path(o.strpath).read_bytes())
+
+    compare_extractors(extractor, null_extractor)


### PR DESCRIPTION
This PR updates the freeze implementation that supports dynamic analysis. The primary change is to keep the file format  similar as possible to v1 and v2: the magic header, compression, and json format remain the same; the version is bumped to 3; and the json document must contain a key "flavor" that specifies static/dynamic.

The upside is that the code/format remains more similar to before (though, I'm not sure anyone actually uses this format or cares about its compatibility). A downside is that there's an additional json decoding pass used to extract version/flavor, but I dont think this should be too expensive.

Added tests that demonstrate the new format works as expected (and fixed a couple bugs).

ref #1697 

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
