### PR TITLE
lint: add WARN for regex features that contain unescaped dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 - cape: make some fields optional @williballenthin #2631 #2632
+- lint: add WARN for regex features that contain unescaped dot #2635
 
 ### capa Explorer Web
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -749,7 +749,7 @@ class FeatureRegexContainsUnescapedPeriod(Lint):
                     return True
 
                 if pat[index - 1] != "\\":
-                    # like "/test.exe/"
+                    # like "/test.exe/" which should be "/test\.exe/"
                     self.recommendation = self.recommendation_template.format(feature.value)
                     return True
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -731,11 +731,8 @@ class FeatureRegexContainsUnescapedPeriod(Lint):
             if isinstance(feature, (Regex,)):
                 assert isinstance(feature.value, str)
 
-                pat = (
-                    feature.value[len("/") : -len("/i")]
-                    if feature.value.endswith("/i")
-                    else feature.value[len("/") : -len("/")]
-                )
+                pat = feature.value.removeprefix("/")
+                pat = pat.removesuffix("/i").removesuffix("/")
 
                 index = pat.find(".")
                 if index == -1:

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -757,12 +757,12 @@ class FeatureRegexContainsUnescapedPeriod(Lint):
                     return True
 
                 if pat[index - 1] == "\\":
-                    # like "/\\\\.\\pipe\\VBoxTrayIPC/"
                     for i, char in enumerate(pat[0:index][::-1]):
                         if char == "\\":
                             continue
 
                         if i % 2 == 0:
+                            # like "/\\\\.\\pipe\\VBoxTrayIPC/"
                             self.recommendation = self.recommendation_template.format(feature.value)
                             return True
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -744,7 +744,7 @@ class FeatureRegexContainsUnescapedPeriod(Lint):
                         return False
 
                 if index == 0:
-                    # like "/.exe/"
+                    # like "/.exe/" which should be "/\.exe/"
                     self.recommendation = self.recommendation_template.format(feature.value)
                     return True
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -49,7 +49,7 @@ import capa.helpers
 import capa.features.insn
 import capa.capabilities.common
 from capa.rules import Rule, RuleSet
-from capa.features.common import OS_AUTO, String, Feature, Substring
+from capa.features.common import OS_AUTO, Regex, String, Feature, Substring
 from capa.render.result_document import RuleMetadata
 
 logger = logging.getLogger("lint")
@@ -721,6 +721,56 @@ class FeatureStringTooShort(Lint):
         return False
 
 
+class FeatureRegexContainsUnescapedPeriod(Lint):
+    name = "feature regex contains unescaped period"
+    recommendation_template = 'escape the period in "{:s}" unless it should be treated as a regex dot operator'
+    level = Lint.WARN
+
+    def check_features(self, ctx: Context, features: list[Feature]):
+        for feature in features:
+            if isinstance(feature, (Regex,)):
+                assert isinstance(feature.value, str)
+
+                pat = (
+                    feature.value[len("/") : -len("/i")]
+                    if feature.value.endswith("/i")
+                    else feature.value[len("/") : -len("/")]
+                )
+
+                index = pat.find(".")
+                if index == -1:
+                    return False
+
+                if index < len(pat) - 1:
+                    if pat[index + 1] in ("*", "+", "?", "{"):
+                        # like "/VB5!.*/"
+                        return False
+
+                if index == 0:
+                    # like "/.exe/"
+                    self.recommendation = self.recommendation_template.format(feature.value)
+                    return True
+
+                if pat[index - 1] != "\\":
+                    # like "/test.exe/"
+                    self.recommendation = self.recommendation_template.format(feature.value)
+                    return True
+
+                if pat[index - 1] == "\\":
+                    # like "/\\\\.\\pipe\\VBoxTrayIPC/"
+                    for i, char in enumerate(pat[0:index][::-1]):
+                        if char == "\\":
+                            continue
+
+                        if i % 2 == 0:
+                            self.recommendation = self.recommendation_template.format(feature.value)
+                            return True
+
+                        break
+
+        return False
+
+
 class FeatureNegativeNumber(Lint):
     name = "feature value is negative"
     recommendation = "specify the number's two's complement representation"
@@ -931,7 +981,12 @@ def lint_meta(ctx: Context, rule: Rule):
     return run_lints(META_LINTS, ctx, rule)
 
 
-FEATURE_LINTS = (FeatureStringTooShort(), FeatureNegativeNumber(), FeatureNtdllNtoskrnlApi())
+FEATURE_LINTS = (
+    FeatureStringTooShort(),
+    FeatureNegativeNumber(),
+    FeatureNtdllNtoskrnlApi(),
+    FeatureRegexContainsUnescapedPeriod(),
+)
 
 
 def lint_features(ctx: Context, rule: Rule):


### PR DESCRIPTION
see https://github.com/mandiant/capa-rules/pull/1026 for an example of how unescaped `.` can results in FPs. This adds a WARN for regular expressions that contain unescaped `.`.