### PR TITLE
lint: log the failed example+rule

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -406,6 +406,7 @@ class DoesntMatchExample(Lint):
                 return True
 
             if rule.name not in capabilities:
+                logger.info("failed to match: %s %s", rule.name, example_id)
                 return True
 
 


### PR DESCRIPTION
this PR adds a new log line to show which sample in a rule is failing in the linter. this makes it easier to identify specific flaws in rules.

old:
```
$ python ../capa/scripts/lint.py --thorough -t "suspicious NtFsControlFile call" -vv . --samples ../capa-testfiles/
INFO     lint: collecting potentially referenced samples

 suspicious NtFsControlFile call
  FAIL: doesn't match on referenced example: Fix the rule logic or provide a different example

rules with FAIL:
  - suspicious NtFsControlFile call
```

new:
```
$ python ../capa/scripts/lint.py --thorough -t "suspicious NtFsControlFile call" -vv . --samples ../capa-testfiles/
INFO     lint: collecting potentially referenced samples
INFO     lint: failed to match: suspicious NtFsControlFile call 7d333c9b11b06ef0982b61bfc062631bb6cf9d12d0d4f2cf1b807a25ddf62fbc.exe_

 suspicious NtFsControlFile call
  FAIL: doesn't match on referenced example: Fix the rule logic or provide a different example

rules with FAIL:
  - suspicious NtFsControlFile call
```

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
