### PR TITLE
add .justfile

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,0 +1,20 @@
+@isort:
+    pre-commit run isort --show-diff-on-failure --all-files
+
+@black:
+    pre-commit run black --show-diff-on-failure --all-files
+
+@ruff:
+    pre-commit run ruff --all-files
+
+@flake8:
+    pre-commit run flake8 --hook-stage manual --all-files
+
+@mypy:
+    pre-commit run mypy --hook-stage manual --all-files
+
+@deptry:
+    pre-commit run deptry --hook-stage manual --all-files
+
+lint: isort black ruff flake8 mypy deptry
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - add landing page https://mandiant.github.io/capa/ @williballenthin #2310
 - add rules website https://mandiant.github.io/capa/rules @DeeyaSingh #2310
-
+- add .justfile @williballenthin #2325
+ 
 ### Breaking Changes
 
 ### New Rules (0)


### PR DESCRIPTION
This PR adds a "justfile", which is a configuration file for the tool [just](https://github.com/casey/just). Just is a command runner, like a simplified Make.

I've been having trouble remembering the pre-commit command line invocations needed to run the various linters. Some need `--hook-stage manual` and others don't. Usually I use my shell's history to find the command I need, but its painful when I move to a new system. I want to use Just to hide all these extra flags away, so I can just type:

```console
just isort
```
![image](https://github.com/user-attachments/assets/6524a160-b0f5-4d51-a696-43cf7cc8ccd0)


```console
just isort black
```
![image](https://github.com/user-attachments/assets/debdeb7d-9a3d-4827-8b86-bee8acaa825a)


```console
just lint
```
![image](https://github.com/user-attachments/assets/86213702-f3db-40d1-947d-bf873550e4d1)


The configuration file is hidden, that is, the filename is `.justfile`, so it won't show up in most directory listings. I'm not sure that we have to add even more documentation about this file, though I'm happy to do so if we expect enough users. Otherwise, its nice for the file to be present, but doesn't affect anything otherwise.

We could optionally migrate from pre-commit to Just, but I don't think we should. pre-commit has nice git integration, it already works for us, and churn is annoying. 




### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
