### PR TITLE
ci: add addlicense linter to CI workflow for license checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,24 @@ jobs:
       run: pre-commit run mypy --hook-stage manual
     - name: Check imports against dependencies
       run: pre-commit run deptry --hook-stage manual
+      run: |
+        curl -sL https://api.github.com/repos/google/addlicense/releases/latest | \
+          grep "browser_download_url.*Linux_x86_64.tar.gz" | \
+          cut -d '"' -f 4 | \
+          xargs curl -sL -o addlicense.tar.gz
+
+        tar -xzf addlicense.tar.gz
+        chmod +x addlicense
+        mv addlicense /usr/local/bin/
+        rm addlicense.tar.gz
+    - name: Check license headers
+      run: |
+        addlicense -c "Google LLC" .
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "License headers missing or incorrect! Please run addlicense locally and commit the changes."
+          git diff
+          exit 1
+        fi
 
   rule_linter:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

### Description:
This PR adds addlicense as a linter in the CI workflow to enforce copyright and license headers across the project. It ensures that all source files include the necessary license headers, and the CI will fail if any file is missing or incorrect.

#### Related Issues:
Closes #2558 

#### Linked PRs:
This PR depends on the following fix in addlicense:

[google/addlicense#172](https://github.com/google/addlicense/pull/172) (Fixes copyright holder check, ignores empty files, and adds support for spec files)

#### Changes Made:
 - Added addlicense to CI workflow
 -  Configured it to check and enforce license headers
 - Ensured the workflow fails if missing headers are detected

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
