### PR TITLE
capabilities: only log "real" matched rules, not derived count

### DIFF
--- a/capa/capabilities/static.py
+++ b/capa/capabilities/static.py
@@ -182,9 +182,16 @@ def find_static_capabilities(
                 )
                 t1 = time.time()
 
-                match_count = sum(len(res) for res in function_matches.values())
-                match_count += sum(len(res) for res in bb_matches.values())
-                match_count += sum(len(res) for res in insn_matches.values())
+                match_count = 0
+                for name, matches in itertools.chain(
+                    function_matches.items(), bb_matches.items(), insn_matches.items()
+                ):
+                    # in practice, most matches are derived rules,
+                    # like "check OS version/5bf4c7f39fd4492cbed0f6dc7d596d49"
+                    # but when we log to the human, they really care about "real" rules.
+                    if not ruleset.rules[name].is_subscope_rule():
+                        match_count += len(matches)
+
                 logger.debug(
                     "analyzed function 0x%x and extracted %d features, %d matches in %0.02fs",
                     f.address,

--- a/capa/capabilities/static.py
+++ b/capa/capabilities/static.py
@@ -183,14 +183,14 @@ def find_static_capabilities(
                 t1 = time.time()
 
                 match_count = 0
-                for name, matches in itertools.chain(
+                for name, matches_ in itertools.chain(
                     function_matches.items(), bb_matches.items(), insn_matches.items()
                 ):
                     # in practice, most matches are derived rules,
                     # like "check OS version/5bf4c7f39fd4492cbed0f6dc7d596d49"
                     # but when we log to the human, they really care about "real" rules.
                     if not ruleset.rules[name].is_subscope_rule():
-                        match_count += len(matches)
+                        match_count += len(matches_)
 
                 logger.debug(
                     "analyzed function 0x%x and extracted %d features, %d matches in %0.02fs",
@@ -220,7 +220,7 @@ def find_static_capabilities(
     all_file_matches, feature_count = find_file_capabilities(ruleset, extractor, function_and_lower_features)
     feature_counts.file = feature_count
 
-    matches = dict(
+    matches: MatchResults = dict(
         itertools.chain(
             # each rule exists in exactly one scope,
             # so there won't be any overlap among these following MatchResults,


### PR DESCRIPTION
When emitting log message, show the number of "real" rule matches, ignoring any of the derived subscope rule matches, which account for most matches.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
