### PR TITLE
rearrange navbar icons

### DIFF
--- a/web/explorer/src/components/NavBar.vue
+++ b/web/explorer/src/components/NavBar.vue
@@ -1,9 +1,15 @@
 <script setup>
 import Menubar from "primevue/menubar";
+import { RouterLink } from "vue-router";
 </script>
 
 <template>
     <Menubar class="p-1">
+        <template #start>
+            <RouterLink to="/">
+                <img src="@/assets/images/icon.png" alt="Logo" class="w-2rem" />
+            </RouterLink>
+        </template>
         <template #end>
             <div class="flex align-items-center gap-3">
                 <a
@@ -18,7 +24,6 @@ import Menubar from "primevue/menubar";
                 <a v-ripple href="https://github.com/mandiant/capa" class="flex justify-content-center w-2rem">
                     <i class="pi pi-github text-2xl"></i>
                 </a>
-                <img src="@/assets/images/icon.png" alt="Logo" class="w-2rem" />
             </div>
         </template>
     </Menubar>


### PR DESCRIPTION
resolves https://github.com/mandiant/capa/issues/2286#issuecomment-2286392406 and https://github.com/mandiant/capa/issues/2286#issuecomment-2286637495
<details><summary>moves FLARE logo to the right left side, and make a clickable link to / </summary>


![Kapture 2024-08-15 at 16 54 11](https://github.com/user-attachments/assets/5a5057a0-6541-439b-a07c-bfba32e3683d)

</details>


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
