### PR TITLE
web: add umami script for collecting metrics

### DIFF
--- a/web/explorer/index.html
+++ b/web/explorer/index.html
@@ -5,6 +5,7 @@
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Capa Explorer</title>
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="0bb8ff9e-fbcc-4ee2-9f9f-b337a2e8cc7f"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -34,6 +34,7 @@
         isolation: isolate;
       }
     </style>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="0bb8ff9e-fbcc-4ee2-9f9f-b337a2e8cc7f"></script>
   </head>
   <body>
     


### PR DESCRIPTION
[x] No CHANGELOG update needed

Public metrics URL here: https://cloud.umami.is/share/rVo8TE6uNFsCi0aw/mandiant.github.io

We plan to use this analytics script to collect pageview metrics, since the capa website is hosted on GH Pages and they don't share the raw access logs. Umami is a privacy focused analytics solution, and we're impressed by their commitments and open source releases. We publish the above link so that its clear to anyone the sorts of information that are collected: # of page loads over time, essentially.