### PR TITLE
web: add copy rule name and description to VT to right click menu

### DIFF
--- a/web/explorer/src/components/RuleMatchesTable.vue
+++ b/web/explorer/src/components/RuleMatchesTable.vue
@@ -152,6 +152,7 @@
                 <span v-if="item.icon !== 'vt-icon'" :class="item.icon" />
                 <VTIcon v-else-if="item.icon === 'vt-icon'" />
                 <span>{{ item.label }}</span>
+                <i v-if="item.description" class="pi pi-info-circle text-xs" v-tooltip.right="item.description" />
             </a>
         </template>
     </ContextMenu>
@@ -216,6 +217,13 @@ const menu = ref();
 const selectedNode = ref({});
 const contextMenuItems = computed(() => [
     {
+        label: "Copy rule name",
+        icon: "pi pi-copy",
+        command: () => {
+            navigator.clipboard.writeText(selectedNode.value.data?.name);
+        }
+    },
+    {
         label: "View source",
         icon: "pi pi-eye",
         command: () => {
@@ -232,6 +240,7 @@ const contextMenuItems = computed(() => [
         label: "Lookup rule in VirusTotal",
         icon: "vt-icon",
         target: "_blank",
+        description: "Requires VirusTotal Premium account",
         url: createVirusTotalUrl(selectedNode.value.data?.name)
     }
 ]);


### PR DESCRIPTION
closes #2236

<details><summary>This PR adds support for copying rule name and adds a description to the VT deep link</summary>

![image](https://github.com/user-attachments/assets/225af9e5-0719-45d3-af25-58fe93f1373e)


</details>

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
