### PR TITLE
web: omit unneeded function param in createCapaRulesUrl

### DIFF
--- a/web/explorer/src/utils/urlHelpers.js
+++ b/web/explorer/src/utils/urlHelpers.js
@@ -53,15 +53,14 @@ export function createATTACKHref(attack) {
 }
 
 /**
- * Creates a CAPA rules URL for a given node with tag.
+ * Creates an href for a given rule in the rules website
  *
- * @param {Object} node - The node object containing data about the rule.
- * @param {string} node.data.namespace - The namespace of the rule (optional).
+ * @param {Object} node - The node object
  * @param {string} node.data.name - The name of the rule.
- * @returns {string} The formatted CAPA rules URL.
+ * @returns {string} The formatted capa rules URL.
  */
-export function createCapaRulesUrl(node, tag) {
-    if (!node || !node.data || !tag) return null;
+export function createCapaRulesUrl(node) {
+    if (!node || !node.data) return null;
     const ruleName = node.data.name.toLowerCase().replace(/\s+/g, "-");
     return `https://mandiant.github.io/capa/rules/${ruleName}/`;
 }


### PR DESCRIPTION
resolves https://github.com/mandiant/capa/pull/2338#issuecomment-2318270162
remove `tag` param from the function definition, otherwise this function will always return `null` 

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
