### PR TITLE
Replacalo spinner with rich

### DIFF
--- a/capa/loader.py
+++ b/capa/loader.py
@@ -11,7 +11,7 @@ import datetime
 from typing import Set, Dict, List, Optional
 from pathlib import Path
 
-import halo
+from rich.console import Console
 from typing_extensions import assert_never
 
 import capa.perf
@@ -176,6 +176,8 @@ def get_extractor(
       UnsupportedArchError
       UnsupportedOSError
     """
+    console = Console(stderr=True, quiet=disable_progress)
+
     if backend == BACKEND_CAPE:
         import capa.features.extractors.cape.extractor
 
@@ -222,7 +224,7 @@ def get_extractor(
             if os_ == OS_AUTO and not is_supported_os(input_path):
                 raise UnsupportedOSError()
 
-        with halo.Halo(text="analyzing program", spinner="simpleDots", stream=sys.stderr, enabled=not disable_progress):
+        with console.status("Analyzing program...", spinner="dots"):
             bv: BinaryView = binaryninja.load(str(input_path))
             if bv is None:
                 raise RuntimeError(f"Binary Ninja cannot open file {input_path}")
@@ -247,7 +249,7 @@ def get_extractor(
             if os_ == OS_AUTO and not is_supported_os(input_path):
                 raise UnsupportedOSError()
 
-        with halo.Halo(text="analyzing program", spinner="simpleDots", stream=sys.stderr, enabled=not disable_progress):
+        with console.status("Analyzing program...", spinner="dots"):
             vw = get_workspace(input_path, input_format, sigpaths)
 
             if should_save_workspace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "dncil==1.0.2",
     "pydantic==2.7.1",
     "protobuf==5.26.1",
+    "rich==13.4.2"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This PR is a candidate replacement for Halo spinner as discussed in #1812. It uses [Rich](https://github.com/Textualize/rich) module.

If we end up adopting rich, we could _maybe_ use some of its other features to reduce dependencies, for example replacing `tqdm` with `rich.progress` and `tabulate` with `rich.table`.
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
