### PR TITLE
ELF: Detect OS from Go binaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,16 @@ repos:
 
 -   repo: local
     hooks:
+    -   id: deptry
+        name: deptry
+        stages: [push, manual]
+        language: system
+        entry: deptry .
+        always_run: true
+        pass_filenames: false
+
+-   repo: local
+    hooks:
     -   id: pytest-fast
         name: pytest (fast)
         stages: [manual]
@@ -128,12 +138,3 @@ repos:
         always_run: true
         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: deptry
-        name: deptry
-        stages: [push, manual]
-        language: system
-        entry: deptry .
-        always_run: true
-        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### New Features
+- ELF: detect OS from statically-linked Go binaries #1978 @williballenthin
 
 
 ### Breaking Changes

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -966,6 +966,15 @@ def is_go_binary(elf: ELF) -> bool:
             logger.debug("go buildinfo: found section .note.go.buildid")
             return True
 
+    # The `go version` command enumerates sections for the name `.go.buildinfo`
+    # (in addition to looking for the BUILDINFO_MAGIC) to check if an executable is go or not. 
+    # See references to the `errNotGoExe` error here: 
+    # https://github.com/golang/go/blob/master/src/debug/buildinfo/buildinfo.go#L41
+    for shdr in elf.section_headers:
+        if shdr.get_name(elf) == ".go.buildinfo":
+            logger.debug("go buildinfo: found section .go.buildinfo")
+            return True
+
     # other strategy used by FLOSS: search for known runtime strings.
     # https://github.com/mandiant/flare-floss/blob/b2ca8adfc5edf278861dd6bff67d73da39683b46/floss/language/identify.py#L88
     return False

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -870,6 +870,8 @@ def guess_os_from_ident_directive(elf: ELF) -> Optional[OS]:
             return OS.LINUX
         elif "Red Hat" in comment:
             return OS.LINUX
+        elif "Alpine" in comment:
+            return OS.LINUX
         elif "Android" in comment:
             return OS.ANDROID
 

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -1416,6 +1416,7 @@ def detect_elf_os(f) -> str:
         logger.warning("Error guessing OS from symbol table: %s", e)
         symtab_guess = None
 
+<<<<<<< Updated upstream
     try:
         goos_guess = guess_os_from_go_buildinfo(elf)
         logger.debug("guess: Go buildinfo: %s", goos_guess)
@@ -1430,6 +1431,16 @@ def detect_elf_os(f) -> str:
         logger.warning("Error guessing OS from Go source path: %s", e)
         gosrc_guess = None
 
+||||||| Stash base
+=======
+    try:
+        vdso_guess = guess_os_from_vdso_strings(elf)
+        logger.debug("guess: vdso strings: %s", vdso_guess)
+    except Exception as e:
+        logger.warning("Error guessing OS from vdso strings: %s", e)
+        symtab_guess = None
+
+>>>>>>> Stashed changes
     ret = None
 
     if osabi_guess:
@@ -1465,6 +1476,11 @@ def detect_elf_os(f) -> str:
         # at the bottom because we don't trust this too much
         # due to potential for bugs with cross-compilation.
         ret = ident_guess
+
+    elif vdso_guess:
+        # at the bottom because this is just scanning strings,
+        # which isn't very authoritative.
+        ret = vdso_guess
 
     return ret.value if ret is not None else "unknown"
 

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -965,6 +965,9 @@ def is_go_binary(elf: ELF) -> bool:
         if shdr.get_name(elf) == ".note.go.buildid":
             logger.debug("go buildinfo: found section .note.go.buildid")
             return True
+
+    # other strategy used by FLOSS: search for known runtime strings.
+    # https://github.com/mandiant/flare-floss/blob/b2ca8adfc5edf278861dd6bff67d73da39683b46/floss/language/identify.py#L88
     return False
 
 

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -967,8 +967,8 @@ def is_go_binary(elf: ELF) -> bool:
             return True
 
     # The `go version` command enumerates sections for the name `.go.buildinfo`
-    # (in addition to looking for the BUILDINFO_MAGIC) to check if an executable is go or not. 
-    # See references to the `errNotGoExe` error here: 
+    # (in addition to looking for the BUILDINFO_MAGIC) to check if an executable is go or not.
+    # See references to the `errNotGoExe` error here:
     # https://github.com/golang/go/blob/master/src/debug/buildinfo/buildinfo.go#L41
     for shdr in elf.section_headers:
         if shdr.get_name(elf) == ".go.buildinfo":

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -1098,10 +1098,12 @@ def guess_os_from_go_buildinfo(elf: ELF) -> Optional[OS]:
     }
 
     if has_inline_strings:
-        # common path
+        # This is the common case/path. Most samples will have an inline GOOS string.
         #
-        # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 04 02}
-        # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 08 02}
+        # To find samples on VT, use these VTGrep searches:
+        #
+        #   content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 04 02}
+        #   content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 08 02}
 
         # If present, the GOOS key will be found within
         # the current buildinfo data region.
@@ -1113,23 +1115,24 @@ def guess_os_from_go_buildinfo(elf: ELF) -> Optional[OS]:
                 logger.debug("go buildinfo: found os: %s", os)
                 return os
     else:
-        # uncommon path
-
+        # This is the uncommon path. Most samples will have an inline GOOS string.
+        #
+        # To find samples on VT, use the referenced VTGrep content searches.
         info_format = {
             # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 04 00}
             # like: 71e617e5cc7fda89bf67422ff60f437e9d54622382c5ed6ff31f75e601f9b22e
-            # modinfo doesn't have GOOS
+            # in which the modinfo doesn't have GOOS.
             (4, False): "<II",
             # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 08 00}
             # like: 93d3b3e2a904c6c909e20f2f76c3c2e8d0c81d535eb46e5493b5701f461816c3
-            # modinfo doesn't have GOOS
+            # in which the modinfo doesn't have GOOS.
             (8, False): "<QQ",
             # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 04 01}
-            # no matches
+            # (no matches on VT today)
             (4, True): ">II",
             # content: {ff 20 47 6f 20 62 75 69 6c 64 69 6e 66 3a 08 01}
             # like: d44ba497964050c0e3dd2a192c511e4c3c4f17717f0322a554d64b797ee4690a
-            # modinfo doesn't have GOOS
+            # in which the modinfo doesn't have GOOS.
             (8, True): ">QQ",
         }
 

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -957,6 +957,7 @@ def guess_os_from_symtab(elf: ELF) -> Optional[OS]:
 
         for os, hints in keywords.items():
             if any(hint in sym_name for hint in hints):
+                logger.debug("symtab: %s looks like %s", sym_name, os)
                 return os
 
     return None

--- a/capa/features/extractors/elf.py
+++ b/capa/features/extractors/elf.py
@@ -1163,7 +1163,7 @@ def guess_os_from_go_buildinfo(elf: ELF) -> Optional[OS]:
                 logger.debug("go buildinfo: found os: %s", os)
                 return os
 
-        return None
+    return None
 
 
 def guess_os_from_go_source(elf: ELF) -> Optional[OS]:

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -158,6 +158,8 @@ def get_workspace(path: Path, input_format: str, sigpaths: List[Path]):
 
     viv_utils.flirt.register_flirt_signature_analyzers(vw, [str(s) for s in sigpaths])
 
+    vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")
+
     vw.analyze()
 
     logger.debug("%s", get_meta_str(vw))

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -162,7 +162,7 @@ def get_workspace(path: Path, input_format: str, sigpaths: List[Path]):
         # Remove the symbolic switch case solver.
         # This is only enabled for ELF files, not PE files.
         # During the following performance investigation, this analysis module
-        # had some terrible worst-case behavior. 
+        # had some terrible worst-case behavior.
         # We can put up with slightly worse CFG reconstruction in order to avoid this.
         # https://github.com/mandiant/capa/issues/1989#issuecomment-1948022767
         vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -154,7 +154,12 @@ def get_workspace(path: Path, input_format: str, sigpaths: List[Path]):
 
     viv_utils.flirt.register_flirt_signature_analyzers(vw, [str(s) for s in sigpaths])
 
-    vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")
+    try:
+        vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")
+    except Exception:
+        # unfortuately viv raises a raw Exception (not any subclass).
+        # This happens when the module isn't found, such as with a viv upgrade.
+        pass
 
     vw.analyze()
 

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -8,6 +8,7 @@
 import sys
 import logging
 import datetime
+import contextlib
 from typing import Set, Dict, List, Optional
 from pathlib import Path
 
@@ -154,12 +155,17 @@ def get_workspace(path: Path, input_format: str, sigpaths: List[Path]):
 
     viv_utils.flirt.register_flirt_signature_analyzers(vw, [str(s) for s in sigpaths])
 
-    try:
-        vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")
-    except Exception:
+    with contextlib.suppress(Exception):
         # unfortuately viv raises a raw Exception (not any subclass).
         # This happens when the module isn't found, such as with a viv upgrade.
-        pass
+        #
+        # Remove the symbolic switch case solver.
+        # This is only enabled for ELF files, not PE files.
+        # During the following performance investigation, this analysis module
+        # had some terrible worst-case behavior. 
+        # We can put up with slightly worse CFG reconstruction in order to avoid this.
+        # https://github.com/mandiant/capa/issues/1989#issuecomment-1948022767
+        vw.delFuncAnalysisModule("vivisect.analysis.generic.symswitchcase")
 
     vw.analyze()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ dev = [
     "isort==5.13.2",
     "mypy==1.10.0",
     "mypy-protobuf==3.6.0",
+    "PyGithub==2.3.0",
     # type stubs for mypy
     "types-backports==0.1.3",
     "types-colorama==0.4.15.11",
@@ -215,6 +216,7 @@ DEP002 = [
     "mypy",
     "mypy-protobuf",
     "pre-commit",
+    "PyGithub",
     "pyinstaller",
     "pytest",
     "pytest-cov",
@@ -237,6 +239,9 @@ DEP002 = [
 DEP003 = [
     "typing_extensions" # TODO(s-ff): remove when Python 3.9 is deprecated, see #1699
 ]
+
+[tool.deptry.package_module_name_map]
+PyGithub = "github"
 
 [project.urls]
 Homepage = "https://github.com/mandiant/capa"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -389,6 +389,8 @@ def get_data_path_by_name(name) -> Path:
         return CD / "data" / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
     elif name.startswith("1038a2"):
         return CD / "data" / "1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_"
+    elif name.startswith("3da7c"):
+        return CD / "data" / "3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_"
     elif name.startswith("nested_typedef"):
         return CD / "data" / "dotnet" / "dd9098ff91717f4906afe9dafdfa2f52.exe_"
     elif name.startswith("nested_typeref"):

--- a/tests/test_os_detection.py
+++ b/tests/test_os_detection.py
@@ -92,6 +92,12 @@ def test_elf_android_notes():
         assert capa.features.extractors.elf.detect_elf_os(f) == "android"
 
 
+def test_elf_go_buildinfo():
+    path = get_data_path_by_name("3da7c")
+    with Path(path).open("rb") as f:
+        assert capa.features.extractors.elf.detect_elf_os(f) == "linux"
+
+
 def test_elf_parse_capa_pyinstaller_header():
     # error after misidentified large pydata section with address 0; fixed in #1454
     # compressed ELF header of capa-v5.1.0-linux


### PR DESCRIPTION
use the strategies pioneered by GoReSym to detect the target OS for ELF binaries compiled by Go:
  - find the GOOS configuration, and
  - find embedded Go source filenames

closes #1978
FYI @C0d3R3ad3r
FYI @stevemk14ebr

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
