### PR TITLE
ghidra: Updates capa_explorer.py to enable users to select if namespaces, comments and bookmarks are added. Closes #1977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+- Adds user-options for adding comments, bookmarks, and namespaces via a dialog box in `capa_explorer.py`.
+- Implemented granular control over annotations:
+- `create_capa_namespace`: Handles namespace creation and labels.
+- `create_capa_comments`: Manages plate and pre-comments.
+
 ### New Features
 
 ### Breaking Changes

--- a/capa/ghidra/capa_explorer.py
+++ b/capa/ghidra/capa_explorer.py
@@ -184,7 +184,7 @@ class CapaMatchData:
                     create_label(func_addr, func.getName(), capa_namespace)
 
                 for sub_match in self.matches.get(addr):
-                    for loc in sub_match.items():
+                    for loc, node in sub_match.items():
                         sub_ghidra_addr = toAddr(hex(loc))  # type: ignore [name-defined] # noqa: F821
                         if func is not None:
                             # basic block/ insn scope under resolved function
@@ -226,6 +226,7 @@ class CapaMatchData:
             for sub_match in self.matches.get(addr):
                 for loc, node in sub_match.items():
                     sub_ghidra_addr = toAddr(hex(loc)) # type: ignore [name-defined] # noqa: F821
+                    func = getFunctionContaining(sub_ghidra_addr)  # type: ignore [name-defined] # noqa: F821
                     
                     if node != {}:
                         if func is not None:
@@ -395,12 +396,14 @@ def main():
         return capa.main.E_EMPTY_REPORT
 
     options = ["Add Labels/Namespace", "Add Comments", "Add Bookmarks"]
-    selected_options = askChoices("Capa Explorer Options",
-                                  "Select options for capa analysis", options, [])  # type: ignore [name-defined] # noqa: F821
+    selected_options = askChoices("Capa Explorer Options",  # type: ignore [name-defined] # noqa: F821
+                                  "Select options for capa analysis",
+                                  options,
+                                  options)  
     
-    do_labels = "Labels/Namespace" in selected_options
-    do_comments = "Comments" in selected_options
-    do_bookmarks = "Bookmarks" in selected_options
+    do_labels = "Add Labels/Namespace" in selected_options
+    do_comments = "Add Comments" in selected_options
+    do_bookmarks = "Add Bookmarks" in selected_options
 
     if not any([do_bookmarks, do_comments, do_labels]):
         logger.info("No annotations selected")


### PR DESCRIPTION
closes #1977 

Enhances the `capa_explorer.py` script by adding user-selectable options for annotations in Ghidra. Users can now choose whether to add labels/namespaces, comments, or bookmarks during analysis.

- Allows user to select whether they want to add labels/namespaces, comments, or bookmarks using a dialog box which is made possible using Ghidra's `askChoices` API.
- `label_matches()` has been split into `create_capa_namespaces(`) and `create_capa_comments()`.
- `parse_json()` has new arguments which are further passed to the `CapaMatchData` class to faciliate the usage of guard clauses in `create_capa_namespaces(`) and `create_capa_comments()`.
- `CHANGELOG.md` updated

### Checklist


- [ ] No CHANGELOG update needed
- [x] No new tests needed
- [ ] No documentation update needed
