### PR TITLE
rules: scopes can now have subscope blocks with same scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - strings: add type hints and fix uncovered bugs @williballenthin #2555
 - elffile: handle symbols without a name @williballenthin #2553
 - project: remove pytest-cov that wasn't used @williballenthin @2491
+- rules: scopes can now have subscope blocks with the same scope @williballenthin #2584
 
 ### capa Explorer Web
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -48,7 +48,7 @@ import capa.loader
 import capa.helpers
 import capa.features.insn
 import capa.capabilities.common
-from capa.rules import Rule, Scope, RuleSet
+from capa.rules import Rule, RuleSet
 from capa.features.common import OS_AUTO, String, Feature, Substring
 from capa.render.result_document import RuleMetadata
 
@@ -536,15 +536,8 @@ class RuleDependencyScopeMismatch(Lint):
             # Assume for now it is not.
             return True
 
-        static_scope_order = [
-            None,
-            Scope.FILE,
-            Scope.FUNCTION,
-            Scope.BASIC_BLOCK,
-            Scope.INSTRUCTION,
-        ]
-
-        return static_scope_order.index(child.scopes.static) >= static_scope_order.index(parent.scopes.static)
+        assert child.scopes.static is not None
+        return capa.rules.is_subscope_compatible(parent.scopes.static, child.scopes.static)
 
     @staticmethod
     def _is_dynamic_scope_compatible(parent: Rule, child: Rule) -> bool:
@@ -563,16 +556,8 @@ class RuleDependencyScopeMismatch(Lint):
             # Assume for now it is not.
             return True
 
-        dynamic_scope_order = [
-            None,
-            Scope.FILE,
-            Scope.PROCESS,
-            Scope.THREAD,
-            Scope.SPAN_OF_CALLS,
-            Scope.CALL,
-        ]
-
-        return dynamic_scope_order.index(child.scopes.dynamic) >= dynamic_scope_order.index(parent.scopes.dynamic)
+        assert child.scopes.dynamic is not None
+        return capa.rules.is_subscope_compatible(parent.scopes.dynamic, child.scopes.dynamic)
 
 
 class OptionalNotUnderAnd(Lint):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -515,6 +515,36 @@ def test_meta_scope_keywords():
         )
 
 
+def test_subscope_same_as_scope():
+    static_scopes = sorted(
+        [e.value for e in capa.rules.STATIC_SCOPES if e not in (capa.rules.Scope.FILE, capa.rules.Scope.GLOBAL)]
+    )
+    dynamic_scopes = sorted(
+        [e.value for e in capa.rules.DYNAMIC_SCOPES if e not in (capa.rules.Scope.FILE, capa.rules.Scope.GLOBAL)]
+    )
+
+    for static_scope in static_scopes:
+        for dynamic_scope in dynamic_scopes:
+            _ = capa.rules.Rule.from_yaml(
+                textwrap.dedent(
+                    f"""
+                    rule:
+                        meta:
+                            name: test rule
+                            scopes:
+                                static: {static_scope}
+                                dynamic: {dynamic_scope}
+                        features:
+                            - or:
+                                - {static_scope}:
+                                    - format: pe
+                                - {dynamic_scope}:
+                                    - format: pe
+                    """
+                )
+            )
+
+
 def test_lib_rules():
     rules = capa.rules.RuleSet(
         [


### PR DESCRIPTION
Allows us to do this (note the subscope blocks match the rule scopes):

```yml
rule:
  meta:
    scopes:
      static: basic block
      dynamic: span of calls
  features:
    - or:
      - basic block:
         api: CreateFileW
      - span of calls:
         api: CreateFileZ
```

This enables us to have a block only match in either static/dynamic mode (in a slightly hacky way).

See thread here:
https://github.com/mandiant/capa-rules/pull/987/files#r1936164120

Note that we already supported this sort of behavior for `match` statements that referenced a rule with the same scope. Now we're enabling the same behavior for subscope statements. Because `match` and subscopes use the same implementation, I don't expect there to be much risk here.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] tests
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
