### PR TITLE
vmray: loosen file checks to enable processing of additional file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 - vmray: load more analysis archives @mr-tz
 - dynamic: only check file limitations for static file formats @mr-tz
 - vmray: skip non-printable strings @mike-hunhoff
-- strings: add type hints and fix uncovered bugs @williballenthin @2555
+- strings: add type hints and fix uncovered bugs @williballenthin #2555
 - elffile: handle symbols without a name @williballenthin #2553
+- vmray: loosen file checks to enable processing more file types @mike-hunhoff #2571
 
 ### capa Explorer Web
 

--- a/capa/features/extractors/vmray/__init__.py
+++ b/capa/features/extractors/vmray/__init__.py
@@ -81,7 +81,7 @@ class VMRayAnalysis:
         # map function calls to their associated monitor thread ID mapped to its associated monitor process ID
         self.monitor_process_calls: dict[int, dict[int, list[FunctionCall]]] = defaultdict(lambda: defaultdict(list))
 
-        self.submission_base_address: int = 0
+        self.submission_base_address: Optional[int] = None
         self.submission_sha256: Optional[str] = None
         self.submission_meta: Optional[File] = None
         self.submission_static: Optional[StaticData] = None

--- a/capa/features/extractors/vmray/__init__.py
+++ b/capa/features/extractors/vmray/__init__.py
@@ -126,12 +126,7 @@ class VMRayAnalysis:
             submission_path,
         )
 
-        # only collect submission bytes if VMRay recorded static anlaysis for the submission
-        self.submission_bytes: bytes = (
-            self.zipfile.read(submission_path, pwd=DEFAULT_ARCHIVE_PASSWORD)
-            if self.submission_static is not None
-            else bytes()
-        )
+        self.submission_bytes: bytes = self.zipfile.read(submission_path, pwd=DEFAULT_ARCHIVE_PASSWORD)
 
         logger.debug("submission_bytes: %s", self.submission_bytes[:10])
 

--- a/capa/features/extractors/vmray/extractor.py
+++ b/capa/features/extractors/vmray/extractor.py
@@ -56,13 +56,13 @@ def get_formatted_params(params: ParamList) -> list[str]:
 
 class VMRayExtractor(DynamicFeatureExtractor):
     def __init__(self, analysis: VMRayAnalysis):
-        assert analysis.sample_file_analysis is not None
+        assert analysis.submission_meta is not None
 
         super().__init__(
             hashes=SampleHashes(
-                md5=analysis.sample_file_analysis.hash_values.md5.lower(),
-                sha1=analysis.sample_file_analysis.hash_values.sha1.lower(),
-                sha256=analysis.sample_file_analysis.hash_values.sha256.lower(),
+                md5=analysis.submission_meta.hash_values.md5.lower(),
+                sha1=analysis.submission_meta.hash_values.sha1.lower(),
+                sha256=analysis.submission_meta.hash_values.sha256.lower(),
             )
         )
 
@@ -73,7 +73,7 @@ class VMRayExtractor(DynamicFeatureExtractor):
 
     def get_base_address(self) -> Address:
         # value according to the PE header, the actual trace may use a different imagebase
-        return AbsoluteVirtualAddress(self.analysis.base_address)
+        return AbsoluteVirtualAddress(self.analysis.submission_base_address)
 
     def extract_file_features(self) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.vmray.file.extract_features(self.analysis)

--- a/capa/features/extractors/vmray/extractor.py
+++ b/capa/features/extractors/vmray/extractor.py
@@ -73,7 +73,7 @@ class VMRayExtractor(DynamicFeatureExtractor):
 
     def get_base_address(self) -> Address:
         # value according to submission file header, the actual trace may use a different imagebase
-        # value may be zero for certain submission file types, e.g. PS1
+        # value may not exist for certain submission file types, e.g. PS1
         if self.analysis.submission_base_address is None:
             return NO_ADDRESS
         else:

--- a/capa/features/extractors/vmray/extractor.py
+++ b/capa/features/extractors/vmray/extractor.py
@@ -21,7 +21,14 @@ import capa.features.extractors.vmray.call
 import capa.features.extractors.vmray.file
 import capa.features.extractors.vmray.global_
 from capa.features.common import Feature
-from capa.features.address import Address, ThreadAddress, ProcessAddress, DynamicCallAddress, AbsoluteVirtualAddress
+from capa.features.address import (
+    NO_ADDRESS,
+    Address,
+    ThreadAddress,
+    ProcessAddress,
+    DynamicCallAddress,
+    AbsoluteVirtualAddress,
+)
 from capa.features.extractors.vmray import VMRayAnalysis, VMRayMonitorThread, VMRayMonitorProcess
 from capa.features.extractors.vmray.models import PARAM_TYPE_STR, ParamList, FunctionCall
 from capa.features.extractors.base_extractor import (
@@ -67,7 +74,10 @@ class VMRayExtractor(DynamicFeatureExtractor):
     def get_base_address(self) -> Address:
         # value according to submission file header, the actual trace may use a different imagebase
         # value may be zero for certain submission file types, e.g. PS1
-        return AbsoluteVirtualAddress(self.analysis.submission_base_address)
+        if self.analysis.submission_base_address is None:
+            return NO_ADDRESS
+        else:
+            return AbsoluteVirtualAddress(self.analysis.submission_base_address)
 
     def extract_file_features(self) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.vmray.file.extract_features(self.analysis)

--- a/capa/features/extractors/vmray/extractor.py
+++ b/capa/features/extractors/vmray/extractor.py
@@ -20,15 +20,8 @@ import capa.helpers
 import capa.features.extractors.vmray.call
 import capa.features.extractors.vmray.file
 import capa.features.extractors.vmray.global_
-from capa.features.common import Feature, Characteristic
-from capa.features.address import (
-    NO_ADDRESS,
-    Address,
-    ThreadAddress,
-    ProcessAddress,
-    DynamicCallAddress,
-    AbsoluteVirtualAddress,
-)
+from capa.features.common import Feature
+from capa.features.address import Address, ThreadAddress, ProcessAddress, DynamicCallAddress, AbsoluteVirtualAddress
 from capa.features.extractors.vmray import VMRayAnalysis, VMRayMonitorThread, VMRayMonitorProcess
 from capa.features.extractors.vmray.models import PARAM_TYPE_STR, ParamList, FunctionCall
 from capa.features.extractors.base_extractor import (

--- a/capa/features/extractors/vmray/extractor.py
+++ b/capa/features/extractors/vmray/extractor.py
@@ -72,7 +72,8 @@ class VMRayExtractor(DynamicFeatureExtractor):
         self.global_features = list(capa.features.extractors.vmray.global_.extract_features(self.analysis))
 
     def get_base_address(self) -> Address:
-        # value according to the PE header, the actual trace may use a different imagebase
+        # value according to submission file header, the actual trace may use a different imagebase
+        # value may be zero for certain submission file types, e.g. PS1
         return AbsoluteVirtualAddress(self.analysis.submission_base_address)
 
     def extract_file_features(self) -> Iterator[tuple[Feature, Address]]:
@@ -102,11 +103,8 @@ class VMRayExtractor(DynamicFeatureExtractor):
             yield ThreadHandle(address=address, inner=monitor_thread)
 
     def extract_thread_features(self, ph: ProcessHandle, th: ThreadHandle) -> Iterator[tuple[Feature, Address]]:
-        if False:
-            # force this routine to be a generator,
-            # but we don't actually have any elements to generate.
-            yield Characteristic("never"), NO_ADDRESS
-        return
+        # we have not identified thread-specific features for VMRay yet
+        yield from []
 
     def get_calls(self, ph: ProcessHandle, th: ThreadHandle) -> Iterator[CallHandle]:
         for function_call in self.analysis.monitor_process_calls[ph.inner.monitor_id][th.inner.monitor_id]:

--- a/capa/features/extractors/vmray/file.py
+++ b/capa/features/extractors/vmray/file.py
@@ -67,7 +67,8 @@ def extract_referenced_registry_key_names(analysis: VMRayAnalysis) -> Iterator[t
 
 
 def extract_file_strings(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
-    yield from capa.features.extractors.common.extract_file_strings(analysis.submission_bytes)
+    if analysis.submission_static is not None:
+        yield from capa.features.extractors.common.extract_file_strings(analysis.submission_bytes)
 
 
 def extract_features(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:

--- a/capa/features/extractors/vmray/file.py
+++ b/capa/features/extractors/vmray/file.py
@@ -67,7 +67,7 @@ def extract_referenced_registry_key_names(analysis: VMRayAnalysis) -> Iterator[t
 
 
 def extract_file_strings(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
-    yield from capa.features.extractors.common.extract_file_strings(analysis.sample_file_buf)
+    yield from capa.features.extractors.common.extract_file_strings(analysis.submission_bytes)
 
 
 def extract_features(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:

--- a/capa/features/extractors/vmray/global_.py
+++ b/capa/features/extractors/vmray/global_.py
@@ -45,7 +45,7 @@ def extract_arch(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
         yield Arch(ARCH_ANY), NO_ADDRESS
 
         logger.debug(
-            "unrecognized arch for file submission (filename: %s, file_type: %s)",
+            "unrecognized arch for submission (filename: %s, file_type: %s)",
             analysis.submission_name,
             analysis.submission_type,
         )
@@ -62,7 +62,7 @@ def extract_format(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]
         # so this should be fine for now
 
         logger.debug(
-            "unrecognized format for file submission (filename: %s, file_type: %s)",
+            "unrecognized format for submission (filename: %s, file_type: %s)",
             analysis.submission_name,
             analysis.submission_type,
         )
@@ -77,7 +77,7 @@ def extract_os(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
         yield OS(OS_ANY), NO_ADDRESS
 
         logger.debug(
-            "unrecognized os for file submission (filename: %s, file_type: %s)",
+            "unrecognized os for submission (filename: %s, file_type: %s)",
             analysis.submission_name,
             analysis.submission_type,
         )

--- a/capa/features/extractors/vmray/global_.py
+++ b/capa/features/extractors/vmray/global_.py
@@ -35,35 +35,37 @@ logger = logging.getLogger(__name__)
 
 
 def extract_arch(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
-    file_type: str = analysis.file_type
-
-    if "x86-32" in file_type:
+    if "x86-32" in analysis.file_type:
         yield Arch(ARCH_I386), NO_ADDRESS
-    elif "x86-64" in file_type:
+    elif "x86-64" in analysis.file_type:
         yield Arch(ARCH_AMD64), NO_ADDRESS
-    else:
-        raise ValueError("unrecognized arch from the VMRay report: %s" % file_type)
+
+    logger.warning(
+        "unrecognized arch found in the VMRay report (file_type: %s): results may be incomplete", analysis.file_type
+    )
 
 
 def extract_format(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
-    assert analysis.sample_file_static_data is not None
-    if analysis.sample_file_static_data.pe:
-        yield Format(FORMAT_PE), NO_ADDRESS
-    elif analysis.sample_file_static_data.elf:
-        yield Format(FORMAT_ELF), NO_ADDRESS
-    else:
-        raise ValueError("unrecognized file format from the VMRay report: %s" % analysis.file_type)
+    if analysis.sample_file_static_data is not None:
+        if analysis.sample_file_static_data.pe:
+            yield Format(FORMAT_PE), NO_ADDRESS
+        elif analysis.sample_file_static_data.elf:
+            yield Format(FORMAT_ELF), NO_ADDRESS
+
+    logger.warning(
+        "unrecognized format found in the VMRay report (file_type: %s): results may be incomplete", analysis.file_type
+    )
 
 
 def extract_os(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:
-    file_type: str = analysis.file_type
-
-    if "windows" in file_type.lower():
+    if "windows" in analysis.file_type.lower():
         yield OS(OS_WINDOWS), NO_ADDRESS
-    elif "linux" in file_type.lower():
+    elif "linux" in analysis.file_type.lower():
         yield OS(OS_LINUX), NO_ADDRESS
-    else:
-        raise ValueError("unrecognized OS from the VMRay report: %s" % file_type)
+
+    logger.warning(
+        "unrecognized os found in the VMRay report (file_type: %s): results may be incomplete", analysis.file_type
+    )
 
 
 def extract_features(analysis: VMRayAnalysis) -> Iterator[tuple[Feature, Address]]:

--- a/scripts/minimize_vmray_results.py
+++ b/scripts/minimize_vmray_results.py
@@ -49,9 +49,9 @@ def main(argv=None):
     vmra = VMRayAnalysis(analysis_archive)
     sv2_json = vmra.zipfile.read("logs/summary_v2.json", pwd=DEFAULT_ARCHIVE_PASSWORD)
     flog_xml = vmra.zipfile.read("logs/flog.xml", pwd=DEFAULT_ARCHIVE_PASSWORD)
-    sample_file_buf = vmra.sample_file_buf
-    assert vmra.sample_file_analysis is not None
-    sample_sha256: str = vmra.sample_file_analysis.hash_values.sha256.lower()
+    sample_file_buf = vmra.submission_bytes
+    assert vmra.submission_meta is not None
+    sample_sha256: str = vmra.submission_meta.hash_values.sha256.lower()
 
     new_zip_name = f"{analysis_archive.parent / analysis_archive.stem}_min.zip"
     with zipfile.ZipFile(new_zip_name, "w") as new_zip:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -453,6 +453,14 @@ def get_data_path_by_name(name) -> Path:
             / "vmray"
             / "2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip"
         )
+    elif name.startswith("eb1287-vmray"):
+        return (
+            CD
+            / "data"
+            / "dynamic"
+            / "vmray"
+            / "eb12873c0ce3e9ea109c2a447956cbd10ca2c3e86936e526b2c6e28764999f21_min_archive.zip"
+        )
     elif name.startswith("ea2876"):
         return CD / "data" / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
     elif name.startswith("1038a2"):

--- a/tests/test_vmray_features.py
+++ b/tests/test_vmray_features.py
@@ -35,6 +35,7 @@ DYNAMIC_VMRAY_FEATURE_PRESENCE_TESTS = sorted(
         ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("DoesNotExist"), False),
         # call/api
         ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2361", capa.features.insn.API("GetAddrInfoW"), True),
+        ("eb1287-vmray", "process=(4968:0),thread=5992,call=10981", capa.features.insn.API("CreateMutexW"), True),
         # call/string argument
         (
             "93b2d1-vmray",


### PR DESCRIPTION
closes #2403 

This PR addresses two issues:
1. Loosen file checks to enable processing of additional file types, e.g. PS1 and MSI. We handle this by largely ignoring _file_ and _global_ feature extraction because we care most about the dynamic trace analysis anyways. This accepts that capa's results may be incomplete but still useful.
2. Handle VMRay analysis archives that may have more than one file marked as the submission, e.g. compound ZIP files. Unfortunately, I have not identified a sure way of differentiating which of the files is the actual submission. Instead, we rely on the ordering of the files and use the last file marked as the submission file. This appears to hold true for compound ZIP files.