### PR TITLE
fix: do not trim api names that include ::

### DIFF
--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -602,7 +602,9 @@ def trim_dll_part(api: str) -> str:
 
     # kernel32.CreateFileA
     if api.count(".") == 1:
-        api = api.split(".")[1]
+        if "::" not in api:
+            # skip System.Convert::FromBase64String
+            api = api.split(".")[1]
     return api
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -949,6 +949,7 @@ def test_count_api():
             features:
                 - or:
                     - count(api(kernel32.CreateFileA)): 1
+                    - count(api(System.Convert::FromBase64String)): 1
         """
     )
     r = capa.rules.Rule.from_yaml(rule)
@@ -957,6 +958,7 @@ def test_count_api():
     assert bool(r.evaluate({API("kernel32.CreateFile"): set()})) is False
     assert bool(r.evaluate({API("CreateFile"): {ADDR1}})) is False
     assert bool(r.evaluate({API("CreateFileA"): {ADDR1}})) is True
+    assert bool(r.evaluate({API("System.Convert::FromBase64String"): {ADDR1}})) is True
 
 
 def test_invalid_number():


### PR DESCRIPTION
capa v7 ignores the DLL portion of API features. Unfortunately the logic that implements this created a subtle bug that breaks matching for `.NET` `api` features e.g. `System.Convert::FromBase64String`. This PR updates the `trim_dll_part` function to fix the bug. 


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [X] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
