### PR TITLE
Handles circular dependencies while getting rules and dependencies

### DIFF
--- a/capa/ida/plugin/view.py
+++ b/capa/ida/plugin/view.py
@@ -196,7 +196,7 @@ class CapaExplorerRulegenPreview(QtWidgets.QTextEdit):
             f"      - {author}",
             "    scopes:",
             f"      static: {scope}",
-            "      dynamic: unspecified",
+            "      dynamic: unsupported",
             "    references:",
             "      - <insert_references>",
             "    examples:",

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1221,13 +1221,17 @@ def get_rules_and_dependencies(rules: List[Rule], rule_name: str) -> Iterator[Ru
     namespaces = index_rules_by_namespace(rules)
     rules_by_name = {rule.name: rule for rule in rules}
     wanted = {rule_name}
+    visited = set()
 
     def rec(rule: Rule):
+        wanted.add(rule.name)
+        visited.add(rule.name)
+
         for dep in rule.get_dependencies(namespaces):
-            if dep in wanted:
-                raise InvalidRule(f'rule "{rule.name}" has circular dependency')
-            wanted.add(dep)
+            if dep in visited:
+                raise InvalidRule(f'rule "{dep}" has a circular dependency')
             rec(rules_by_name[dep])
+        visited.remove(rule.name)
 
     rec(rules_by_name[rule_name])
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1223,10 +1223,10 @@ def get_rules_and_dependencies(rules: List[Rule], rule_name: str) -> Iterator[Ru
     wanted = {rule_name}
 
     def rec(rule: Rule):
-        wanted.add(rule.name)
         for dep in rule.get_dependencies(namespaces):
             if dep in wanted:
-                continue
+                raise InvalidRule(f'rule "{rule.name}" has circular dependency')
+            wanted.add(dep)
             rec(rules_by_name[dep])
 
     rec(rules_by_name[rule_name])

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -166,9 +166,7 @@ class MissingScopes(Lint):
 
 class MissingStaticScope(Lint):
     name = "missing static scope"
-    recommendation = (
-        "Add a static scope for the rule (file, function, basic block, instruction, or unspecified/unsupported)"
-    )
+    recommendation = "Add a static scope for the rule (file, function, basic block, instruction, or unsupported)"
 
     def check_rule(self, ctx: Context, rule: Rule):
         return "static" not in rule.meta.get("scopes")
@@ -176,7 +174,7 @@ class MissingStaticScope(Lint):
 
 class MissingDynamicScope(Lint):
     name = "missing dynamic scope"
-    recommendation = "Add a dynamic scope for the rule (file, process, thread, call, or unspecified/unsupported)"
+    recommendation = "Add a dynamic scope for the rule (file, process, thread, call, or unsupported)"
 
     def check_rule(self, ctx: Context, rule: Rule):
         return "dynamic" not in rule.meta.get("scopes")
@@ -184,9 +182,7 @@ class MissingDynamicScope(Lint):
 
 class InvalidStaticScope(Lint):
     name = "invalid static scope"
-    recommendation = (
-        "For the static scope, use either: file, function, basic block, instruction, or unspecified/unsupported"
-    )
+    recommendation = "For the static scope, use either: file, function, basic block, instruction, or unsupported"
 
     def check_rule(self, ctx: Context, rule: Rule):
         return rule.meta.get("scopes").get("static") not in (
@@ -194,14 +190,13 @@ class InvalidStaticScope(Lint):
             "function",
             "basic block",
             "instruction",
-            "unspecified",
             "unsupported",
         )
 
 
 class InvalidDynamicScope(Lint):
     name = "invalid static scope"
-    recommendation = "For the dynamic scope, use either: file, process, thread, call, or unspecified/unsupported"
+    recommendation = "For the dynamic scope, use either: file, process, thread, call, or unsupported"
 
     def check_rule(self, ctx: Context, rule: Rule):
         return rule.meta.get("scopes").get("dynamic") not in (
@@ -209,7 +204,6 @@ class InvalidDynamicScope(Lint):
             "process",
             "thread",
             "call",
-            "unspecified",
             "unsupported",
         )
 
@@ -219,8 +213,8 @@ class InvalidScopes(Lint):
     recommendation = "At least one scope (static or dynamic) must be specified"
 
     def check_rule(self, ctx: Context, rule: Rule):
-        return (rule.meta.get("scopes").get("static") in ("unspecified", "unsupported")) and (
-            rule.meta.get("scopes").get("dynamic") in ("unspecified", "unsupported")
+        return (rule.meta.get("scopes").get("static") == "unsupported") and (
+            rule.meta.get("scopes").get("dynamic") == "unsupported"
         )
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -475,40 +475,6 @@ def test_meta_scope_keywords():
             )
         )
 
-    # its also ok to specify "unspecified"
-    for static_scope in static_scopes:
-        _ = capa.rules.Rule.from_yaml(
-            textwrap.dedent(
-                f"""
-                rule:
-                    meta:
-                        name: test rule
-                        scopes:
-                            static: {static_scope}
-                            dynamic: unspecified
-                    features:
-                        - or:
-                            - format: pe
-                """
-            )
-        )
-    for dynamic_scope in dynamic_scopes:
-        _ = capa.rules.Rule.from_yaml(
-            textwrap.dedent(
-                f"""
-                rule:
-                    meta:
-                        name: test rule
-                        scopes:
-                            static: unspecified
-                            dynamic: {dynamic_scope}
-                    features:
-                        - or:
-                            - format: pe
-                """
-            )
-        )
-
     # but at least one scope must be specified
     with pytest.raises(capa.rules.InvalidRule):
         _ = capa.rules.Rule.from_yaml(
@@ -534,22 +500,6 @@ def test_meta_scope_keywords():
                         scopes:
                             static: unsupported
                             dynamic: unsupported
-                    features:
-                        - or:
-                            - format: pe
-                """
-            )
-        )
-    with pytest.raises(capa.rules.InvalidRule):
-        _ = capa.rules.Rule.from_yaml(
-            textwrap.dedent(
-                """
-                rule:
-                    meta:
-                        name: test rule
-                        scopes:
-                            static: unspecified
-                            dynamic: unspecified
                     features:
                         - or:
                             - format: pe

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1577,3 +1577,42 @@ def test_invalid_com_features():
                 """
             )
         )
+
+
+def test_circular_dependency():
+    rules = [
+        capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule 1
+                        scopes:
+                            static: function
+                            dynamic: process
+                        lib: true
+                    features:
+                    - or:
+                        - match: test rule 2
+                        - api: kernel32.VirtualAlloc
+                """
+            )
+        ),
+        capa.rules.Rule.from_yaml(
+            textwrap.dedent(
+                """
+                rule:
+                    meta:
+                        name: test rule 2
+                        scopes:
+                            static: function
+                            dynamic: process
+                        lib: true
+                    features:
+                        - match: test rule 1
+                """
+            )
+        ),
+    ]
+    with pytest.raises(capa.rules.InvalidRule):
+        list(capa.rules.get_rules_and_dependencies(rules, rules[0].name))


### PR DESCRIPTION
closes #1747 
handles circular dependencies in `filter_rules_by_meta` and `get_rules_and_dependencies`

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
