### PR TITLE
Wrapper for get_extractor error handling and logging

### DIFF
--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -126,33 +126,28 @@ def redirecting_print_to_tqdm(disable_progress):
         inspect.builtins.print = old_print  # type: ignore
 
 
-def log_unsupported_format_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to be a PE or ELF file.")
-    logger.error(" ")
-    logger.error(
-        " capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64)."
-    )
-    logger.error(" If you don't know the input file type, you can try using the `file` utility to guess it.")
-    logger.error("-" * 80)
+def raise_log_unsupported_error(e):
+    if e = UnsupportedFormatError:
+        logger.error("-" * 80)
+        logger.error(" Input file does not appear to be a PE or ELF file.")
+        logger.error(" ")
+        logger.error(" capa currently only supports analyzing PE and ELF files (or shellcode, when using --format sc32|sc64).")
+        logger.error(" If you don't know the input file type, you can try using the `file` utility to guess it.")
+        return E_INVALID_FILE_TYPE
+        
+    if e = UnsupportedArchError:
+        logger.error("-" * 80)
+        logger.error(" Input file does not appear to target a supported architecture.")
+        logger.error(" ")
+        logger.error(" capa currently only supports analyzing x86 (32- and 64-bit).")
+        return E_INVALID_FILE_ARCH
 
-
-def log_unsupported_os_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to target a supported OS.")
-    logger.error(" ")
-    logger.error(
-        " capa currently only supports analyzing executables for some operating systems (including Windows and Linux)."
-    )
-    logger.error("-" * 80)
-
-
-def log_unsupported_arch_error():
-    logger.error("-" * 80)
-    logger.error(" Input file does not appear to target a supported architecture.")
-    logger.error(" ")
-    logger.error(" capa currently only supports analyzing x86 (32- and 64-bit).")
-    logger.error("-" * 80)
+    if e = UnsupportedOSError:
+        logger.error("-" * 80)
+        logger.error(" Input file does not appear to target a supported OS.")
+        logger.error(" ")
+        logger.error(" capa currently only supports analyzing executables for some operating systems (including Windows and Linux).")
+        return E_INVALID_FILE_OS
 
 
 def log_unsupported_runtime_error():


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed

Apologies for cluttering up your PRs. Here is an implementation of a an error logging wrapper for get_extractor. I have tried to cut down some of the logging code. @williballenthin if you would prefer not to alter this part of the code, no worries! I will work on making sure the code passes the tests in the meantime :)