### PR TITLE
feat: add lint to validate rule dependency scope compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - add span-of-calls scope to match features against a across a sliding window of API calls within a thread @williballenthin #2532
+- add lint to catch rules that depend on other rules with impossible scope @williballenthin #2124
 
 ### Breaking Changes
 


### PR DESCRIPTION
closes #2124


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed

### output

```
❯ python scripts/lint.py rules/
INFO     lint: collecting potentially referenced samples                                                                                                           lint.py:1090

 acquire debug privileges
  FAIL: rule dependency scope mismatch: rule 'acquire debug privileges' (Scope.BASIC_BLOCK) depends on rule 'modify access privileges' (Scope.FUNCTION).


 check mutex
  FAIL: rule dependency scope mismatch: rule 'check mutex' (Scope.BASIC_BLOCK) depends on rule 'create mutex' (Scope.FUNCTION).


 delete drive layout via IOCTL
  FAIL: rule dependency scope mismatch: rule 'delete drive layout via IOCTL' (Scope.CALL) depends on rule 'interact with driver via IOCTL' (Scope.THREAD).


    (nursery)  persist via application shimming
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'persist via application shimming' (Scope.CALL) depends on rule 'write file on Linux' (Scope.THREAD).


    (nursery)  upload file to OneDrive
      WARN: 'no lint failures': Graduate the rule


    (nursery)  get volume information via IOCTL
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'get volume information via IOCTL' (Scope.CALL) depends on rule 'interact with driver via IOCTL' (Scope.THREAD).


    (nursery)  unmount volume via IOCTL
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'unmount volume via IOCTL' (Scope.CALL) depends on rule 'interact with driver via IOCTL' (Scope.THREAD).


    (nursery)  linked against hp-socket
      WARN: referenced example doesn't exist: Add the referenced example to samples directory ($capa-root/tests/data or supplied via --samples)


    (nursery)  resize volume shadow copy storage
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'resize volume shadow copy storage' (Scope.CALL) depends on rule 'interact with driver via IOCTL' (Scope.THREAD).


    (nursery)  persist via Print Processors registry key
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'persist via Print Processors registry key' (Scope.CALL) depends on rule 'write file on Linux' (Scope.THREAD).


    (nursery)  get disk information via IOCTL
      WARN: missing examples: Add meta.examples so that the rule can be tested and verified
      WARN: rule dependency scope mismatch: rule 'get disk information via IOCTL' (Scope.CALL) depends on rule 'interact with driver via IOCTL' (Scope.THREAD).


 send file via HTTP
  FAIL: rule dependency scope mismatch: rule 'send file via HTTP' (Scope.BASIC_BLOCK) depends on rule 'connect to URL' (Scope.FUNCTION).

rules with WARN:
  - linked against hp-socket

rules with FAIL:
  - acquire debug privileges
  - check mutex
  - delete drive layout via IOCTL
  - get disk information via IOCTL
  - get volume information via IOCTL
  - persist via Print Processors registry key
  - persist via application shimming
  - resize volume shadow copy storage
  - send file via HTTP
  - unmount volume via IOCTL
```
