### PR TITLE
capa Explorer Web: improve url navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### capa explorer IDA Pro plugin
 
 ### Development
+- capa Explorer Web: improve navigation in capa Explorer Web
 
 ### Raw diffs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,10 @@
 - replace tabulate, tqdm, and termcolor with rich #2374 @s-ff
 - dynamic: emit complete features for A/W APIs #2409 @mike-hunhoff
 
-### capa explorer IDA Pro plugin
-
 ### capa Explorer Web
 - improve navigation in capa Explorer Web @s-ff #2425
 
+### capa Explorer IDA Pro plugin
 ### Development
 
 ### Raw diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - improve navigation in capa Explorer Web @s-ff #2425
 
 ### capa Explorer IDA Pro plugin
+
 ### Development
 
 ### Raw diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,10 @@
 
 ### capa explorer IDA Pro plugin
 
+### capa Explorer Web
+- improve navigation in capa Explorer Web @s-ff #2425
+
 ### Development
-- capa Explorer Web: improve navigation in capa Explorer Web
 
 ### Raw diffs
 

--- a/web/explorer/src/router/index.js
+++ b/web/explorer/src/router/index.js
@@ -18,12 +18,20 @@ const router = createRouter({
             name: "analysis",
             component: AnalysisView,
             beforeEnter: (to, from, next) => {
-                if (rdocStore.data.value === null) {
-                    // No rdoc loaded, redirect to home page
-                    next({ name: "home" });
-                } else {
-                    // rdoc is loaded, proceed to analysis page
+                // check if rdoc is loaded
+                if (rdocStore.data.value !== null) {
+                    // rdocStore.data already contains the rdoc json - continue
                     next();
+                } else {
+                    // rdoc is not loaded, check if the rdoc query param is set in the URL
+                    const rdocUrl = to.query.rdoc;
+                    if (rdocUrl) {
+                        // query param is set - try to load the rdoc from the homepage
+                        next({ name: "home", query: { rdoc: rdocUrl } });
+                    } else {
+                        // no query param is set - go back home
+                        next({ name: "home" });
+                    }
                 }
             }
         },


### PR DESCRIPTION
closes #2419 

This PR enhances the navigation in capa Explorer Web by making sure the links generated are shareable. [Preview](https://s-ff.github.io/capa/explorer/#/analysis?rdoc=https://raw.githubusercontent.com/mandiant/capa-testfiles/master/rd/al-khaser_x64.exe_.json).

Previously: users browsing to `/analysis` were always redirected to the homepage `/`.

With this PR:
- If a user accesses `/analysis` without an rdoc query parameter set in the URL, they are still redirected to the homepage.
- If a user accesses `/analysis` with the rdoc query parameter set, capa Explorer Web loads from that URL instead of redirecting to homepage.


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
