### PR TITLE
Load .json.gz files directly

### DIFF
--- a/capa/helpers.py
+++ b/capa/helpers.py
@@ -71,7 +71,11 @@ def assert_never(value) -> NoReturn:
 
 
 def get_format_from_report(sample: Path) -> str:
-    report = json.load(sample.open(encoding="utf-8"))
+    import gzip
+
+    with gzip.open(sample, "r") as compressed_report:
+        report_json = compressed_report.read()
+        report = json.loads(report_json)
 
     if "CAPE" in report:
         return FORMAT_CAPE


### PR DESCRIPTION
closes #1883

For loading .json.gz files directly, used the code from tests:
> https://github.com/mandiant/capa/blob/0f9dd9095b04c844fd3b1923ec8eb6241e7252b5/tests/fixtures.py#L193

This is my first contribution and I'm sorry if I did something wrong

### Checklist

- [ ] No CHANGELOG update needed
- [ ] No new tests needed
- [ ] No documentation update needed
