### PR TITLE
tighten rule pre-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - add function in capa/helpers to load plain and compressed JSON reports #1883 @Rohit1123
 - document Antivirus warnings and VirusTotal false positive detections #2028 @RionEV @mr-tz
+- optimize rule matching #2080 @williballenthin
 
 ### Breaking Changes
 

--- a/capa/engine.py
+++ b/capa/engine.py
@@ -270,6 +270,14 @@ class Subscope(Statement):
 MatchResults = Mapping[str, List[Tuple[Address, Result]]]
 
 
+def get_rule_namespaces(rule: "capa.rules.Rule") -> Iterator[str]:
+    namespace = rule.meta.get("namespace")
+    if namespace:
+        while namespace:
+            yield namespace
+            namespace, _, _ = namespace.rpartition("/")
+
+
 def index_rule_matches(features: FeatureSet, rule: "capa.rules.Rule", locations: Iterable[Address]):
     """
     record into the given featureset that the given rule matched at the given locations.
@@ -280,11 +288,8 @@ def index_rule_matches(features: FeatureSet, rule: "capa.rules.Rule", locations:
     updates `features` in-place. doesn't modify the remaining arguments.
     """
     features[capa.features.common.MatchedRule(rule.name)].update(locations)
-    namespace = rule.meta.get("namespace")
-    if namespace:
-        while namespace:
-            features[capa.features.common.MatchedRule(namespace)].update(locations)
-            namespace, _, _ = namespace.rpartition("/")
+    for namespace in get_rule_namespaces(rule):
+        features[capa.features.common.MatchedRule(namespace)].update(locations)
 
 
 def match(rules: List["capa.rules.Rule"], features: FeatureSet, addr: Address) -> Tuple[FeatureSet, MatchResults]:

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -387,6 +387,7 @@ class Bytes(Feature):
     def evaluate(self, features: "capa.engine.FeatureSet", short_circuit=True):
         capa.perf.counters["evaluate.feature"] += 1
         capa.perf.counters["evaluate.feature.bytes"] += 1
+        capa.perf.counters["evaluate.feature.bytes." + str(len(self.value))] += 1
 
         assert isinstance(self.value, bytes)
         for feature, locations in features.items():

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -385,11 +385,12 @@ class Bytes(Feature):
         self.value = value
 
     def evaluate(self, features: "capa.engine.FeatureSet", short_circuit=True):
+        assert isinstance(self.value, bytes)
+
         capa.perf.counters["evaluate.feature"] += 1
         capa.perf.counters["evaluate.feature.bytes"] += 1
         capa.perf.counters["evaluate.feature.bytes." + str(len(self.value))] += 1
 
-        assert isinstance(self.value, bytes)
         for feature, locations in features.items():
             if not isinstance(feature, (Bytes,)):
                 continue

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -490,6 +490,6 @@ class Format(Feature):
 def is_global_feature(feature):
     """
     is this a feature that is extracted at every scope?
-    today, these are OS and arch features.
+    today, these are OS, arch, and format features.
     """
-    return isinstance(feature, (OS, Arch))
+    return isinstance(feature, (OS, Arch, Format))

--- a/capa/features/extractors/binexport2/__init__.py
+++ b/capa/features/extractors/binexport2/__init__.py
@@ -261,7 +261,9 @@ class BinExport2Analysis:
     def _compute_thunks(self):
         for addr, idx in self.idx.vertex_index_by_address.items():
             vertex: BinExport2.CallGraph.Vertex = self.be2.call_graph.vertex[idx]
-            if not capa.features.extractors.binexport2.helpers.is_vertex_type(vertex, BinExport2.CallGraph.Vertex.Type.THUNK):
+            if not capa.features.extractors.binexport2.helpers.is_vertex_type(
+                vertex, BinExport2.CallGraph.Vertex.Type.THUNK
+            ):
                 continue
 
             curr_idx: int = idx

--- a/capa/features/extractors/binexport2/basicblock.py
+++ b/capa/features/extractors/binexport2/basicblock.py
@@ -13,6 +13,7 @@ from capa.features.address import Address, AbsoluteVirtualAddress
 from capa.features.basicblock import BasicBlock
 from capa.features.extractors.binexport2 import FunctionContext, BasicBlockContext
 from capa.features.extractors.base_extractor import BBHandle, FunctionHandle
+from capa.features.extractors.binexport2.binexport2_pb2 import BinExport2
 
 
 def extract_bb_tight_loop(fh: FunctionHandle, bbh: BBHandle) -> Iterator[Tuple[Feature, Address]]:

--- a/capa/features/extractors/binexport2/extractor.py
+++ b/capa/features/extractors/binexport2/extractor.py
@@ -75,7 +75,9 @@ class BinExport2FeatureExtractor(StaticFeatureExtractor):
             be2_vertex: BinExport2.CallGraph.Vertex = self.be2.call_graph.vertex[vertex_idx]
 
             # skip thunks
-            if capa.features.extractors.binexport2.helpers.is_vertex_type(be2_vertex, BinExport2.CallGraph.Vertex.Type.THUNK):
+            if capa.features.extractors.binexport2.helpers.is_vertex_type(
+                be2_vertex, BinExport2.CallGraph.Vertex.Type.THUNK
+            ):
                 continue
 
             yield FunctionHandle(

--- a/capa/features/extractors/binexport2/insn.py
+++ b/capa/features/extractors/binexport2/insn.py
@@ -14,7 +14,7 @@ import capa.features.extractors.binexport2.helpers
 from capa.features.insn import API, Number, Mnemonic, OperandNumber
 from capa.features.common import Bytes, String, Feature, Characteristic
 from capa.features.address import Address, AbsoluteVirtualAddress
-from capa.features.extractors.binexport2 import FunctionContext, ReadMemoryError, InstructionContext, AnalysisContext
+from capa.features.extractors.binexport2 import AnalysisContext, FunctionContext, ReadMemoryError, InstructionContext
 from capa.features.extractors.base_extractor import BBHandle, InsnHandle, FunctionHandle
 from capa.features.extractors.binexport2.binexport2_pb2 import BinExport2
 

--- a/capa/features/extractors/binexport2/insn.py
+++ b/capa/features/extractors/binexport2/insn.py
@@ -54,7 +54,9 @@ def extract_insn_api_features(fh: FunctionHandle, _bbh: BBHandle, ih: InsnHandle
         vertex_idx: int = be2_index.vertex_index_by_address[addr]
         vertex: BinExport2.CallGraph.Vertex = be2.call_graph.vertex[vertex_idx]
 
-        if not capa.features.extractors.binexport2.helpers.is_vertex_type(vertex, BinExport2.CallGraph.Vertex.Type.IMPORTED):
+        if not capa.features.extractors.binexport2.helpers.is_vertex_type(
+            vertex, BinExport2.CallGraph.Vertex.Type.IMPORTED
+        ):
             continue
 
         if not vertex.HasField("mangled_name"):

--- a/capa/features/extractors/binexport2/insn.py
+++ b/capa/features/extractors/binexport2/insn.py
@@ -14,7 +14,7 @@ import capa.features.extractors.binexport2.helpers
 from capa.features.insn import API, Number, Mnemonic, OperandNumber
 from capa.features.common import Bytes, String, Feature, Characteristic
 from capa.features.address import Address, AbsoluteVirtualAddress
-from capa.features.extractors.binexport2 import AnalysisContext, FunctionContext, ReadMemoryError, InstructionContext
+from capa.features.extractors.binexport2 import FunctionContext, ReadMemoryError, InstructionContext
 from capa.features.extractors.base_extractor import BBHandle, InsnHandle, FunctionHandle
 from capa.features.extractors.binexport2.binexport2_pb2 import BinExport2
 
@@ -31,8 +31,7 @@ def extract_insn_api_features(fh: FunctionHandle, _bbh: BBHandle, ih: InsnHandle
     insn = be2.instruction[ii.instruction_index]
 
     for addr in insn.call_target:
-        if addr in be2_analysis.thunks:
-            addr = be2_analysis.thunks[addr]
+        addr = be2_analysis.thunks.get(addr, addr)
 
         if addr not in be2_index.vertex_index_by_address:
             # disassembler did not define function at address

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1992,7 +1992,7 @@ class RuleSet:
         return (augmented_features, results)
 
     def match(
-        self, scope: Scope, features: FeatureSet, addr: Address, paranoid=False
+        self, scope: Scope, features: FeatureSet, addr: Address, paranoid=True
     ) -> Tuple[FeatureSet, ceng.MatchResults]:
         """
         Match rules from this ruleset at the given scope against the given features.

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1463,7 +1463,7 @@ class RuleSet:
             if rule_name not in scores_by_rule:
                 # Its possible that we haven't scored the rule that is being requested here.
                 # This means that it won't ever match (because it won't be evaluated before this one).
-                # Still, we need to provide a default value here. 
+                # Still, we need to provide a default value here.
                 # So we give it 9, because it won't match, so its very selective.
                 #
                 # But how could this dependency not exist?

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1459,6 +1459,25 @@ class RuleSet:
             # If logic changes and you see issues here, ensure that `scores_by_rule` is correctly provided.
             rule_name = node.value
             assert isinstance(rule_name, str)
+
+            if rule_name not in scores_by_rule:
+                # Its possible that we haven't scored the rule that is being requested here.
+                # This means that it won't ever match (because it won't be evaluated before this one).
+                # Still, we need to provide a default value here. 
+                # So we give it 9, because it won't match, so its very selective.
+                #
+                # But how could this dependency not exist?
+                # Consider a rule that supports both static and dynamic analysis, but also has
+                # a `instruction: ` block. This block gets translated into a derived rule that only
+                # matches in static mode. Therefore, when the parent rule is run in dynamic mode, it
+                # won't be able to find the derived rule. This is the case we have to handle here.
+                #
+                # A better solution would be to prune this logic based on static/dynamic mode, but
+                # that takes more work and isn't in scope of this feature.
+                #
+                # See discussion in: https://github.com/mandiant/capa/pull/2080/#discussion_r1624783396
+                return 9
+
             return scores_by_rule[rule_name]
 
         elif isinstance(node, (capa.features.insn.Number, capa.features.insn.OperandNumber)):

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1579,9 +1579,13 @@ class RuleSet:
                 # and this is checked by the linter,
                 return None
 
-            elif isinstance(node, (ceng.Range)) and node.min == 0:
+            elif isinstance(node, (ceng.Range)) and node.min == 0 and node.max != 0:
                 # `count(foo): 0 or more` is just like an optional block,
                 # because the min is 0, this subtree *can* match just about any feature.
+                return None
+
+            elif isinstance(node, (ceng.Range)) and node.min == 0 and node.max == 0:
+                # `count(foo): 0` is like a not block, which we don't index.
                 return None
 
             elif isinstance(node, capa.features.common.Feature):

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1429,7 +1429,7 @@ class RuleSet:
         """
         Score the given feature by how "uncommon" we think it will be.
         Features that we expect to be very selective (ie. uniquely identify a rule and be required to match),
-         or "uncommon", should get a high score. 
+         or "uncommon", should get a high score.
         Features that are not good for indexing will have a low score, or 0.
 
         The range of values doesn't really matter, but here we use 0-10, where
@@ -1492,7 +1492,6 @@ class RuleSet:
             #   - 0 is a very common, not selective, bad for indexing a rule.
             #
             # You shouldn't try to interpret the scores, beyond to compare features to pick one or the other.
-
             # -----------------------------------------------------------------
             #
             # Very uncommon features that are probably very selective in capa's domain.

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1957,15 +1957,6 @@ class RuleSet:
                         if wanted_bytes.evaluate(bytes_features):
                             candidate_rule_names.add(rule_name)
 
-        # trace
-        # logger.debug(
-        #     "perf: match: %s: %s: %d features, %d candidate rules",
-        #     scope,
-        #     addr,
-        #     len(features),
-        #     len(candidate_rule_names),
-        # )
-
         # No rules can possibly match, so quickly return.
         if not candidate_rule_names:
             return (features, {})

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1992,7 +1992,7 @@ class RuleSet:
         return (augmented_features, results)
 
     def match(
-        self, scope: Scope, features: FeatureSet, addr: Address, paranoid=True
+        self, scope: Scope, features: FeatureSet, addr: Address, paranoid=False
     ) -> Tuple[FeatureSet, ceng.MatchResults]:
         """
         Match rules from this ruleset at the given scope against the given features.

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1856,6 +1856,8 @@ class RuleSet:
         # feature frequently whenever a string/bytes feature is encountered. Its slow, but we can't
         # get around it. Reducing our reliance on regex/bytes feature and/or finding a way to
         # index these can futher improve performance.
+        #
+        # See the corresponding unstable tests in `test_match.py::test_index_features_*`.
 
         # Find all the rules that could match the given feature set.
         # Ideally we want this set to be as small and focused as possible,

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -2009,7 +2009,8 @@ class RuleSet:
         TODO(williballenthin): add lints for logic edge cases
 
         Args:
-          paranoid: when true, demonstrate that the naive matcher agrees with this optimized matcher (much slower!).
+          paranoid: when true, demonstrate that the naive matcher agrees with this
+           optimized matcher (much slower! around 10x slower).
         """
         features, matches = self._match(scope, features, addr)
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1666,10 +1666,13 @@ class RuleSet:
                 rules_by_feature[feature].add(rule_name)
 
         logger.debug("indexing: %d features indexed for scope %s", len(rules_by_feature), scope)
-        logger.debug("indexing: %d indexed features are shared by more than 3 rules",
-                     len([feature for feature, rules in rules_by_feature.items() if len(rules) > 3]))
-        logger.debug("indexing: %d scanning string features, %d scanning bytes features",
-                     len(string_rules), len(bytes_rules))
+        logger.debug(
+            "indexing: %d indexed features are shared by more than 3 rules",
+            len([feature for feature, rules in rules_by_feature.items() if len(rules) > 3]),
+        )
+        logger.debug(
+            "indexing: %d scanning string features, %d scanning bytes features", len(string_rules), len(bytes_rules)
+        )
 
         # TODO(wb): remember, when evaluating candidates, make sure
         # to do it in topological order, so match statements work.
@@ -1756,7 +1759,6 @@ class RuleSet:
 
         feature_index = self._feature_indexes_by_scopes[scope]
         rules = self.rules_by_scope[scope]
-        rules_by_name = {rule.name: rule for rule in rules}
         # topologic location of rule given its name
         rule_index_by_rule_name = {rule.name: i for i, rule in enumerate(rules)}
 
@@ -1804,7 +1806,7 @@ class RuleSet:
         # The following is derived from ceng.match
         # extended to interact with candidate_rules upon rule match.
         #
-        results: MatchResults = collections.defaultdict(list)
+        results: ceng.MatchResults = collections.defaultdict(list)
 
         # copy features so that we can modify it
         # without affecting the caller (keep this function pure)
@@ -1838,7 +1840,7 @@ class RuleSet:
                     resort_rules_topologically(candidate_rules)
 
         return (features, results)
-        
+
 
 def is_nursery_rule_path(path: Path) -> bool:
     """

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1543,14 +1543,15 @@ class RuleSet:
         """
         Index the given rules by their minimal set of most "uncommon" features required to match.
 
-        If absolutely necessary, provide the Regex/Substring/Bytes features 
+        If absolutely necessary, provide the Regex/Substring/Bytes features
         (which are not hashable and require a scan) that have to match, too.
         """
 
         rules_by_feature: Dict[Feature, Set[str]] = collections.defaultdict(set)
 
         def rec(
-            rule_name: str, node: Union[Feature, Statement],
+            rule_name: str,
+            node: Union[Feature, Statement],
             # closure over: scores_by_rule
         ) -> Optional[Tuple[int, Set[Feature]]]:
             """
@@ -1981,7 +1982,7 @@ class RuleSet:
         """
         Match rules from this ruleset at the given scope against the given features.
 
-        This wrapper around _match exists so that we can assert it matches precisely 
+        This wrapper around _match exists so that we can assert it matches precisely
         the same as `capa.engine.match`, just faster.
         """
         features1, matches1 = self._match(scope, features, addr)

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1380,7 +1380,7 @@ class RuleSet:
         self.rules_by_namespace = index_rules_by_namespace(rules)
         self.rules_by_scope = {scope: self._get_rules_for_scope(rules, scope) for scope in scopes}
 
-        # unstable
+        # these structures are unstable and may change before the next major release.
         scores_by_rule: Dict[str, int] = {}
         self._feature_indexes_by_scopes = {
             scope: self._index_rules_by_feature(scope, self.rules_by_scope[scope], scores_by_rule) for scope in scopes
@@ -1423,7 +1423,7 @@ class RuleSet:
     def __contains__(self, rulename):
         return rulename in self.rules
 
-    # unstable
+    # this routine is unstable and may change before the next major release.
     @staticmethod
     def _score_feature(scores_by_rule: Dict[str, int], node: capa.features.common.Feature) -> int:
         """
@@ -1526,7 +1526,7 @@ class RuleSet:
             # bytes: 0
         }[C]
 
-    # unstable
+    # this class is unstable and may change before the next major release.
     @dataclass
     class _RuleFeatureIndex:
         # Mapping from hashable feature to a list of rules that might have this feature.
@@ -1538,7 +1538,7 @@ class RuleSet:
         # All these features will be evaluated whenever a Bytes feature is encountered.
         bytes_rules: Dict[str, List[Feature]]
 
-    # unstable
+    # this routine is unstable and may change before the next major release.
     @staticmethod
     def _index_rules_by_feature(scope: Scope, rules: List[Rule], scores_by_rule: Dict[str, int]) -> _RuleFeatureIndex:
         """
@@ -1806,7 +1806,7 @@ class RuleSet:
                             break
         return RuleSet(list(rules_filtered))
 
-    # unstable
+    # this routine is unstable and may change before the next major release.
     @staticmethod
     def _sort_rules_by_index(rule_index_by_rule_name: Dict[str, int], rules: List[Rule]):
         """

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -790,6 +790,7 @@ def test_match_os_any():
     assert "test rule" in matches
 
 
+# this test demonstrates the behavior of unstable features that may change before the next major release.
 def test_index_features_and_unstable():
     rule = textwrap.dedent(
         """
@@ -818,6 +819,7 @@ def test_index_features_and_unstable():
     assert not index.bytes_rules
 
 
+# this test demonstrates the behavior of unstable features that may change before the next major release.
 def test_index_features_or_unstable():
     rule = textwrap.dedent(
         """
@@ -847,6 +849,7 @@ def test_index_features_or_unstable():
     assert not index.bytes_rules
 
 
+# this test demonstrates the behavior of unstable features that may change before the next major release.
 def test_index_features_nested_unstable():
     rule = textwrap.dedent(
         """

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -5,8 +5,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-
 import textwrap
+
+import pytest
 
 import capa.rules
 import capa.engine
@@ -130,22 +131,29 @@ def test_match_range_exact_zero():
                     static: function
                     dynamic: process
             features:
-                - count(number(100)): 0
+                - and:
+                    - count(number(100)): 0
+
+                    # we can't have `count(foo): 0` at the top level,
+                    # since we don't support top level NOT statements.
+                    # so we have this additional trivial feature.
+                    - mnemonic: mov
+
         """
     )
     r = capa.rules.Rule.from_yaml(rule)
 
     # feature isn't indexed - good.
-    _, matches = match([r], {}, 0x0)
+    _, matches = match([r], {capa.features.insn.Mnemonic("mov"): {}}, 0x0)
     assert "test rule" in matches
 
     # feature is indexed, but no matches.
     # i don't think we should ever really have this case, but good to check anyways.
-    _, matches = match([r], {capa.features.insn.Number(100): {}}, 0x0)
+    _, matches = match([r], {capa.features.insn.Number(100): {}, capa.features.insn.Mnemonic("mov"): {}}, 0x0)
     assert "test rule" in matches
 
     # too many matches
-    _, matches = match([r], {capa.features.insn.Number(100): {1}}, 0x0)
+    _, matches = match([r], {capa.features.insn.Number(100): {1}, capa.features.insn.Mnemonic("mov"): {1}}, 0x0)
     assert "test rule" not in matches
 
 
@@ -159,21 +167,27 @@ def test_match_range_with_zero():
                     static: function
                     dynamic: process
              features:
-                 - count(number(100)): (0, 1)
+                - and:
+                    - count(number(100)): (0, 1)
+
+                    # we can't have `count(foo): 0` at the top level,
+                    # since we don't support top level NOT statements.
+                    # so we have this additional trivial feature.
+                    - mnemonic: mov
          """
     )
     r = capa.rules.Rule.from_yaml(rule)
 
     # ok
-    _, matches = match([r], {}, 0x0)
+    _, matches = match([r], {capa.features.insn.Mnemonic("mov"): {}}, 0x0)
     assert "test rule" in matches
-    _, matches = match([r], {capa.features.insn.Number(100): {}}, 0x0)
+    _, matches = match([r], {capa.features.insn.Number(100): {}, capa.features.insn.Mnemonic("mov"): {}}, 0x0)
     assert "test rule" in matches
-    _, matches = match([r], {capa.features.insn.Number(100): {1}}, 0x0)
+    _, matches = match([r], {capa.features.insn.Number(100): {1}, capa.features.insn.Mnemonic("mov"): {1}}, 0x0)
     assert "test rule" in matches
 
     # too many matches
-    _, matches = match([r], {capa.features.insn.Number(100): {1, 2}}, 0x0)
+    _, matches = match([r], {capa.features.insn.Number(100): {1, 2}, capa.features.insn.Mnemonic("mov"): {1, 2}}, 0x0)
     assert "test rule" not in matches
 
 
@@ -551,7 +565,8 @@ def test_match_regex_values_always_string():
     assert capa.features.common.MatchedRule("test rule") in features
 
 
-def test_match_not():
+@pytest.mark.xfail(reason="can't have top level NOT")
+def test_match_only_not():
     rule = textwrap.dedent(
         """
         rule:
@@ -572,6 +587,30 @@ def test_match_not():
     assert "test rule" in matches
 
 
+def test_match_not():
+    rule = textwrap.dedent(
+        """
+        rule:
+            meta:
+                name: test rule
+                scopes:
+                    static: function
+                    dynamic: process
+                namespace: testns1/testns2
+            features:
+                - and:
+                    - mnemonic: mov
+                    - not:
+                        - number: 99
+        """
+    )
+    r = capa.rules.Rule.from_yaml(rule)
+
+    _, matches = match([r], {capa.features.insn.Number(100): {1, 2}, capa.features.insn.Mnemonic("mov"): {1, 2}}, 0x0)
+    assert "test rule" in matches
+
+
+@pytest.mark.xfail(reason="can't have nested NOT")
 def test_match_not_not():
     rule = textwrap.dedent(
         """


### PR DESCRIPTION
closes #2074
ref #2063, particularly "tighten rule pre-selection" and "lots of time spent in instancecheck"

Stacked on #1950, so I've marked this as a PR onto that branch so the diff is sensible. I think we can probably rebase onto master, though, if necessary.

---

This PR implements the "tighten rule pre-selection" algorithm described here: https://github.com/mandiant/capa/issues/2063#issuecomment-2100498720 . In summary:

> Rather than indexing all features from all rules, we should pick and index the minimal set (ideally, one) of features from each rule that must be present for the rule to match. When we have multiple candidates, pick the feature that is probably most uncommon and therefore "selective".

This seems to work pretty well. Total evaluations when running against mimikatz drop from 19M to 1.1M (wow!) and capa seems to match around 3x more functions per second (wow wow). I did not expect such a good result - in fact, although the capa matches *seem* the be the same, I still wonder if something is broken 🤔. More tests needed. 

| label                                                       | count(evaluations)   | time   |
|-------------------------------------------------------------|----------------------|-------------|
| [before any optimization, prehistoric] | 104,496,193          | 86.62s      |
| 8858537a pep8 [before this PR]                                              | 19,939,632           | 25.74s      |
| a66524ae rules: match: better debug paranoid matching | 1,157,514            | 8.10s       |

TODO:
  - [x] add some tests for the feature indexer, if only to show a human how it works
  - [x] namespace matching
  - [x] prove that it matches exactly the same as before, just faster
  - [x] xfail the tests and document the unsupported constructs
  - [x] inline documentation explaining the algorithm better
  - [x] wall clock performance numbers
