### PR TITLE
ida-explorer: replace deprecated IDA API find_binary with bin_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 
 ### capa explorer IDA Pro plugin
+- replace deprecated IDA API find_binary with bin_search #1606 @s-ff
 
 ### Development
 

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -18,6 +18,8 @@ import ida_segment
 from capa.features.address import AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import FunctionHandle
 
+IDA_BYTES_PATTERNS = ida_bytes.compiled_binpat_vec_t()
+IDA_NALT_ENCODING  = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B) # use one byte-per-character encoding
 
 def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
     """yield all ea of a given byte sequence
@@ -27,11 +29,9 @@ def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
         end: max virtual address
         seq: bytes to search e.g. b"\x01\x03"
     """
-    patterns = ida_bytes.compiled_binpat_vec_t()
-    encoding = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B)
 
     seqstr = " ".join([f"{b:02x}" for b in seq])
-    err = ida_bytes.parse_binpat_str(patterns, 0, seqstr, 16, encoding)
+    err = ida_bytes.parse_binpat_str(IDA_BYTES_PATTERNS, 0, seqstr, 16, IDA_NALT_ENCODING)
 
     if err:
         return

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -33,13 +33,15 @@ def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
     seqstr = " ".join([f"{b:02x}" for b in seq])
     err = ida_bytes.parse_binpat_str(patterns, 0, seqstr, 16, encoding)
 
-    if not err:
-        while True:
-            ea = ida_bytes.bin_search(start, end, patterns, ida_bytes.BIN_SEARCH_FORWARD)
-            if ea == idaapi.BADADDR:
-                break
-            start = ea + 1
-            yield ea
+    if err:
+        return
+
+    while True:
+        ea = ida_bytes.bin_search(start, end, patterns, ida_bytes.BIN_SEARCH_FORWARD)
+        if ea == idaapi.BADADDR:
+            break
+        start = ea + 1
+        yield ea
 
 
 def get_functions(

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -18,7 +18,6 @@ import ida_segment
 from capa.features.address import AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import FunctionHandle
 
-IDA_BYTES_PATTERNS = ida_bytes.compiled_binpat_vec_t()
 IDA_NALT_ENCODING = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B)  # use one byte-per-character encoding
 
 
@@ -30,15 +29,16 @@ def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
         end: max virtual address
         seq: bytes to search e.g. b"\x01\x03"
     """
+    patterns = ida_bytes.compiled_binpat_vec_t()
 
     seqstr = " ".join([f"{b:02x}" for b in seq])
-    err = ida_bytes.parse_binpat_str(IDA_BYTES_PATTERNS, 0, seqstr, 16, IDA_NALT_ENCODING)
+    err = ida_bytes.parse_binpat_str(patterns, 0, seqstr, 16, IDA_NALT_ENCODING)
 
     if err:
         return
 
     while True:
-        ea = ida_bytes.bin_search(start, end, IDA_BYTES_PATTERNS, ida_bytes.BIN_SEARCH_FORWARD)
+        ea = ida_bytes.bin_search(start, end, patterns, ida_bytes.BIN_SEARCH_FORWARD)
         if ea == idaapi.BADADDR:
             break
         start = ea + 1

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -19,7 +19,7 @@ from capa.features.address import AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import FunctionHandle
 
 IDA_BYTES_PATTERNS = ida_bytes.compiled_binpat_vec_t()
-IDA_NALT_ENCODING  = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B) # use one byte-per-character encoding
+IDA_NALT_ENCODING = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B)  # use one byte-per-character encoding
 
 def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
     """yield all ea of a given byte sequence
@@ -37,7 +37,7 @@ def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
         return
 
     while True:
-        ea = ida_bytes.bin_search(start, end, patterns, ida_bytes.BIN_SEARCH_FORWARD)
+        ea = ida_bytes.bin_search(start, end, IDA_BYTES_PATTERNS, ida_bytes.BIN_SEARCH_FORWARD)
         if ea == idaapi.BADADDR:
             break
         start = ea + 1

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -10,10 +10,10 @@ from typing import Any, Dict, Tuple, Iterator, Optional
 
 import idc
 import idaapi
+import ida_nalt
 import idautils
 import ida_bytes
 import ida_segment
-import ida_nalt
 
 from capa.features.address import AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import FunctionHandle

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -21,6 +21,7 @@ from capa.features.extractors.base_extractor import FunctionHandle
 IDA_BYTES_PATTERNS = ida_bytes.compiled_binpat_vec_t()
 IDA_NALT_ENCODING = ida_nalt.get_default_encoding_idx(ida_nalt.BPU_1B)  # use one byte-per-character encoding
 
+
 def find_byte_sequence(start: int, end: int, seq: bytes) -> Iterator[int]:
     """yield all ea of a given byte sequence
 


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
This change closes #1606 by replacing the deprecated IDA API `find_binary` with `bin_search`.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
