### PR TITLE
Refactor error handling and logging in '''get_extractor''' - main.py

### DIFF
--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import contextlib
 import importlib.util
+import functools
 from typing import NoReturn
 from pathlib import Path
 
@@ -126,33 +127,42 @@ def redirecting_print_to_tqdm(disable_progress):
         inspect.builtins.print = old_print  # type: ignore
 
 
-def log_unsupported_format_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to be a PE or ELF file.")
-    logger.error(" ")
-    logger.error(
-        " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64)."
-    )
-    logger.error(" If you don't know the input file type, you can try using the `file` utility to guess it.")
-    logger.error("-" * 80)
+def catch_log_return_errors(func):
+    error_list, return_values, message_list = [(UnsupportedFormatError, E_INVALID_FILE_TYPE, 
+                                           (" Input file does not appear to be a PE or ELF file.",
+                                            " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64).",
+                                            " If you don't know the input file type, you can try using the `file` utility to guess it.")),
+                                           
+                             (UnsupportedArchError, E_INVALID_FILE_ARCH, 
+                              (" Input file does not appear to target a supported architecture.",
+                             " capa currently only supports analyzing x86 (32- and 64-bit).")),
+                                           
+                             (UnsupportedOSError, E_INVALID_FILE_OS, 
+                              (" Input file does not appear to target a supported OS.",
+                             " capa currently only supports analyzing executables for some operating systems (including Windows and Linux)."))]
 
+    @functools.wraps(func)
+    def logging_wrapper(exception):
+        assert(exception in error_list)
+        error_messages = message_list[error_list.index(exception)]
+        error_return_value = return_values[error_list.index(exception)]
 
-def log_unsupported_os_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to target a supported OS.")
-    logger.error(" ")
-    logger.error(
-        " capa currently only supports analyzing executables for some operating systems (including Windows and Linux)."
-    )
-    logger.error("-" * 80)
+        logger.error("-" * 80)
+        logger.error(f"{error_messages[0]}")
+        logger.error(" ")
 
+        for i in error_messages[1:]:
+            logger.error(i)
 
-def log_unsupported_arch_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to target a supported architecture.")
-    logger.error(" ")
-    logger.error(" capa currently only supports analyzing x86 (32- and 64-bit).")
-    logger.error("-" * 80)
+        logger.error("-" * 80)
+
+        return error_return_value
+
+    if type(func(*args, **kwargs)) = ValueError:
+        return logging_wrapper(func(*args, **kwargs))
+    
+    else:
+        return func(*args, **kwargs)
 
 
 def log_unsupported_runtime_error():

--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -127,9 +127,19 @@ def redirecting_print_to_tqdm(disable_progress):
         inspect.builtins.print = old_print  # type: ignore
 
 
+def log_unsupported_format_error():
+    logger.error("-" * 80)
+    logger.error(" Input file does not appear to be a PE or ELF file.")
+    logger.error(" ")
+    logger.error(
+        " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64)."
+    )
+    logger.error(" If you don't know the input file type, you can try using the `file` utility to guess it.")
+    logger.error("-" * 80)
+
+
 def catch_log_return_errors(func):
     error_list, return_values, message_list = \
-    
                             [(UnsupportedFormatError, E_INVALID_FILE_TYPE, 
                             (" Input file does not appear to be a PE or ELF file.",
                             " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64).",

--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -128,10 +128,12 @@ def redirecting_print_to_tqdm(disable_progress):
 
 
 def catch_log_return_errors(func):
-    error_list, return_values, message_list = [(UnsupportedFormatError, E_INVALID_FILE_TYPE, 
-                                           (" Input file does not appear to be a PE or ELF file.",
-                                            " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64).",
-                                            " If you don't know the input file type, you can try using the `file` utility to guess it.")),
+    error_list, return_values, message_list = \
+    
+                            [(UnsupportedFormatError, E_INVALID_FILE_TYPE, 
+                            (" Input file does not appear to be a PE or ELF file.",
+                            " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64).",
+                            " If you don't know the input file type, you can try using the `file` utility to guess it.")),
                                            
                              (UnsupportedArchError, E_INVALID_FILE_ARCH, 
                               (" Input file does not appear to target a supported architecture.",

--- a/capa/main.py
+++ b/capa/main.py
@@ -57,9 +57,8 @@ from capa.helpers import (
     get_format,
     get_file_taste,
     get_auto_format,
-    log_unsupported_os_error,
     redirecting_print_to_tqdm,
-    log_unsupported_arch_error,
+    catch_log_return_errors,
     log_unsupported_format_error,
 )
 from capa.exceptions import UnsupportedOSError, UnsupportedArchError, UnsupportedFormatError, UnsupportedRuntimeError

--- a/capa/main.py
+++ b/capa/main.py
@@ -517,6 +517,7 @@ def get_workspace(path: Path, format_: str, sigpaths: List[Path]):
     return vw
 
 
+@catch_log_return_errors
 def get_extractor(
     path: Path,
     format_: str,
@@ -1257,25 +1258,16 @@ def main(argv: Optional[List[str]] = None):
 
             should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
 
-            try:
-                extractor = get_extractor(
-                    args.sample,
-                    format_,
-                    args.os,
-                    args.backend,
-                    sig_paths,
-                    should_save_workspace,
-                    disable_progress=args.quiet or args.debug,
-                )
-            except UnsupportedFormatError:
-                log_unsupported_format_error()
-                return E_INVALID_FILE_TYPE
-            except UnsupportedArchError:
-                log_unsupported_arch_error()
-                return E_INVALID_FILE_ARCH
-            except UnsupportedOSError:
-                log_unsupported_os_error()
-                return E_INVALID_FILE_OS
+            # Error checking and logging is performed in the get_extractor call
+            extractor = get_extractor(
+                args.sample,
+                format_,
+                args.os,
+                args.backend,
+                sig_paths,
+                should_save_workspace,
+                disable_progress=args.quiet or args.debug,
+            )
 
         meta = collect_metadata(argv, args.sample, args.format, args.os, args.rules, extractor)
 


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed


This PR is to hide the '''get_extractor''' error handling and logging in a decorator. This makes the main function a bit cleaner and reduces the boilerplate code used to log errors.