### PR TITLE
web: change base url for capa Explorer Web

### DIFF
--- a/web/explorer/src/components/NavBar.vue
+++ b/web/explorer/src/components/NavBar.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { ref } from "vue";
 import Menubar from "primevue/menubar";
 </script>
 

--- a/web/explorer/src/components/NavBar.vue
+++ b/web/explorer/src/components/NavBar.vue
@@ -1,19 +1,10 @@
 <script setup>
 import { ref } from "vue";
-
 import Menubar from "primevue/menubar";
-
-const items = ref([
-    {
-        label: "Import Analysis",
-        icon: "pi pi-file-import",
-        command: () => (window.location.href = window.location.origin + "/capa/")
-    }
-]);
 </script>
 
 <template>
-    <Menubar :model="items" class="p-1">
+    <Menubar class="p-1">
         <template #end>
             <div class="flex align-items-center gap-3">
                 <a

--- a/web/explorer/vite.config.js
+++ b/web/explorer/vite.config.js
@@ -3,12 +3,11 @@ import vue from "@vitejs/plugin-vue";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import { fileURLToPath, URL } from "node:url";
 
-// eslint-disable-next-line no-unused-vars
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ mode }) => {
     const isBundle = mode === "bundle";
 
     return {
-        base: isBundle ? "/" : "/capa/explorer",
+        base: './',
         plugins: isBundle ? [vue(), viteSingleFile()] : [vue()],
         resolve: {
             alias: {

--- a/web/explorer/vite.config.js
+++ b/web/explorer/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig(({ command, mode }) => {
     const isBundle = mode === "bundle";
 
     return {
-        base: isBundle ? "/" : "/capa/",
+        base: isBundle ? "/" : "/capa/explorer",
         plugins: isBundle ? [vue(), viteSingleFile()] : [vue()],
         resolve: {
             alias: {


### PR DESCRIPTION
closes https://github.com/mandiant/capa/issues/2266 (and https://github.com/mandiant/capa/issues/2262) 

This PR changes the base url of capa Explorer Web to `/capa/explorer` so that it can be hosted on `mandiant.github.com/capa/explorer`


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
