### PR TITLE
binja: retrieve the LLIL instruction itself without requesting the entire IL function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - ghidra: fix saving of base address @mr-tz
 - binja: support loading raw x86/x86_64 shellcode #2489 @xusheng6
 - binja: fix crash when the IL of certain functions are not available. #2249 @xusheng6
+- binja: major performance improvement on the binja extractor. #1414 @xusheng6
 
 ### capa Explorer Web
 

--- a/capa/features/extractors/binja/helpers.py
+++ b/capa/features/extractors/binja/helpers.py
@@ -6,10 +6,10 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import re
-from typing import Callable
+from typing import Callable, Optional
 from dataclasses import dataclass
 
-from binaryninja import BinaryView, LowLevelILInstruction
+from binaryninja import BinaryView, LowLevelILFunction, LowLevelILInstruction
 from binaryninja.architecture import InstructionTextToken
 
 
@@ -67,3 +67,13 @@ def read_c_string(bv: BinaryView, offset: int, max_len: int) -> str:
         s.append(chr(c))
 
     return "".join(s)
+
+
+def get_llil_instr_at_addr(bv: BinaryView, addr: int) -> Optional[LowLevelILInstruction]:
+    arch = bv.arch
+    buffer = bv.read(addr, arch.max_instr_length)
+    llil = LowLevelILFunction(arch=arch)
+    llil.current_address = addr
+    if arch.get_instruction_low_level_il(buffer, addr, llil) == 0:
+        return None
+    return llil[0]


### PR DESCRIPTION
This is part of the effort to optimize the binja extractor performance (#1414). As I mentioned in https://github.com/mandiant/capa/pull/2509#issuecomment-2507409096, one of the outstanding issue that drags down the binja extractor performance is the re-generation of the IL functions during feature extraction. Those are, however, necessary to ensure the most accurate results.

That said, I found that we can actually just retrieve a single LLIL instruction instead of requesting the entire IL from the function. Getting an LLIL instruction is extremely fast compared to getting the entire IL function and then take the particular instruction from it. 

Here is what I am getting as a difference:

1. For a small file (321338196a46b600ea330fc5d98d0699.exe_, 486 KB in size), the feature extracting time (excluding the initial analysis time) is down from 45 seconds to 32 seconds
2. For a large file (2f7f5fb5de175e770d7eae87666f9831.elf_, 4.1 MB in size), the feature extracting time is down from 15 minutes to 5 minutes. Which is 300% performance improvement! Apparently the IL regeneration issue becomes more severe as the file grows bigger. 

With the change, the extractor is strictly accessing the functions in a sequential order and they never request the IL of a different function, so there is no regeneration of the IL. I also tested the MLIL basic block things, and it makes no noticeable performance gain even if I completely disable the stack string check. In this sense, there is not much motivation to chase after that part. 

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
