### PR TITLE
add path exclusions to python tests.yml workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,20 @@
 name: CI
 
+# tests.yml workflow will run for all changes except:
+# 1. any file or directory under web/explorer/
+# 2. any Markdown (.md) file anywhere in the repository
+
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'web/explorer/**'
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'web/explorer/**'
+      - '**.md'
 
 permissions: read-all
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,21 @@
 name: CI
 
 # tests.yml workflow will run for all changes except:
-# 1. any file or directory under web/explorer/
-# 2. any Markdown (.md) file anywhere in the repository
+# any file or directory under web/ or doc/
+# any Markdown (.md) file anywhere in the repository
 
 on:
   push:
     branches: [ master ]
     paths-ignore:
-      - 'web/explorer/**'
+      - 'web/**'
+      - 'doc/**'
       - '**.md'
   pull_request:
     branches: [ master ]
     paths-ignore:
-      - 'web/explorer/**'
+      - 'web/**'
+      - 'doc/**'
       - '**.md'
 
 permissions: read-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Development
 - CI: use macos-12 since macos-11 is deprecated and will be removed on June 28th, 2024 #2173 @mr-tz
 - CI: update Binary Ninja version to 4.1 and use Python 3.9 to test it #2211 @xusheng6
+- CI: update tests.yml workflow to exclude web/explorer and Markdown files
 
 ### Raw diffs
 - [capa v7.1.0...master](https://github.com/mandiant/capa/compare/v7.1.0...master)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Development
 - CI: use macos-12 since macos-11 is deprecated and will be removed on June 28th, 2024 #2173 @mr-tz
 - CI: update Binary Ninja version to 4.1 and use Python 3.9 to test it #2211 @xusheng6
-- CI: update tests.yml workflow to exclude web/explorer and Markdown files
+- CI: update tests.yml workflow to exclude web/explorer and Markdown files #2263 @s-ff
 
 ### Raw diffs
 - [capa v7.1.0...master](https://github.com/mandiant/capa/compare/v7.1.0...master)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Development
 - CI: use macos-12 since macos-11 is deprecated and will be removed on June 28th, 2024 #2173 @mr-tz
 - CI: update Binary Ninja version to 4.1 and use Python 3.9 to test it #2211 @xusheng6
-- CI: update tests.yml workflow to exclude web/explorer and Markdown files #2263 @s-ff
+- CI: update tests.yml workflow to exclude web and documentation files #2263 @s-ff
 
 ### Raw diffs
 - [capa v7.1.0...master](https://github.com/mandiant/capa/compare/v7.1.0...master)


### PR DESCRIPTION
closes https://github.com/mandiant/capa/issues/2256
Update tests.yml CI workflow to exclude `web/`, `doc/` and Markdown files

This PR modifies the tests.yml workflow to:
- Ignore changes in the 'web/' and `doc/` directory
- Ignore changes to Markdown files (.md) throughout the repository
- Run tests and checks for all other file changes

Let's first try and merge this PR and use [#2258](https://github.com/mandiant/capa/pull/2258) as a test example.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
