### PR TITLE
fix #1686: implement separate help menu and add documentation links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ This release improves a few aspects of dynamic analysis, relaxing our validation
 It also includes an updated rule pack in which many dynamic rules make better use of the "span of calls" scope.
 
 
+### Breaking Changes
+- split single help menu to short and full help menu and adding gihub documentation links @AdityaPatadiya #2640
+
 ### New Rules (3)
 
 - host-interaction/registry/change-registry-key-timestamp wballenthin@google.com

--- a/capa/features/freeze/__init__.py
+++ b/capa/features/freeze/__init__.py
@@ -690,7 +690,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    parser = argparse.ArgumentParser(description="save capa features to a file")
+    parser = argparse.ArgumentParser(description="save capa features to a file", add_help=False)
     capa.main.install_common_args(parser, {"input_file", "format", "backend", "os", "signatures"})
     parser.add_argument("output", type=str, help="Path to output file")
     args = parser.parse_args(args=argv)

--- a/capa/main.py
+++ b/capa/main.py
@@ -525,14 +525,18 @@ def handle_help_from_cli(argv, fh_wanted):
     """
     Generate the full-length help menu dynamically using argparse.
     """
-    desc = """
-The FLARE team's open-source tool to identify capabilities in executable files.
-Github: https://github.com/mandiant/capa
+    DOC_LINKS = """
 Useful Links:
     -Quick start: https://github.com/mandiant/capa/blob/master/doc/capa_quickstart.pdf
     -Installation: https://github.com/mandiant/capa/blob/master/doc/installation.md
     -Usage: https://github.com/mandiant/capa/blob/master/doc/usage.md
     -FAQs: https://github.com/mandiant/capa/blob/master/doc/faq.md
+    """
+
+    desc = f"""
+The FLARE team's open-source tool to identify capabilities in executable files.
+Github: https://github.com/mandiant/capa
+{DOC_LINKS}
     """
 
     short_epilog = "Use --help for detailed help menu and examples."

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1179,7 +1179,7 @@ def main(argv=None):
 
     default_samples_path = str(Path(__file__).resolve().parent.parent / "tests" / "data")
 
-    parser = argparse.ArgumentParser(description="Lint capa rules.")
+    parser = argparse.ArgumentParser(description="Lint capa rules.", add_help=False)
     capa.main.install_common_args(parser, wanted={"tag"})
     parser.add_argument("rules", type=str, action="append", help="Path to rules")
     parser.add_argument("--samples", type=str, default=default_samples_path, help="Path to samples")


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
This PR has done several changes that is given in [issue#1686](https://github.com/mandiant/capa/issues/1686).
- split the existing help menu to short and full length help menu.
- adding documentation pages links of github.


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
