### PR TITLE
Update pydantic to 2.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pyelftools==0.31",
     "dnfile==0.14.1",
     "dncil==1.0.2",
-    "pydantic==2.4.0",
+    "pydantic==2.7.1",
     "protobuf==4.23.4",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
I think any pydantic major updates were disabled in https://github.com/mandiant/capa/pull/1673, so hopefully this enables them again.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
