### PR TITLE
Fix BinExport's "tight loop" feature extraction.

### DIFF
--- a/capa/features/extractors/binexport2/basicblock.py
+++ b/capa/features/extractors/binexport2/basicblock.py
@@ -22,7 +22,8 @@ def extract_bb_tight_loop(fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[F
     idx = fhi.ctx.idx
 
     basic_block_index = bbi.basic_block_index
-    if basic_block_index in idx.target_edges_by_basic_block_index[basic_block_index]:
+    target_edges = idx.target_edges_by_basic_block_index[basic_block_index]
+    if basic_block_index in (e.target_basic_block_index for e in target_edges):
         basic_block_address = idx.basic_block_address_by_index[basic_block_index]
         yield Characteristic("tight loop"), AbsoluteVirtualAddress(basic_block_address)
 


### PR DESCRIPTION
`idx.target_edges_by_basic_block_index[basic_block_index]` is of type `List[Edges]`. The index `basic_block_index` was definitely not an element.


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
