### PR TITLE
added arm64 binary release support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
       - '**.md'
   release:
     types: [edited, published]
+  workflow_dispatch: # manual trigger for testing
 
 permissions:
   contents: write
@@ -27,6 +28,10 @@ jobs:
             artifact_name: capa
             asset_name: linux
             python_version: '3.10'
+          - os: ubuntu-22.04-arm
+            artifact_name: capa
+            asset_name: linux-arm64
+            python_version: '3.10'
           - os: ubuntu-22.04
             artifact_name: capa
             asset_name: linux-py312
@@ -35,10 +40,20 @@ jobs:
             artifact_name: capa.exe
             asset_name: windows
             python_version: '3.10'
+          # Windows 11 ARM64 complains of conflicting package version
+          # Additionally, there is no ARM64 build of Python for Python 3.10 on Windows 11 ARM: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+          #- os: windows-11-arm
+          #  artifact_name: capa.exe
+          #  asset_name: windows-arm64
+          #  python_version: '3.12'
           - os: macos-13
             # use older macOS for assumed better portability
             artifact_name: capa
             asset_name: macos
+            python_version: '3.10'
+          - os: macos-14
+            artifact_name: capa
+            asset_name: macos-arm64
             python_version: '3.10'
     steps:
       - name: Checkout capa
@@ -62,7 +77,7 @@ jobs:
       - name: Does it run without warnings or errors?
         shell: bash
         run: |
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
+          if [[ "${{ matrix.os }}" == "windows-2022" ]] || [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
             EXECUTABLE=".\\dist\\capa"
           else
             EXECUTABLE="./dist/capa"
@@ -107,12 +122,25 @@ jobs:
           - os: ubuntu-22.04
             artifact_name: capa
             asset_name: linux
+          - os: ubuntu-22.04-arm
+            artifact_name: capa
+            asset_name: linux-arm64
           - os: ubuntu-22.04
             artifact_name: capa
             asset_name: linux-py312
           - os: windows-2022
             artifact_name: capa.exe
             asset_name: windows
+          # Windows 11 ARM64 complains of conflicting package version
+          #- os: windows-11-arm
+          #  artifact_name: capa.exe
+          #  asset_name: windows-arm64
+          - os: macos-13
+            artifact_name: capa
+            asset_name: macos
+          - os: macos-14
+            artifact_name: capa
+            asset_name: macos-arm64
     steps:
       - name: Download ${{ matrix.asset_name }}
         uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
@@ -135,11 +163,17 @@ jobs:
         include:
           - asset_name: linux
             artifact_name: capa
+          - asset_name: linux-arm64
+            artifact_name: capa
           - asset_name: linux-py312
             artifact_name: capa
           - asset_name: windows
             artifact_name: capa.exe
+          #- asset_name: windows-arm64
+          #  artifact_name: capa.exe
           - asset_name: macos
+            artifact_name: capa
+          - asset_name: macos-arm64
             artifact_name: capa
     steps:
       - name: Download ${{ matrix.asset_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### New Features
+- ci: add support for arm64 binary releases
 
 ### Breaking Changes
 


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

Closes https://github.com/mandiant/capa/issues/2690

One exception, Windows 11 ARM seems to complain of Python incompatibility (from https://github.com/heywoodlh/capa/actions/runs/15566091415/job/43830414447):

```
ERROR: Cannot install None, flare-capa[build]==9.2.1, viv-utils[flirt]==0.7.10, viv-utils[flirt]==0.7.11, viv-utils[flirt]==0.7.12, viv-utils[flirt]==0.7.13, viv-utils[flirt]==0.7.9 and viv-utils[flirt]==0.8.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    flare-capa 9.2.1 depends on viv-utils>=0.7.9
    flare-capa[build] 9.2.1 depends on viv-utils>=0.7.9
    viv-utils[flirt] 0.8.0 depends on viv-utils 0.8.0 (from https://files.pythonhosted.org/packages/e2/ee/da45fa8057dc76b856ad19759299dcc3163dc764fefe18014a8bfd69b339/viv_utils-0.8.0-py2.py3-none-any.whl (from https://pypi.org/simple/viv-utils/) (requires-python:>=3.9))
    viv-utils[flirt] 0.7.13 depends on python-flirt==0.9.0; extra == "flirt"
    viv-utils[flirt] 0.7.12 depends on python-flirt==0.8.10; extra == "flirt"
    viv-utils[flirt] 0.7.11 depends on python-flirt==0.8.10; extra == "flirt"
    viv-utils[flirt] 0.7.10 depends on python-flirt==0.8.10; extra == "flirt"
    viv-utils[flirt] 0.7.9 depends on python-flirt==0.8.6; extra == "flirt"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```

I don't have the willpower or interest to troubleshoot Windows ARM + Python issues, so I just left the Windows 11 piece commented out.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
