### PR TITLE
add lint for registry control set regex that is not complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Bug Fixes
 - cape: make some fields optional @williballenthin #2631 #2632
 - lint: add WARN for regex features that contain unescaped dot #2635
+- lint: add ERROR for incomplete registry control set regex #2643
 
 ### capa Explorer Web
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -721,6 +721,29 @@ class FeatureStringTooShort(Lint):
         return False
 
 
+class FeatureRegexRegistryControlSetMatchIncomplete(Lint):
+    name = "feature regex registry control set match incomplete"
+    recommendation = (
+        'use "(ControlSet\\d{3}|CurrentControlSet)" to match both indirect references '
+        + 'via "CurrentControlSet" and direct references via "ControlSetXXX"'
+    )
+
+    def check_features(self, ctx: Context, features: list[Feature]):
+        for feature in features:
+            if not isinstance(feature, (Regex,)):
+                continue
+
+            assert isinstance(feature.value, str)
+
+            pat = feature.value.lower()
+
+            if "system\\\\" in pat and "controlset" in pat or "currentcontrolset" in pat:
+                if "system\\\\(controlset\\d{3}|currentcontrolset)" not in pat:
+                    return True
+
+            return False
+
+
 class FeatureRegexContainsUnescapedPeriod(Lint):
     name = "feature regex contains unescaped period"
     recommendation_template = 'escape the period in "{:s}" unless it should be treated as a regex dot operator'
@@ -983,6 +1006,7 @@ FEATURE_LINTS = (
     FeatureNegativeNumber(),
     FeatureNtdllNtoskrnlApi(),
     FeatureRegexContainsUnescapedPeriod(),
+    FeatureRegexRegistryControlSetMatchIncomplete(),
 )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
