### PR TITLE
use relative path for zip release asset

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:bundle
         working-directory: ./web/explorer
       - name: Zip release bundle
-        run: zip -r capa-explorer-web.zip capa-explorer-web
+        run: zip -r public/capa-explorer-web.zip capa-explorer-web
         working-directory: ./web/explorer
       - name: Build
         run: npm run build

--- a/web/explorer/package.json
+++ b/web/explorer/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "build:bundle": "vite build --mode bundle --outDir=capa-exlorer-web",
+        "build:bundle": "vite build --mode bundle --outDir=capa-explorer-web",
         "preview": "vite preview",
         "test": "vitest",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",

--- a/web/explorer/src/components/NavBar.vue
+++ b/web/explorer/src/components/NavBar.vue
@@ -9,7 +9,7 @@ import Menubar from "primevue/menubar";
                 <a
                     v-ripple
                     v-tooltip.right="'Download capa Explorer Web for offline usage'"
-                    href="/capa-explorer-web.zip"
+                    href="./capa-explorer-web.zip"
                     download="capa-explorer-web.zip"
                     aria-label="Download capa Explorer Web release"
                 >


### PR DESCRIPTION
This PR
- fixes a a typo in package.json
- moves the zip asset to the public dir.

Note: `public` dir is a special dir which hosts files that would be served as is, so it makes sense to put the release for download there.


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
