### PR TITLE
loader: fix unhandled name error

### DIFF
--- a/capa/loader.py
+++ b/capa/loader.py
@@ -171,6 +171,7 @@ def get_workspace(path: Path, input_format: str, sigpaths: List[Path]):
         # to do a subclass check via isinstance.
         if type(e) is Exception and "Couldn't convert rva" in e.args[0]:
             raise CorruptFile(e.args[0]) from e
+        raise
 
     viv_utils.flirt.register_flirt_signature_analyzers(vw, [str(s) for s in sigpaths])
 


### PR DESCRIPTION
it was possible that loading the workspace could raise an exception that would get swallowed, but `vw` wasn't bound. this ensures the exception is always raised.

the exception that i saw get swallowed was "unsupported architecture" like 32-bit armv8.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
