### PR TITLE
scripts/show-features.py: use extractor.get_process_name() interface …

### DIFF
--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -171,8 +171,8 @@ def print_dynamic_analysis(extractor: DynamicFeatureExtractor, args):
     process_handles = tuple(extractor.get_processes())
 
     if args.process:
-        process_handles = tuple(filter(lambda ph: ph.inner["name"] == args.process, process_handles))
-        if args.process not in [ph.inner["name"] for ph in args.process]:
+        process_handles = tuple(filter(lambda ph: extractor.get_process_name(ph) == args.process, process_handles))
+        if args.process not in [extractor.get_process_name(ph) for ph in process_handles]:
             print(f"{args.process} not a process")
             return -1
 
@@ -227,13 +227,13 @@ def print_static_features(functions, extractor: StaticFeatureExtractor):
 
 def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
     for p in processes:
-        print(f"proc: {extractor.get_process_name(p)} (ppid={p.address.ppid}, pid={p.address.pid})")
+        print(f"proc: {p.inner.process_name} (ppid={p.address.ppid}, pid={p.address.pid})")
 
         for feature, addr in extractor.extract_process_features(p):
             if is_global_feature(feature):
                 continue
 
-            print(f" proc: {extractor.get_process_name(p)}: {feature}")
+            print(f" proc: {p.inner.process_name}: {feature}")
 
             for t in extractor.get_threads(p):
                 print(f"  thread: {t.address.tid}")

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -227,13 +227,13 @@ def print_static_features(functions, extractor: StaticFeatureExtractor):
 
 def print_dynamic_features(processes, extractor: DynamicFeatureExtractor):
     for p in processes:
-        print(f"proc: {p.inner.process_name} (ppid={p.address.ppid}, pid={p.address.pid})")
+        print(f"proc: {extractor.get_process_name(p)} (ppid={p.address.ppid}, pid={p.address.pid})")
 
         for feature, addr in extractor.extract_process_features(p):
             if is_global_feature(feature):
                 continue
 
-            print(f" proc: {p.inner.process_name}: {feature}")
+            print(f" proc: {extractor.get_process_name(p)}: {feature}")
 
             for t in extractor.get_threads(p):
                 print(f"  thread: {t.address.tid}")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -63,7 +63,7 @@ def get_rule_path():
         pytest.param("show-capabilities-by-function.py", [get_binary_file_path()]),
         pytest.param("show-features.py", [get_binary_file_path()]),
         pytest.param("show-features.py", ["-F", "0x407970", get_binary_file_path()]),
-        pytest.param("show-features.py", ["-P", "MicrosoftEdgeUpdate.exe", get_report_file_path]),
+        pytest.param("show-features.py", ["-P", "MicrosoftEdgeUpdate.exe", get_report_file_path()]),
         pytest.param("show-unused-features.py", [get_binary_file_path()]),
         pytest.param("capa_as_library.py", [get_binary_file_path()]),
     ],

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -23,8 +23,19 @@ def get_script_path(s: str):
     return str(CD / ".." / "scripts" / s)
 
 
-def get_file_path():
+def get_binary_file_path():
     return str(CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
+
+
+def get_report_file_path():
+    return str(
+        CD
+        / "data"
+        / "dynamic"
+        / "cape"
+        / "v2.4"
+        / "fb7ade52dc5a1d6128b9c217114a46d0089147610f99f5122face29e429a1e74.json.gz"
+    )
 
 
 def get_rules_path():
@@ -48,12 +59,13 @@ def get_rule_path():
         pytest.param("lint.py", ["-t", "create directory", get_rules_path()]),
         # `create directory` rule has native and .NET example PEs
         pytest.param("lint.py", ["--thorough", "-t", "create directory", get_rules_path()]),
-        pytest.param("match-function-id.py", [get_file_path()]),
-        pytest.param("show-capabilities-by-function.py", [get_file_path()]),
-        pytest.param("show-features.py", [get_file_path()]),
-        pytest.param("show-features.py", ["-F", "0x407970", get_file_path()]),
-        pytest.param("show-unused-features.py", [get_file_path()]),
-        pytest.param("capa_as_library.py", [get_file_path()]),
+        pytest.param("match-function-id.py", [get_binary_file_path()]),
+        pytest.param("show-capabilities-by-function.py", [get_binary_file_path()]),
+        pytest.param("show-features.py", [get_binary_file_path()]),
+        pytest.param("show-features.py", ["-F", "0x407970", get_binary_file_path()]),
+        pytest.param("show-features.py", ["-P", "MicrosoftEdgeUpdate.exe", get_report_file_path]),
+        pytest.param("show-unused-features.py", [get_binary_file_path()]),
+        pytest.param("capa_as_library.py", [get_binary_file_path()]),
     ],
 )
 def test_scripts(script, args):


### PR DESCRIPTION
Currently `show-features.py` does not use the `get_process_name()` extractor interface method and instead it tries to access the attribute that stores the process name directly. This can cause issues in the future if feature extractors store that attribute in different manners.

I ran into this issue while trying to use the script with the Drakvuf feature extractor, since CAPE extractor stores the process name as a pydantic object attribute, while Drakvuf extractor stores it in a dictionary.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
