### PR TITLE
Output IP addresses, domain names, file manipulations, and (potentially) registry details

### DIFF
--- a/capa/capabilities/common.py
+++ b/capa/capabilities/common.py
@@ -6,15 +6,26 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import re
 import logging
 import itertools
 import collections
-from typing import Any, Tuple
+from typing import Any, List, Tuple, Iterator, Optional
 
+import capa.features.extractors.cape.file as cape_file
 from capa.rules import Scope, RuleSet
 from capa.engine import FeatureSet, MatchResults
 from capa.features.address import NO_ADDRESS
-from capa.features.extractors.base_extractor import FeatureExtractor, StaticFeatureExtractor, DynamicFeatureExtractor
+from capa.features.extractors.cape.models import Call, CapeReport
+from capa.features.extractors.base_extractor import (
+    CallHandle,
+    ThreadHandle,
+    ProcessHandle,
+    FeatureExtractor,
+    StaticFeatureExtractor,
+    DynamicFeatureExtractor,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -77,3 +88,83 @@ def find_capabilities(
         return find_dynamic_capabilities(ruleset, extractor, disable_progress=disable_progress, **kwargs)
 
     raise ValueError(f"unexpected extractor type: {extractor.__class__.__name__}")
+
+
+def extract_ip_addresses(strings: List[str]) -> Iterator[str]:
+    """ yield (IPv4 and IPv6) IP address regex matches from list of strings """
+    # Both the IPv4 and IPv6 regex patterns are discussed here:
+    # (https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses)
+    ipv4_pattern = r"""
+    ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|
+    (2[0-4]|1{0,1}[0-9]){0,1}[0-9])
+    """
+
+    ipv6_pattern = r"""
+    (
+    ([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|
+    ([0-9a-fA-F]{1,4}:){1,7}:|
+    ([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|
+    ([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|
+    ([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|
+    ([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|
+    ([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|
+    [0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|
+    :((:[0-9a-fA-F]{1,4}){1,7}|:)|
+    fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|
+    ::(ffff(:0{1,4}){0,1}:){0,1}
+    ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
+    (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|
+    ([0-9a-fA-F]{1,4}:){1,4}:
+    ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
+    (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])
+    )
+    """
+
+    for string in strings:
+        if re.search(ipv4_pattern, string):
+            yield string
+
+        if re.search(ipv6_pattern, string):
+            yield string
+
+
+def extract_domain_names(strings: List[str]) -> Iterator[str]:
+    """ yield web domain regex matches from list of strings """
+    # See this Stackoverflow post that discusses the parts of this regex (http://stackoverflow.com/a/7933253/433790)
+    domain_pattern = r"^(?!.{256})(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}|xn--[a-z0-9]{1,59})$"
+    for string in strings:
+        if re.search(domain_pattern, string):
+            yield string
+
+
+def extract_file_names(
+    process_handles: Iterator[ProcessHandle],
+    thread_handles: Iterator[ThreadHandle],
+    call_handles: Iterator[CallHandle],
+    report: Optional[CapeReport],
+):
+    """
+    extracts Windows API file maniuplation functions that processes import
+    yields: 1) API name, and 2) file that it iteracts with
+
+    'default.render_file_names' checks whether 'report' is None before calling 'extract_file_name'
+
+    yield:
+      ch.api (str): the API that interacts with the filename
+      call.arguments[0].name (str): a filename, which is a parameter of some WinAPI file interaction functions
+    """
+    # Extract many Windows API functions that take a filename as an argument
+    winapi_file_functions = []
+    for feature, _ in cape_file.extract_import_names(report):
+        assert type(feature.value) == "str"  # feature.value type annotation is: 'value: Union[str, int, float, bytes]'
+        if feature.value.str.contains("File"):
+            winapi_file_functions.append(feature[0])
+
+    for ph in process_handles:
+        for th in thread_handles:
+            for ch in call_handles:
+                call: Call = ch.inner
+                if call.api in winapi_file_functions:
+                    # winapi_file_functions functions take filename as their first variable
+                    # therefore, we yield the filename with call.arguments[0].name
+                    yield call.api, call.arguments[0].name

--- a/capa/capabilities/common.py
+++ b/capa/capabilities/common.py
@@ -157,7 +157,7 @@ def extract_file_names(
     winapi_file_functions = []
     for feature, _ in cape_file.extract_import_names(report):
         assert type(feature.value) == "str"  # feature.value type annotation is: 'value: Union[str, int, float, bytes]'
-        if feature.value.str.contains("File"):
+        if feature.value.str.contains("File"):  # a lot of Windows API file interaction function names contain "File"
             winapi_file_functions.append(feature[0])
 
     for ph in process_handles:
@@ -165,6 +165,8 @@ def extract_file_names(
             for ch in call_handles:
                 call: Call = ch.inner
                 if call.api in winapi_file_functions:
-                    # winapi_file_functions functions take filename as their first variable
-                    # therefore, we yield the filename with call.arguments[0].name
-                    yield call.api, call.arguments[0].name
+                    # winapi_file_functions functions take file name as their first variable
+                    # since calling conventions commonly store function parameters on the stack in reverse order,
+                    # we yield the file name with call.arguments[-1].name
+                    # although should we use call.arguments[0].name to get file names for different calling conventions?
+                    yield call.api, call.arguments[-1].name

--- a/capa/ghidra/capa_ghidra.py
+++ b/capa/ghidra/capa_ghidra.py
@@ -74,6 +74,10 @@ def run_headless():
     meta = capa.ghidra.helpers.collect_metadata([rules_path])
     extractor = capa.features.extractors.ghidra.extractor.GhidraFeatureExtractor()
 
+    strings = None
+    sandbox_data = None
+    report = None
+    
     capabilities, counts = capa.capabilities.common.find_capabilities(rules, extractor, False)
 
     meta.analysis.feature_counts = counts["feature_counts"]
@@ -84,13 +88,13 @@ def run_headless():
         logger.info("capa encountered warnings during analysis")
 
     if args.json:
-        print(capa.render.json.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.json.render(meta, rules, capabilities, strings, sandbox_data))  # noqa: T201
     elif args.vverbose:
-        print(capa.render.vverbose.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.vverbose.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
     elif args.verbose:
-        print(capa.render.verbose.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.verbose.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
     else:
-        print(capa.render.default.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.default.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
 
     return 0
 
@@ -124,6 +128,10 @@ def run_ui():
     meta = capa.ghidra.helpers.collect_metadata([rules_path])
     extractor = capa.features.extractors.ghidra.extractor.GhidraFeatureExtractor()
 
+    strings = None
+    sandbox_data = None
+    report = None
+    
     capabilities, counts = capa.capabilities.common.find_capabilities(rules, extractor, True)
 
     meta.analysis.feature_counts = counts["feature_counts"]
@@ -134,11 +142,11 @@ def run_ui():
         logger.info("capa encountered warnings during analysis")
 
     if verbose == "vverbose":
-        print(capa.render.vverbose.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.vverbose.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
     elif verbose == "verbose":
-        print(capa.render.verbose.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.verbose.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
     else:
-        print(capa.render.default.render(meta, rules, capabilities))  # noqa: T201
+        print(capa.render.default.render(meta, rules, capabilities, strings, sandbox_data, report))  # noqa: T201
 
     return 0
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -823,9 +823,16 @@ class CapaExplorerForm(idaapi.PluginForm):
 
                 update_wait_box("collecting results")
 
+                strings = None
+                sandbox_data = None
+
                 try:
                     self.resdoc_cache = capa.render.result_document.ResultDocument.from_capa(
-                        meta, ruleset, capabilities
+                        meta,
+                        ruleset,
+                        capabilities,
+                        strings,
+                        sandbox_data,
                     )
                 except Exception as e:
                     logger.exception("Failed to collect results (error: %s)", e)

--- a/capa/render/json.py
+++ b/capa/render/json.py
@@ -5,10 +5,21 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+from typing import List, Tuple, Iterator, Optional
+
 import capa.render.result_document as rd
 from capa.rules import RuleSet
 from capa.engine import MatchResults
+from capa.features.extractors.base_extractor import CallHandle, ThreadHandle, ProcessHandle
 
 
-def render(meta, rules: RuleSet, capabilities: MatchResults) -> str:
-    return rd.ResultDocument.from_capa(meta, rules, capabilities).model_dump_json(exclude_none=True)
+def render(
+    meta,
+    rules: RuleSet,
+    capabilities: MatchResults,
+    strings: Optional[List[str]],
+    sandbox_data: Optional[Tuple[Iterator[ProcessHandle], Iterator[ThreadHandle], Iterator[CallHandle]]],
+) -> str:
+    return rd.ResultDocument.from_capa(meta, rules, capabilities, strings, sandbox_data).model_dump_json(
+        exclude_none=True
+    )

--- a/scripts/bulk-process.py
+++ b/scripts/bulk-process.py
@@ -69,6 +69,7 @@ import logging
 import argparse
 import multiprocessing
 import multiprocessing.pool
+from typing import Tuple, Iterator, Optional
 from pathlib import Path
 
 import capa
@@ -78,6 +79,8 @@ import capa.render.json
 import capa.capabilities.common
 import capa.render.result_document as rd
 from capa.features.common import OS_AUTO
+from capa.features.extractors.cape.models import CapeReport
+from capa.features.extractors.base_extractor import CallHandle, ThreadHandle, ProcessHandle
 
 logger = logging.getLogger("capa")
 
@@ -142,7 +145,17 @@ def get_capa_results(args):
     meta = capa.main.collect_metadata([], path, format, os_, [], extractor, counts)
     meta.analysis.layout = capa.main.compute_layout(rules, extractor, capabilities)
 
-    doc = rd.ResultDocument.from_capa(meta, rules, capabilities)
+    sandbox_data = Optional[Tuple[Iterator[ProcessHandle], Iterator[ThreadHandle], Iterator[CallHandle]]
+    # report = Optional[CapeReport]
+    Path(__file__).resolve().parent.parent
+    report = json.load(Path(args.sample).open(encoding="utf-8"))
+
+    try:
+        strings = report.static.pe.imports
+    except AttributeError:
+        strings = None
+
+    doc = rd.ResultDocument.from_capa(meta, rules, capabilities, strings, sandbox_data)
     return {"path": path, "status": "ok", "ok": doc.model_dump()}
 
 

--- a/scripts/capa_as_library.py
+++ b/scripts/capa_as_library.py
@@ -183,18 +183,22 @@ def capa_details(rules_path: Path, file_path: Path, output_format="dictionary"):
     meta.analysis.layout = capa.main.compute_layout(rules, extractor, capabilities)
 
     capa_output: Any = False
+    
+    strings = None
+    sandbox_data = None
+    report = None
 
     if output_format == "dictionary":
         # ...as python dictionary, simplified as textable but in dictionary
-        doc = rd.ResultDocument.from_capa(meta, rules, capabilities)
+        doc = rd.ResultDocument.from_capa(meta, rules, capabilities, strings, sandbox_data)
         capa_output = render_dictionary(doc)
     elif output_format == "json":
         # render results
         # ...as json
-        capa_output = json.loads(capa.render.json.render(meta, rules, capabilities))
+        capa_output = json.loads(capa.render.json.render(meta, rules, capabilities, strings, sandbox_data))
     elif output_format == "texttable":
         # ...as human readable text table
-        capa_output = capa.render.default.render(meta, rules, capabilities)
+        capa_output = capa.render.default.render(meta, rules, capabilities, strings, sandbox_data, report)
 
     return capa_output
 


### PR DESCRIPTION
This PR addresses issue #1907. It extracts IP addresses, domain names, and file manipulations from CAPE sandbox traces and outputs them. It may eventually extract and present registry details as well. It uses a regex to identify IPv4 and IPv6 addresses. It uses another regex to identify web domains and potential subdomains.

The extraction and rendering functions require tests (still a work in progress). This PR may require changelog and documentation updates.

Most of the significant features are in common.py and default.py - changes in the other files are to make the main additions compatible. I have gotten it to pass most of the tests locally. I'm still working on a few issues and need to improve the tests (especially the rendering tests). What do you think of the general design? Do you have any questions or suggestions?

The output would look like this:
        +-----------------+
        |   Domain Names  |
        |------------------+
        | google.com         |
        | web.domain.net |
        | mywebsite.edu   |
        +-----------------+
        +-----------------+
        |    IP Addresses    |
        |-----------------  |
        |       10.0.0.1           |
        |     192.1.23.45      |
        +-----------------+
        +------------------------+------------------------+
        |        APIs               |      File Names                              |
        |------------------------+-------------------------|
        |        CreateFile      |          /path/to/file.txt                   |
        |        WriteFile         |           /path/to/other_file.txt      |
        +------------------------+------------------------+
The ResultDocument class seems to be the staging ground for outputting results. I have added a couple attributes that I use for presenting IPs and domains, and might be useful if capa outputs further dynamic analysis results in the future. The default, verbose, and vverbose modes all output the same results right now, but the verbose and vverbose modes can probably be expanded.

Also, @mr-tz can you please tell me a bit more about what type of registry key/value analysis you think would be useful? I was thinking about listing: what keys are created, modified, and deleted; whether any of these registry keys are run when the computer starts up; whether functions like RegSetKeySecurity are called, which can grant malware increased privileges; and the registry keys that all of these actions relate to. But I don't want to add too many details for a simple default output - it might be good to add additional details in verbose and vverbose mode. What do you think of these things?

EDIT: I actually think it would be better to refactor the new features out of "common.py" into their own file(s), and also their rendering functions into files like "render_ip_addresses.py", "render_domains.py", "render_file_names.py", etc. Default, verbose, and vverbose rendering functions could be included in each of these files. I am going to work on this, and also work on making sure the suggested changes pass the CI tests.