### PR TITLE
Fixed infinite loop when parsing dotnet TypeRef table

### DIFF
--- a/capa/features/extractors/dnfile/helpers.py
+++ b/capa/features/extractors/dnfile/helpers.py
@@ -370,6 +370,7 @@ def resolve_nested_typeref_name(
     # If the ResolutionScope decodes to a typeRef type then it is nested
     if isinstance(typeref.ResolutionScope.table, dnfile.mdtable.TypeRef):
         typeref_name = []
+        typeref_tb = []
         name = typeref.TypeName
         # Not appending the current typeref name to avoid potential duplicate
 
@@ -380,10 +381,11 @@ def resolve_nested_typeref_name(
 
         while isinstance(table_row.ResolutionScope.table, dnfile.mdtable.TypeRef):
             # Iterate through the typeref table to resolve the nested name
+            typeref_tb.append(table_row)
             typeref_name.append(name)
             name = table_row.TypeName
             table_row = get_dotnet_table_row(pe, dnfile.mdtable.TypeRef.number, table_row.ResolutionScope.row_index)
-            if table_row is None:
+            if table_row is None or table_row in typeref_tb:
                 return typeref.TypeNamespace, tuple(typeref_name[::-1])
 
         # Document the root enclosing details


### PR DESCRIPTION
There was a `TypeRef` table infinite loop issue when dotnet parser parsing a crafted dotnet sample with ref index refer to each other:

![problematic-dotnet](https://github.com/mandiant/capa/assets/4924242/7c68d84f-c76b-4c7b-a5ca-6c52b3c3925e)
 
Let me know if you need the sample for testing, I could upload it here.

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
