### PR TITLE
binja: fix up analysis for the al-khaser_x64.exe_ file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - binja: fix crash when the IL of certain functions are not available. #2249 @xusheng6
 - binja: major performance improvement on the binja extractor. #1414 @xusheng6
 - cape: make Process model flexible and procmemory optional to load newest reports #2466 @mr-tz
+- binja: fix unit test failure by fixing up the analysis for file al-khaser_x64.exe_ #2507 @xusheng6
 
 ### capa Explorer Web
 

--- a/capa/features/extractors/binja/insn.py
+++ b/capa/features/extractors/binja/insn.py
@@ -45,14 +45,15 @@ def is_stub_function(bv: BinaryView, addr: int) -> Optional[int]:
     ]:
         return None
 
-    if llil.dest.value.type not in [
-        RegisterValueType.ImportedAddressValue,
-        RegisterValueType.ConstantValue,
-        RegisterValueType.ConstantPointerValue,
+    # The LLIL instruction retrieved by `get_llil_instr_at_addr` did not go through a full analysis, so we cannot check
+    # `llil.dest.value.type` here
+    if llil.dest.operation not in [
+        LowLevelILOperation.LLIL_CONST,
+        LowLevelILOperation.LLIL_CONST_PTR,
     ]:
         return None
 
-    return llil.dest.value.value
+    return llil.dest.constant
 
 
 def extract_insn_api_features(fh: FunctionHandle, bbh: BBHandle, ih: InsnHandle) -> Iterator[tuple[Feature, Address]]:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -180,6 +180,12 @@ def get_binja_extractor(path: Path):
     if path.name.endswith("kernel32-64.dll_"):
         settings.set_bool("pdb.loadGlobalSymbols", old_pdb)
 
+    # TODO(xusheng6): Temporary fix for https://github.com/mandiant/capa/issues/2507. Remove this once it is fixed in
+    # binja
+    if "al-khaser_x64.exe_" in path.name:
+        bv.create_user_function(0x14004B4F0)
+        bv.update_analysis_and_wait()
+
     extractor = capa.features.extractors.binja.extractor.BinjaFeatureExtractor(bv)
 
     # overload the extractor so that the fixture exposes `extractor.path`

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -40,10 +40,6 @@ except ImportError:
     indirect=["sample", "scope"],
 )
 def test_binja_features(sample, scope, feature, expected):
-    # TODO(mr-tz): BinaryNinja does not recognize this function
-    # https://github.com/mandiant/capa/issues/2507
-    if scope.__name__ == "function=0x14004B4F0":
-        pytest.xfail("BinaryNinja does not recognize this function")
     fixtures.do_test_feature_presence(fixtures.get_binja_extractor, sample, scope, feature, expected)
 
 


### PR DESCRIPTION
This provides a better fix for #2507 by fixing up the binja analysis (i.e., manually defining the function at 0x14004b4f0)

This issue also exposes a bug when I previously introduced the optimization in https://github.com/mandiant/capa/commit/b6763ac5fe72034cf841d401a1188c06bf0a0af3. It is not fixed in this PR as well 

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
