### PR TITLE
web: fix class feature type

### DIFF
--- a/web/explorer/src/utils/rdocParser.js
+++ b/web/explorer/src/utils/rdocParser.js
@@ -490,6 +490,8 @@ function getFeatureName(feature) {
             return formatBytes(feature.bytes);
         case "operand offset":
             return `operand[${feature.index}].offset: 0x${feature.operand_offset.toString(16).toUpperCase()}`;
+        case "class":
+            return `${feature.class_}`;
         default:
             return `${feature[feature.type]}`;
     }


### PR DESCRIPTION
capa JSON output with dnfile uses `class_` instead of `class` for feature types. This PR fixes a bug that shows undefined for `class` feature types.

Example: rule `encrypt data using AES via .NET` in https://mandiant.github.io/capa/explorer/#/?rdoc=https://dpaste.org/wEWd9/raw

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
