### PR TITLE
web: add file scope rules and display decimal repr for hex values

### DIFF
--- a/web/explorer/src/components/FunctionCapabilities.vue
+++ b/web/explorer/src/components/FunctionCapabilities.vue
@@ -26,7 +26,7 @@
             :showClearButton="false"
         >
             <template #filter v-if="props.showColumnFilters">
-                <InputText v-model="filters['address'].value" placeholder="Filter by name" />
+                <InputText v-model="filters['address'].value" placeholder="Filter by function address" />
             </template>
             <template #body="{ data }">
                 <span class="font-monospace text-base">{{ data.address }}</span>
@@ -36,9 +36,16 @@
             </template>
         </Column>
 
-        <Column field="rule" sortable header="Matches" class="w-min" :showFilterMenu="false" :showClearButton="false">
+        <Column
+            field="rule"
+            sortable
+            header="Rule Matches"
+            class="w-min"
+            :showFilterMenu="false"
+            :showClearButton="false"
+        >
             <template #filter v-if="props.showColumnFilters">
-                <InputText v-model="filters['rule'].value" placeholder="Filter by name" />
+                <InputText v-model="filters['rule'].value" placeholder="Filter by rule" />
             </template>
             <template #body="{ data }">
                 {{ data.rule }}
@@ -48,7 +55,7 @@
 
         <Column field="namespace" sortable header="Namespace" :showFilterMenu="false" :showClearButton="false">
             <template #filter v-if="props.showColumnFilters">
-                <InputText v-model="filters['namespace'].value" placeholder="Filter by name" />
+                <InputText v-model="filters['namespace'].value" placeholder="Filter by namespace" />
             </template>
         </Column>
     </DataTable>

--- a/web/explorer/src/components/FunctionCapabilities.vue
+++ b/web/explorer/src/components/FunctionCapabilities.vue
@@ -36,14 +36,7 @@
             </template>
         </Column>
 
-        <Column
-            field="rule"
-            sortable
-            header="Rule Matches"
-            class="w-min"
-            :showFilterMenu="false"
-            :showClearButton="false"
-        >
+        <Column field="rule" header="Rule Matches" class="w-min" :showFilterMenu="false" :showClearButton="false">
             <template #filter v-if="props.showColumnFilters">
                 <InputText v-model="filters['rule'].value" placeholder="Filter by rule" />
             </template>
@@ -53,7 +46,7 @@
             </template>
         </Column>
 
-        <Column field="namespace" sortable header="Namespace" :showFilterMenu="false" :showClearButton="false">
+        <Column field="namespace" header="Namespace" :showFilterMenu="false" :showClearButton="false">
             <template #filter v-if="props.showColumnFilters">
                 <InputText v-model="filters['namespace'].value" placeholder="Filter by namespace" />
             </template>

--- a/web/explorer/src/components/columns/RuleColumn.vue
+++ b/web/explorer/src/components/columns/RuleColumn.vue
@@ -75,9 +75,7 @@ defineProps({
 const getTooltipContent = (data) => {
     if (data.typeValue === "number" || data.typeValue === "offset") {
         const decimalValue = parseInt(data.name, 16);
-        const octalValue = "0o" + decimalValue.toString(8);
-        return `Decimal: ${decimalValue}
-Octal: ${octalValue}`;
+        return `Decimal: ${decimalValue}`;
     }
     return null;
 };

--- a/web/explorer/src/components/columns/RuleColumn.vue
+++ b/web/explorer/src/components/columns/RuleColumn.vue
@@ -31,7 +31,15 @@
         <template v-else-if="node.data.type === 'feature'">
             <span>
                 - {{ node.data.typeValue }}:
-                <span :class="{ 'text-green-700': node.data.typeValue !== 'regex' }" class="font-monospace">
+                <span
+                    :class="{ 'text-green-700': node.data.typeValue !== 'regex' }"
+                    class="font-monospace"
+                    v-tooltip.top="{
+                        value: getTooltipContent(node.data),
+                        showDelay: 1000,
+                        hideDelay: 300
+                    }"
+                >
                     {{ node.data.name }}
                 </span>
             </span>
@@ -63,4 +71,14 @@ defineProps({
         required: true
     }
 });
+
+const getTooltipContent = (data) => {
+    if (data.typeValue === "number" || data.typeValue === "offset") {
+        const decimalValue = parseInt(data.name, 16);
+        const octalValue = "0o" + decimalValue.toString(8);
+        return `Decimal: ${decimalValue}
+Octal: ${octalValue}`;
+    }
+    return null;
+};
 </script>


### PR DESCRIPTION
This PR resolves the items:
> - [x] allow users to hover over a hex feature value to view its decimal representation
> - [x] show capas by function: include file level matches in section as a table row


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
