### PR TITLE
IDA 9.2 Compatibility Fix

### DIFF
--- a/capa/capabilities/common.py
+++ b/capa/capabilities/common.py
@@ -81,7 +81,6 @@ def find_capabilities(ruleset: RuleSet, extractor: FeatureExtractor, disable_pro
 
 
 def has_limitation(rules: list, capabilities: Capabilities | FileCapabilities, is_standalone: bool) -> bool:
-
     for rule in rules:
         if rule.name not in capabilities.matches:
             continue

--- a/capa/features/address.py
+++ b/capa/features/address.py
@@ -17,7 +17,8 @@ import abc
 
 class Address(abc.ABC):
     @abc.abstractmethod
-    def __eq__(self, other): ...
+    def __eq__(self, other):
+        ...
 
     @abc.abstractmethod
     def __lt__(self, other):

--- a/capa/features/extractors/binexport2/__init__.py
+++ b/capa/features/extractors/binexport2/__init__.py
@@ -324,10 +324,12 @@ class MemoryRegion:
         return self.address <= address < self.end
 
 
-class ReadMemoryError(ValueError): ...
+class ReadMemoryError(ValueError):
+    ...
 
 
-class AddressNotMappedError(ReadMemoryError): ...
+class AddressNotMappedError(ReadMemoryError):
+    ...
 
 
 @dataclass

--- a/capa/features/extractors/vmray/models.py
+++ b/capa/features/extractors/vmray/models.py
@@ -205,7 +205,8 @@ class GenericReference(BaseModel):
     source: str
 
 
-class StaticDataReference(GenericReference): ...
+class StaticDataReference(GenericReference):
+    ...
 
 
 class PEFileBasicInfo(BaseModel):

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -941,9 +941,9 @@ class CapaExplorerForm(idaapi.PluginForm):
                     update_wait_box("verifying cached results")
 
                     try:
-                        results: Optional[capa.render.result_document.ResultDocument] = (
-                            capa.ida.helpers.load_and_verify_cached_results()
-                        )
+                        results: Optional[
+                            capa.render.result_document.ResultDocument
+                        ] = capa.ida.helpers.load_and_verify_cached_results()
                     except Exception as e:
                         capa.ida.helpers.inform_user_ida_ui("Failed to verify cached results, reanalyzing program")
                         logger.exception("Failed to verify cached results (error: %s)", e)

--- a/capa/ida/plugin/item.py
+++ b/capa/ida/plugin/item.py
@@ -21,9 +21,11 @@ import idaapi
 
 try:
     from PySide6 import QtCore
+
     _QT6 = True
 except ImportError:
     from PyQt5 import QtCore
+
     _QT6 = False
 
 import capa.ida.helpers
@@ -41,14 +43,15 @@ def ea_to_hex(ea):
     return f"{hex(ea)}"
 
 
-
 _HAS_ITEMFLAG = hasattr(QtCore.Qt, "ItemFlag")
+
 
 def _qt_flag(name: str):
     """Return a single flag enum across Qt5/Qt6."""
     if _HAS_ITEMFLAG:
         return getattr(QtCore.Qt.ItemFlag, name)
     return getattr(QtCore.Qt, name)
+
 
 def _qt_flags_or(*flags):
     """Build ItemFlags value across Qt5/Qt6."""

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 from typing import Optional
 from collections import deque
 
@@ -23,9 +22,11 @@ import idaapi
 # Qt compat: prefer PySide6 (IDA 9.2), fallback PyQt5
 try:
     from PySide6 import QtGui, QtCore
+
     _QT6 = True
 except ImportError:
     from PyQt5 import QtGui, QtCore  # type: ignore
+
     _QT6 = False
 
 import capa.rules
@@ -57,10 +58,12 @@ DEFAULT_HIGHLIGHT = 0xE6C700
 _HAS_ITEMFLAG = hasattr(QtCore.Qt, "ItemFlag")
 _HAS_MATCHFLAG = hasattr(QtCore.Qt, "MatchFlag")
 
+
 def _qt_noitemflags():
     if _HAS_ITEMFLAG:
         return QtCore.Qt.ItemFlags()
     return QtCore.Qt.NoItemFlags
+
 
 def _qt_matchflag(name: str):
     if _HAS_MATCHFLAG:

--- a/capa/render/result_document.py
+++ b/capa/render/result_document.py
@@ -170,7 +170,8 @@ class CompoundStatementType:
     OPTIONAL = "optional"
 
 
-class StatementModel(FrozenModel): ...
+class StatementModel(FrozenModel):
+    ...
 
 
 class CompoundStatement(StatementModel):
@@ -393,7 +394,6 @@ class Match(FrozenModel):
                     )
 
                 for location in result.locations:
-
                     # keep this in sync with the copy below
                     if isinstance(location, DynamicCallAddress):
                         if location in rule_matches:
@@ -733,9 +733,9 @@ class ResultDocument(FrozenModel):
     def to_capa(self) -> tuple[Metadata, "Capabilities"]:
         from capa.capabilities.common import Capabilities
 
-        matches: dict[str, list[tuple[capa.features.address.Address, capa.features.common.Result]]] = (
-            collections.defaultdict(list)
-        )
+        matches: dict[
+            str, list[tuple[capa.features.address.Address, capa.features.common.Result]]
+        ] = collections.defaultdict(list)
 
         # this doesn't quite work because we don't have the rule source for rules that aren't matched.
         rules_by_name = {


### PR DESCRIPTION
## Summary

Fix capa explorer plugin compatibility with IDA Essential 9.2 (PySide6).

## Problem

The plugin crashed due to Qt enum/flag differences and unavailable APIs in IDA 9.2 Essential. Specifically, Qt.ItemIsTristate is not present and bitwise ops on QtCore.Qt.* rely on PyQt5 shims, causing runtime errors/warnings.

## Solution

Add Qt5/Qt6 compatibility helpers and remove reliance on missing flags. Build ItemFlags safely across PySide6/PyQt5, avoid raw int() casts, and access MatchFlag in a Qt6-safe way. No behavior changes to the UI or matching logic.

## Scope

Only IDA plugin internals; users must still point the plugin to a rules directory containing .yml files (e.g., the official capa-rules tree).

## Changes

Update flag handling and enum access:

- capa/ida/plugin/item.py
- capa/ida/plugin/model.py

**Tested on IDA Essential 9.2 (PySide6), Python 3.13: plugin initializes, UI renders, and analysis runs when a valid capa-rules directory is selected.**

 [x] No CHANGELOG update needed