### PR TITLE
match BinExport2 instructions using patterns

### DIFF
--- a/capa/features/extractors/binexport2/__init__.py
+++ b/capa/features/extractors/binexport2/__init__.py
@@ -104,6 +104,7 @@ class BinExport2Index:
         self.string_reference_index_by_source_instruction_index: Dict[int, List[int]] = defaultdict(list)
 
         self.insn_address_by_index: Dict[int, int] = {}
+        self.insn_index_by_address: Dict[int, int] = {}
         self.insn_by_address: Dict[int, BinExport2.Instruction] = {}
 
         # must index instructions first
@@ -187,6 +188,7 @@ class BinExport2Index:
                 addr = next_addr
                 next_addr += len(insn.raw_bytes)
             self.insn_address_by_index[idx] = addr
+            self.insn_index_by_address[addr] = idx
             self.insn_by_address[addr] = insn
 
     @staticmethod

--- a/capa/features/extractors/binexport2/__init__.py
+++ b/capa/features/extractors/binexport2/__init__.py
@@ -9,6 +9,9 @@
 Proto files generated via protobuf v24.4:
 
     protoc --python_out=. --mypy_out=. binexport2.proto
+
+from BinExport2 at 6916731d5f6693c4a4f0a052501fd3bd92cfd08b
+https://github.com/google/binexport/blob/6916731/binexport2.proto
 """
 import io
 import hashlib

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -818,7 +818,9 @@ FEATURE_PRESENCE_TESTS = sorted(
         ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x8), False),
         ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x10), False),
         # insn/offset: negative
+        # 0x4012b4  MOVZX       ECX, [EAX+0xFFFFFFFFFFFFFFFF]
         ("mimikatz", "function=0x4011FB", capa.features.insn.Offset(-0x1), True),
+        # 0x4012b8  MOVZX       EAX, [EAX+0xFFFFFFFFFFFFFFFE]
         ("mimikatz", "function=0x4011FB", capa.features.insn.Offset(-0x2), True),
         #
         # insn/offset from mnemonic: add
@@ -841,7 +843,7 @@ FEATURE_PRESENCE_TESTS = sorted(
         # should not be considered, lea operand invalid encoding
         #    .text:004717B1 8D 4C 31 D0             lea     ecx, [ecx+esi-30h]
         ("mimikatz", "function=0x47153B,bb=0x4717AB,insn=0x4717B1", capa.features.insn.Number(-0x30), False),
-        # yes, this is also a number (imagine edx is zero):
+        # yes, this is also a number (imagine ebx is zero):
         #    .text:004018C0 8D 4B 02                lea     ecx, [ebx+2]
         ("mimikatz", "function=0x401873,bb=0x4018B2,insn=0x4018C0", capa.features.insn.Number(0x2), True),
         # insn/api

--- a/tests/test_binexport_accessors.py
+++ b/tests/test_binexport_accessors.py
@@ -200,7 +200,6 @@ def test_get_instruction_operands_count():
         # 00210184 02 68 61 38     ldrb       w2,[x0, x1, LSL ]
         #                                                 ^^^ issue in Ghidra?
         #  IDA gives               LDRB       W2, [X0,X1]
-        # still need to test/handle this and it's the only complex operand expression in this test binary :/
         (
             0x210184,
             (
@@ -210,8 +209,6 @@ def test_get_instruction_operands_count():
                     BinExport2.Expression(type=BinExport2.Expression.REGISTER, symbol="x0"),
                     BinExport2.Expression(type=BinExport2.Expression.OPERATOR, symbol=","),
                     BinExport2.Expression(type=BinExport2.Expression.REGISTER, symbol="x1"),
-                    BinExport2.Expression(type=BinExport2.Expression.OPERATOR, symbol=","),
-                    BinExport2.Expression(type=BinExport2.Expression.REGISTER, symbol="LSL"),
                     BinExport2.Expression(type=BinExport2.Expression.DEREFERENCE, symbol="]"),
                 ),
             ),


### PR DESCRIPTION
This PR against the BinExport2 PR introduces a way to match instructions and extract expression values. We use this mini-language to specify how to extract features from BinExport2 instructions, such as Number, Offset, nzxor, etc. While there's a fair amount of code (~500 lines, with tests) to implement this matching language, it is:

  1. more human readable
  2. less fragile
  3. better tested
  4. and therefore more maintainable (I think).


To understand all the changes here, I'd recommend reading:

  1. https://github.com/mandiant/capa/commit/2cff6333c1ac83dc514eec61656d2a4ff19c2c51: consolidate expression tree handling. Specifically, this introduces fixes for Ghidra BinExport2 containing `lsl #0` expressions that have no effect. We prune these from the expression tree.
  2. https://github.com/mandiant/capa/commit/76eed3d9fc3a1b7bab9b4295ea7da6ecd8fe2aad: introduce instruction patterns. Start by looking at the tests (maybe bottom up) so you see *what* the routines do, and then read how they do it. I think the performance *should* be similiar to hand-written code, but I'd be curious if you can prove me wrong.



### Checklist

- [x] No CHANGELOG update needed
- [x] No documentation update needed
