### PR TITLE
Restrict signature debug logging to vivisect backend

### DIFF
--- a/capa/main.py
+++ b/capa/main.py
@@ -338,8 +338,9 @@ def handle_common_args(args):
       - rules: file system path to rule files.
       - signatures: file system path to signature files.
 
-    the following field may be added:
+    the following fields may be added:
       - is_default_rules: if the default rules were used.
+      - is_default_signatures: if the default signatures were used.
 
     args:
       args: The parsed command line arguments from `install_common_args`.
@@ -432,25 +433,11 @@ def handle_common_args(args):
 
     if hasattr(args, "signatures"):
         if args.signatures == SIGNATURES_PATH_DEFAULT_STRING:
-            logger.debug("-" * 80)
-            logger.debug(" Using default embedded signatures.")
-            logger.debug(
-                " To provide your own signatures, use the form `capa.exe --signature ./path/to/signatures/  /path/to/mal.exe`."
-            )
-            logger.debug("-" * 80)
-
             sigs_path = get_default_root() / "sigs"
-
-            if not sigs_path.exists():
-                logger.error(
-                    "Using default signature path, but it doesn't exist. "  # noqa: G003 [logging statement uses +]
-                    + "Please install the signatures first: "
-                    + "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
-                )
-                raise IOError(f"signatures path {sigs_path} does not exist or cannot be accessed")
+            args.is_default_signatures = True
         else:
             sigs_path = Path(args.signatures)
-            logger.debug("using signatures path: %s", sigs_path)
+            args.is_default_signatures = False
 
         args.signatures = sigs_path
 
@@ -700,6 +687,24 @@ def get_signatures_from_cli(args, input_format: str, backend: str) -> List[Path]
     if input_format != FORMAT_PE:
         logger.debug("skipping library code matching: signatures only supports PE files")
         return []
+
+    if args.is_default_signatures:
+        logger.debug("-" * 80)
+        logger.debug(" Using default embedded signatures.")
+        logger.debug(
+            " To provide your own signatures, use the form `capa.exe --signature ./path/to/signatures/  /path/to/mal.exe`."
+        )
+        logger.debug("-" * 80)
+
+        if not args.signatures.exists():
+            logger.error(
+                "Using default signature path, but it doesn't exist. "  # noqa: G003 [logging statement uses +]
+                + "Please install the signatures first: "
+                + "https://github.com/mandiant/capa/blob/master/doc/installation.md#method-2-using-capa-as-a-python-library."
+            )
+            raise IOError(f"signatures path {args.signatures} does not exist or cannot be accessed")
+    else:
+        logger.debug("using signatures path: %s", args.signatures)
 
     try:
         return capa.loader.get_signatures(args.signatures)


### PR DESCRIPTION
I noticed that signatures will only load when the backend is vivisect:
https://github.com/mandiant/capa/blob/7debc54dbd90372af8f4e3b1819fe632afdaa3fa/capa/main.py#L695-L698

I moved the debug logging from `handle_common_args` to `get_signatures_from_cli`, so it's only printed when the signatures are actually used. This means that other backends don't need the default signatures directory to exist.

Closes #1875

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
