### PR TITLE
web: don't include preview data and options in release mode

### DIFF
--- a/web/explorer/src/components/NavBar.vue
+++ b/web/explorer/src/components/NavBar.vue
@@ -1,6 +1,8 @@
 <script setup>
 import Menubar from "primevue/menubar";
 import { RouterLink } from "vue-router";
+
+const isBundle = import.meta.env.MODE === "bundle";
 </script>
 
 <template>
@@ -13,8 +15,9 @@ import { RouterLink } from "vue-router";
         <template #end>
             <div class="flex align-items-center gap-3">
                 <a
+                    v-if="!isBundle"
                     v-ripple
-                    v-tooltip.right="'Download capa Explorer Web for offline usage'"
+                    v-tooltip.bottom="'Download capa Explorer Web for offline usage'"
                     href="./capa-explorer-web.zip"
                     download="capa-explorer-web.zip"
                     aria-label="Download capa Explorer Web release"

--- a/web/explorer/src/components/RuleMatchesTable.vue
+++ b/web/explorer/src/components/RuleMatchesTable.vue
@@ -49,7 +49,7 @@
             </template>
         </Column>
 
-        <!-- Address column (only shown in static flavors)  -->
+        <!-- Address column (only shown for static flavor)  -->
         <Column
             v-if="props.data.meta.flavor === 'static'"
             field="address"

--- a/web/explorer/src/components/RuleMatchesTable.vue
+++ b/web/explorer/src/components/RuleMatchesTable.vue
@@ -3,7 +3,7 @@
         :value="filteredTreeData"
         v-model:expandedKeys="expandedKeys"
         size="small"
-        scrollable
+        :scrollable="true"
         :filters="filters"
         :filterMode="filterMode"
         sortField="namespace"
@@ -252,7 +252,6 @@ const onRightClick = (event, instance) => {
         selectedNode.value = instance.node;
 
         // show the context menu
-        console.log(menu);
         menu.value.show(event);
     }
 };

--- a/web/explorer/src/components/RuleMatchesTable.vue
+++ b/web/explorer/src/components/RuleMatchesTable.vue
@@ -49,10 +49,11 @@
             </template>
         </Column>
 
-        <!-- Address/Process column  -->
+        <!-- Address column (only shown in static flavors)  -->
         <Column
+            v-if="props.data.meta.flavor === 'static'"
             field="address"
-            :header="props.data.meta.flavor === 'dynamic' ? 'Process' : 'Address'"
+            header="Address"
             filterMatchMode="contains"
             style="width: 8.5%"
             class="cursor-default"

--- a/web/explorer/src/components/UploadOptions.vue
+++ b/web/explorer/src/components/UploadOptions.vue
@@ -38,7 +38,10 @@
                     </Divider>
 
                     <div class="flex-grow-1 flex align-items-center justify-content-center">
-                        <Button label="Preview Static" @click="$emit('load-demo-static')" class="p-button" />
+                        <Button
+                            label="Preview Static"
+                            @click="router.push({ path: '/', query: { rdoc: staticURL } })"
+                        />
                     </div>
 
                     <Divider layout="vertical" class="hidden-mobile">
@@ -48,7 +51,10 @@
                         <b>OR</b>
                     </Divider>
                     <div class="flex-grow-1 flex align-items-center justify-content-center">
-                        <Button label="Preview Dynamic" @click="$emit('load-demo-dynamic')" class="p-button" />
+                        <Button
+                            label="Preview Static"
+                            @click="router.push({ path: '/', query: { rdoc: dynamicURL } })"
+                        />
                     </div>
                 </template>
             </div>
@@ -65,10 +71,17 @@ import FloatLabel from "primevue/floatlabel";
 import InputText from "primevue/inputtext";
 import Button from "primevue/button";
 
+import { useRouter } from "vue-router";
+const router = useRouter();
+
 const loadURL = ref("");
 const isBundle = import.meta.env.MODE === "bundle";
 
-defineEmits(["load-from-local", "load-from-url", "load-demo-static", "load-demo-dynamic"]);
+defineEmits(["load-from-local", "load-from-url"]);
+
+const dynamicURL =
+    "https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json";
+const staticURL = "https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/al-khaser_x64.exe_.json";
 </script>
 
 <style scoped>

--- a/web/explorer/src/components/UploadOptions.vue
+++ b/web/explorer/src/components/UploadOptions.vue
@@ -29,28 +29,28 @@
                     </FloatLabel>
                     <Button icon="pi pi-arrow-right" @click="$emit('load-from-url', loadURL)" :disabled="!loadURL" />
                 </div>
+                <template v-if="!isBundle">
+                    <Divider layout="vertical" class="hidden-mobile">
+                        <b>OR</b>
+                    </Divider>
+                    <Divider layout="horizontal" class="visible-mobile" align="center">
+                        <b>OR</b>
+                    </Divider>
 
-                <Divider layout="vertical" class="hidden-mobile">
-                    <b>OR</b>
-                </Divider>
-                <Divider layout="horizontal" class="visible-mobile" align="center">
-                    <b>OR</b>
-                </Divider>
+                    <div class="flex-grow-1 flex align-items-center justify-content-center">
+                        <Button label="Preview Static" @click="$emit('load-demo-static')" class="p-button" />
+                    </div>
 
-                <div class="flex-grow-1 flex align-items-center justify-content-center">
-                    <Button label="Preview Static" @click="$emit('load-demo-static')" class="p-button" />
-                </div>
-
-                <Divider layout="vertical" class="hidden-mobile">
-                    <b>OR</b>
-                </Divider>
-                <Divider layout="horizontal" class="visible-mobile" align="center">
-                    <b>OR</b>
-                </Divider>
-
-                <div class="flex-grow-1 flex align-items-center justify-content-center">
-                    <Button label="Preview Dynamic" @click="$emit('load-demo-dynamic')" class="p-button" />
-                </div>
+                    <Divider layout="vertical" class="hidden-mobile">
+                        <b>OR</b>
+                    </Divider>
+                    <Divider layout="horizontal" class="visible-mobile" align="center">
+                        <b>OR</b>
+                    </Divider>
+                    <div class="flex-grow-1 flex align-items-center justify-content-center">
+                        <Button label="Preview Dynamic" @click="$emit('load-demo-dynamic')" class="p-button" />
+                    </div>
+                </template>
             </div>
         </template>
     </Card>
@@ -66,6 +66,7 @@ import InputText from "primevue/inputtext";
 import Button from "primevue/button";
 
 const loadURL = ref("");
+const isBundle = import.meta.env.MODE === "bundle";
 
 defineEmits(["load-from-local", "load-from-url", "load-demo-static", "load-demo-dynamic"]);
 </script>

--- a/web/explorer/src/components/UploadOptions.vue
+++ b/web/explorer/src/components/UploadOptions.vue
@@ -80,7 +80,7 @@ const isBundle = import.meta.env.MODE === "bundle";
 defineEmits(["load-from-local", "load-from-url"]);
 
 const dynamicURL =
-    "https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json";
+    "https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz";
 const staticURL = "https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/al-khaser_x64.exe_.json";
 </script>
 

--- a/web/explorer/src/components/UploadOptions.vue
+++ b/web/explorer/src/components/UploadOptions.vue
@@ -52,7 +52,7 @@
                     </Divider>
                     <div class="flex-grow-1 flex align-items-center justify-content-center">
                         <Button
-                            label="Preview Static"
+                            label="Preview Dynamic"
                             @click="router.push({ path: '/', query: { rdoc: dynamicURL } })"
                         />
                     </div>

--- a/web/explorer/src/components/columns/RuleColumn.vue
+++ b/web/explorer/src/components/columns/RuleColumn.vue
@@ -11,7 +11,7 @@
 
         <!-- example node: "basic block @ 0x401000" or "explorer.exe" -->
         <template v-else-if="node.data.type === 'match location'">
-            <span class="text-sm font-italic">{{ node.data.name }}</span>
+            <span class="text-sm font-monospace text-xs">{{ node.data.name }}</span>
         </template>
 
         <!-- example node: "- or", "- and" -->

--- a/web/explorer/src/components/columns/RuleColumn.vue
+++ b/web/explorer/src/components/columns/RuleColumn.vue
@@ -52,7 +52,7 @@
 
         <!-- example node: "exit(0) -> 0" (if the node type is call-info, we highlight node.data.name.callInfo) -->
         <template v-else-if="node.data.type === 'call-info'">
-            <highlightjs lang="c" :code="node.data.name.callInfo" />
+            <highlightjs lang="c" :code="node.data.name.callInfo" class="text-xs" />
         </template>
 
         <!-- example node: " = IMAGE_NT_SIGNATURE (PE)" -->

--- a/web/explorer/src/composables/useRdocLoader.js
+++ b/web/explorer/src/composables/useRdocLoader.js
@@ -3,7 +3,7 @@ import { isGzipped, decompressGzip, readFileAsText } from "@/utils/fileUtils";
 
 export function useRdocLoader() {
     const toast = useToast();
-    const MIN_SUPPORTED_VERSION = "7.0.0";
+    const MIN_SUPPORTED_VERSION = "6.1.0";
 
     /**
      * Checks if the loaded rdoc version is supported

--- a/web/explorer/src/composables/useRdocLoader.js
+++ b/web/explorer/src/composables/useRdocLoader.js
@@ -45,13 +45,7 @@ export function useRdocLoader() {
                 }
                 data = await response.json();
             } else if (source instanceof File) {
-                let fileContent;
-                if (await isGzipped(source)) {
-                    fileContent = await decompressGzip(source);
-                } else {
-                    fileContent = await readFileAsText(source);
-                }
-                data = JSON.parse(fileContent);
+                data = await processFile(source);
             } else if (typeof source === "object") {
                 // Direct JSON object (Preview options)
                 data = source;
@@ -73,13 +67,23 @@ export function useRdocLoader() {
             console.error("Error loading JSON:", error);
             toast.add({
                 severity: "error",
-                summary: "Error",
-                detail: "Failed to process the file. Please ensure it's a valid JSON or gzipped JSON file.",
+                summary: "Failed to process the file",
+                detail: error,
                 life: 3000,
                 group: "bc" // bottom-center
             });
         }
         return null;
+    };
+
+    const processFile = async (blob) => {
+        let fileContent;
+        if (await isGzipped(blob)) {
+            fileContent = await decompressGzip(blob);
+        } else {
+            fileContent = await readFileAsText(blob);
+        }
+        return JSON.parse(fileContent);
     };
 
     return {

--- a/web/explorer/src/utils/rdocParser.js
+++ b/web/explorer/src/utils/rdocParser.js
@@ -3,10 +3,10 @@
  * @param {Object} rules - The rules object from the rodc JSON data
  * @param {string} flavor - The flavor of the analysis (static or dynamic)
  * @param {Object} layout - The layout object from the rdoc JSON data
- * @param {number} [maxMatches=1] - Maximum number of matches to parse per rule
+ * @param {number} [maxMatches=30] - Maximum number of matches to parse per rule
  * @returns {Array} - Parsed tree data for the TreeTable component
  */
-export function parseRules(rules, flavor, layout, maxMatches = 1) {
+export function parseRules(rules, flavor, layout, maxMatches = 30) {
     return Object.entries(rules).map(([, rule], index) => {
         const ruleNode = {
             key: `${index}`,

--- a/web/explorer/src/views/ImportView.vue
+++ b/web/explorer/src/views/ImportView.vue
@@ -16,15 +16,15 @@ import DescriptionPanel from "@/components/DescriptionPanel.vue";
 import UploadOptions from "@/components/UploadOptions.vue";
 
 const isBundle = import.meta.env.MODE === "bundle";
-const demoRdocStatic = null;
-const demoRdocDynamic = null;
+let demoRdocStatic = null;
+let demoRdocDynamic = null;
 
 if (!isBundle) {
     import("@testfiles/rd/al-khaser_x64.exe_.json").then((module) => {
-        demoRdocStatic.value = module.default;
+        demoRdocStatic = module.default;
     });
     import("@testfiles/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz").then((module) => {
-        demoRdocDynamic.value = module.default;
+        demoRdocDynamic = module.default;
     });
 }
 
@@ -52,6 +52,7 @@ const loadFromURL = async (url) => {
     const result = await loadRdoc(url);
     if (result) {
         rdocStore.setData(result);
+        console.log(result);
         router.push({ name: "analysis", query: { rdoc: url } });
     }
 };

--- a/web/explorer/src/views/ImportView.vue
+++ b/web/explorer/src/views/ImportView.vue
@@ -10,8 +10,6 @@ import { watch } from "vue";
 import DescriptionPanel from "@/components/DescriptionPanel.vue";
 import UploadOptions from "@/components/UploadOptions.vue";
 
-const isBundle = import.meta.env.MODE === "bundle";
-
 // import router utils
 import { useRouter, useRoute } from "vue-router";
 const router = useRouter();
@@ -36,7 +34,6 @@ const loadFromURL = async (url) => {
     const result = await loadRdoc(url);
     if (result) {
         rdocStore.setData(result);
-        console.log(result);
         router.push({ name: "analysis", query: { rdoc: url } });
     }
 };

--- a/web/explorer/src/views/ImportView.vue
+++ b/web/explorer/src/views/ImportView.vue
@@ -1,11 +1,6 @@
 <template>
     <DescriptionPanel />
-    <UploadOptions
-        @load-from-local="loadFromLocal"
-        @load-from-url="loadFromURL"
-        @load-demo-static="loadDemoDataStatic"
-        @load-demo-dynamic="loadDemoDataDynamic"
-    />
+    <UploadOptions @load-from-local="loadFromLocal" @load-from-url="loadFromURL" />
 </template>
 
 <script setup>
@@ -16,17 +11,6 @@ import DescriptionPanel from "@/components/DescriptionPanel.vue";
 import UploadOptions from "@/components/UploadOptions.vue";
 
 const isBundle = import.meta.env.MODE === "bundle";
-let demoRdocStatic = null;
-let demoRdocDynamic = null;
-
-if (!isBundle) {
-    import("@testfiles/rd/al-khaser_x64.exe_.json").then((module) => {
-        demoRdocStatic = module.default;
-    });
-    import("@testfiles/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz").then((module) => {
-        demoRdocDynamic = module.default;
-    });
-}
 
 // import router utils
 import { useRouter, useRoute } from "vue-router";
@@ -54,22 +38,6 @@ const loadFromURL = async (url) => {
         rdocStore.setData(result);
         console.log(result);
         router.push({ name: "analysis", query: { rdoc: url } });
-    }
-};
-
-const loadDemoDataStatic = async () => {
-    const result = await loadRdoc(demoRdocStatic);
-    if (result) {
-        rdocStore.setData(result);
-        router.push("/analysis");
-    }
-};
-
-const loadDemoDataDynamic = async () => {
-    const result = await loadRdoc(demoRdocDynamic);
-    if (result) {
-        rdocStore.setData(result);
-        router.push("/analysis");
     }
 };
 

--- a/web/explorer/src/views/ImportView.vue
+++ b/web/explorer/src/views/ImportView.vue
@@ -15,9 +15,18 @@ import { watch } from "vue";
 import DescriptionPanel from "@/components/DescriptionPanel.vue";
 import UploadOptions from "@/components/UploadOptions.vue";
 
-// import demo data
-import demoRdocStatic from "@testfiles/rd/al-khaser_x64.exe_.json";
-import demoRdocDynamic from "@testfiles/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json";
+const isBundle = import.meta.env.MODE === "bundle";
+const demoRdocStatic = null;
+const demoRdocDynamic = null;
+
+if (!isBundle) {
+    import("@testfiles/rd/al-khaser_x64.exe_.json").then((module) => {
+        demoRdocStatic.value = module.default;
+    });
+    import("@testfiles/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz").then((module) => {
+        demoRdocDynamic.value = module.default;
+    });
+}
 
 // import router utils
 import { useRouter, useRoute } from "vue-router";
@@ -50,7 +59,7 @@ const loadFromURL = async (url) => {
 const loadDemoDataStatic = async () => {
     const result = await loadRdoc(demoRdocStatic);
     if (result) {
-        rdocStore.setData(demoRdocStatic);
+        rdocStore.setData(result);
         router.push("/analysis");
     }
 };
@@ -58,7 +67,7 @@ const loadDemoDataStatic = async () => {
 const loadDemoDataDynamic = async () => {
     const result = await loadRdoc(demoRdocDynamic);
     if (result) {
-        rdocStore.setData(demoRdocDynamic);
+        rdocStore.setData(result);
         router.push("/analysis");
     }
 };

--- a/web/explorer/vite.config.js
+++ b/web/explorer/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => {
                 "@": fileURLToPath(new URL("src", import.meta.url)),
                 "@testfiles": fileURLToPath(new URL("../../tests/data", import.meta.url))
             }
-        }
+        },
+        assetsInclude: ["**/*.gz"]
     };
 });


### PR DESCRIPTION
closes #2285
closes #2259 

This PR -
- disables the preview data buttons from being displayed and excludes the test files from the build and release.
- bumps the number of matches in dynamic to 300 instead of 1 (still slow, but manageable)
- extend `rdoc` query param to support loading remote `.gz` files.
- refactors `parseRules` used to parse the rdoc rules.

Please preview this PR here: https://s-ff.github.io/capa/explorer



### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
