### PR TITLE
ci: Update Ubuntu version in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             # use old linux so that the shared library versioning is more portable
             artifact_name: capa
             asset_name: linux
             python_version: '3.10'
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             artifact_name: capa
             asset_name: linux-py312
             python_version: '3.12'
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ matrix.python_version }}
-      - if: matrix.os == 'ubuntu-20.04'
+      - if: matrix.os == 'ubuntu-24.04'
         run: sudo apt-get install -y libyaml-dev
       - name: Upgrade pip, setuptools
         run: python -m pip install --upgrade pip setuptools
@@ -82,10 +82,10 @@ jobs:
       matrix:
         include:
           # OSs not already tested above
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             artifact_name: capa
             asset_name: linux
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             artifact_name: capa
             asset_name: linux-py312
           - os: windows-2022

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   changelog_format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout capa
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -37,7 +37,7 @@ jobs:
         if [ $number != 1 ]; then exit 1; fi
 
   code_style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout capa
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -64,7 +64,7 @@ jobs:
       run: pre-commit run deptry --hook-stage manual
 
   rule_linter:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout capa with submodules
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -88,16 +88,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-24.04, windows-2019, macos-13]
         # across all operating systems
         python-version: ["3.10", "3.11"]
         include:
           # on Ubuntu run these as well
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             python-version: "3.10"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             python-version: "3.11"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             python-version: "3.12"
     steps:
     - name: Checkout capa with submodules
@@ -109,7 +109,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pyyaml
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-24.04'
       run: sudo apt-get install -y libyaml-dev
     - name: Install capa
       run: |
@@ -126,7 +126,7 @@ jobs:
     name: Binary Ninja tests for ${{ matrix.python-version }}
     env:
       BN_SERIAL: ${{ secrets.BN_SERIAL }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [tests]
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
 
   ghidra-tests:
     name: Ghidra tests for ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [tests]
     strategy:
       fail-fast: false


### PR DESCRIPTION
ubuntu-20.04 has been deprecated causing several GH actions to fail: https://github.com/actions/runner-images/issues/11101

Without this change, the CI will start failing (it started failing 2 days ago in VM-Packages).

<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [X] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [X] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
