### PR TITLE
bump upload size limit to 100MB from 10MB

### DIFF
--- a/web/explorer/src/components/UploadOptions.vue
+++ b/web/explorer/src/components/UploadOptions.vue
@@ -5,7 +5,7 @@
                 mode="basic"
                 name="model[]"
                 accept=".json,.gz"
-                :max-file-size="10000000"
+                :max-file-size="100000000"
                 :auto="true"
                 :custom-upload="true"
                 choose-label="Upload from local"


### PR DESCRIPTION
closes #2398 


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
