### PR TITLE
 ida-explorer: replace deprecated IDA API find_binary with bin_search #1606

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 
 ### capa explorer IDA Pro plugin
+- replace deprecated IDA API find_binary with bin_search  #1606 @s-ff
 
 ### Development
 

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -13,6 +13,7 @@ import idaapi
 import idautils
 import ida_bytes
 import ida_segment
+import ida_nalt
 
 from capa.features.address import AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import FunctionHandle
@@ -26,15 +27,19 @@ def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
         end: max virtual address
         seq: bytes to search e.g. b"\x01\x03"
     """
+    patterns = ida_bytes.compiled_binpat_vec_t()
+    encoding = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B)
+
     seqstr = " ".join([f"{b:02x}" for b in seq])
-    while True:
-        # TODO(mike-hunhoff): find_binary is deprecated. Please use ida_bytes.bin_search() instead.
-        # https://github.com/mandiant/capa/issues/1606
-        ea = idaapi.find_binary(start, end, seqstr, 0, idaapi.SEARCH_DOWN)
-        if ea == idaapi.BADADDR:
-            break
-        start = ea + 1
-        yield ea
+    err = ida_bytes.parse_binpat_str(patterns, 0, seqstr, 16, encoding)
+
+    if not err:
+		while True:
+			ea  = ida_bytes.bin_search(start, end, patterns, ida_bytes.BIN_SEARCH_FORWARD)
+			if ea == idaapi.BADADDR:
+				break
+			start = ea + 1
+			yield ea
 
 
 def get_functions(


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
This change closes #1606 by replacing the deprecated IDA API `find_binary` with `bin_search`.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
