### PR TITLE
fix pydantic vuln (ReDoS)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pyelftools==0.30",
     "dnfile==0.14.1",
     "dncil==1.0.2",
-    "pydantic==2.1.1",
+    "pydantic==2.4.0",
     "protobuf==4.23.4",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Regular Expression Denial of Service (ReDoS)
MEDIUM SEVERITY
Package Manager: pip
Vulnerable module: pydantic
Remediation
Upgrade pydantic to version 1.10.13, 2.4.0 or higher.


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
