### PR TITLE
profile-time: more result reporting, and learn to specify other backends

### DIFF
--- a/scripts/profile-time.py
+++ b/scripts/profile-time.py
@@ -10,7 +10,7 @@ Invoke capa multiple times and record profiling informations.
 Use the --number and --repeat options to change the number of iterations.
 By default, the script will emit a markdown table with a label pulled from git.
 
-Note: you can run this script against pre-generated .frz files to reduce the startup time.
+This script requires the additional dependency `humanize`.
 
 usage:
 
@@ -43,6 +43,7 @@ import argparse
 import subprocess
 
 import tqdm
+import humanize
 import tabulate
 
 import capa.main
@@ -74,7 +75,7 @@ def main(argv=None):
         label += " (dirty)"
 
     parser = argparse.ArgumentParser(description="Profile capa performance")
-    capa.main.install_common_args(parser, wanted={"format", "os", "input_file", "signatures", "rules"})
+    capa.main.install_common_args(parser, wanted={"format", "backend", "os", "input_file", "signatures", "rules"})
     parser.add_argument("--number", type=int, default=3, help="batch size of profile collection")
     parser.add_argument("--repeat", type=int, default=30, help="batch count of profile collection")
     parser.add_argument("--label", type=str, default=label, help="description of the profile collection")
@@ -106,6 +107,18 @@ def main(argv=None):
 
     for counter, count in capa.perf.counters.most_common():
         logger.debug("perf: counter: %s: %s", counter, count)
+
+    print(
+        tabulate.tabulate(
+            [
+                (counter, humanize.intcomma(count))
+                for counter, count in capa.perf.counters.most_common()
+            ],
+            headers=["feature class", "evaluation count"],
+            tablefmt="github",
+        )
+    )
+    print()
 
     print(
         tabulate.tabulate(

--- a/scripts/profile-time.py
+++ b/scripts/profile-time.py
@@ -110,10 +110,7 @@ def main(argv=None):
 
     print(
         tabulate.tabulate(
-            [
-                (counter, humanize.intcomma(count))
-                for counter, count in capa.perf.counters.most_common()
-            ],
+            [(counter, humanize.intcomma(count)) for counter, count in capa.perf.counters.most_common()],
             headers=["feature class", "evaluation count"],
             tablefmt="github",
         )


### PR DESCRIPTION
Output looks like:

![image](https://github.com/mandiant/capa/assets/156560/4ac4422b-bbeb-431c-a487-ab22fc625b6c)


which renders to this on Github:

| feature class                      | evaluation count   |
|------------------------------------|--------------------|
| evaluate.feature                   | 19,939,641         |
| evaluate.feature.and               | 4,441,407          |
| evaluate.feature.rule              | 4,124,464          |
| evaluate.feature.api               | 2,385,944          |
| evaluate.feature.bytes             | 1,756,958          |
| evaluate.feature.match             | 1,546,698          |
| evaluate.feature.or                | 1,443,142          |
| evaluate.feature.number            | 1,246,595          |
| evaluate.feature.mnemonic          | 1,205,911          |
| evaluate.feature.regex             | 271,779            |
| evaluate.feature.os                | 264,511            |
| evaluate.feature.string            | 192,866            |
| evaluate.feature.characteristic    | 178,392            |
| evaluate.feature.some              | 163,596            |
| evaluate.feature.operand[1].number | 155,261            |
| evaluate.feature.substring         | 127,813            |
| evaluate.feature.arch              | 127,381            |
| evaluate.feature.operand[0].offset | 104,100            |
| evaluate.feature.operand[1].offset | 78,648             |
| evaluate.feature.offset            | 56,995             |
| evaluate.feature.range             | 31,907             |
| evaluate.feature.property          | 21,125             |
| evaluate.feature.format            | 7,604              |
| evaluate.feature.not               | 6,108              |
| evaluate.feature.operand[2].number | 425                |
| evaluate.feature.section           | 5                  |
| evaluate.feature.export            | 3                  |
| evaluate.feature.import            | 2                  |
| evaluate.feature.operand[0].number | 1                  |

| label                                                   | count(evaluations)   | min(time)   | avg(time)   | max(time)   |
|---------------------------------------------------------|----------------------|-------------|-------------|-------------|
| 5390e1a0 be2: insn: polish thunk handling a bit (dirty) | 19,939,641           | 81.45s      | 83.54s      | 86.74s      |




### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
