### PR TITLE
Fix/corrupted file architecture key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- extractor: fix exception when PE extractor encounters unknown architecture #2440 @Tamir-K
+
 ### capa Explorer Web
 
 ### capa Explorer IDA Pro plugin

--- a/capa/features/extractors/pefile.py
+++ b/capa/features/extractors/pefile.py
@@ -130,7 +130,13 @@ def extract_file_arch(pe, **kwargs):
     elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]:
         yield Arch(ARCH_AMD64), NO_ADDRESS
     else:
-        logger.warning("unsupported architecture: %s", pefile.MACHINE_TYPE[pe.FILE_HEADER.Machine])
+        try:
+            logger.warning(
+                "unsupported architecture: %s",
+                pefile.MACHINE_TYPE[pe.FILE_HEADER.Machine],
+            )
+        except KeyError:
+            logger.warning("unknown architecture: %s", pe.FILE_HEADER.Machine)
 
 
 def extract_file_features(pe, buf):


### PR DESCRIPTION
Handles key error when machine type from PE file header doesn't match any value in the MACHINE_TYPE dictionary from the pefile module.

closes #2440