### PR TITLE
delay import to not load Qt* when running under idalib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 - add `ida-plugin.json` for inclusion in the IDA Pro plugin repository @williballenthin
 - ida plugin: add Qt compatibility layer for PyQt5 and PySide6 support @williballenthin #2707
+- delay import to not load Qt* when running under idalib @mr-tz #2752
 
 ### Development
 

--- a/capa/ida/plugin/__init__.py
+++ b/capa/ida/plugin/__init__.py
@@ -17,7 +17,6 @@ import logging
 import idaapi
 import ida_kernwin
 
-from capa.ida.plugin.form import CapaExplorerForm
 from capa.ida.plugin.icon import ICON
 
 logger = logging.getLogger(__name__)
@@ -74,6 +73,9 @@ class CapaExplorerPlugin(idaapi.plugin_t):
           arg (int): bitflag. Setting LSB enables automatic analysis upon
           loading. The other bits are currently undefined. See `form.Options`.
         """
+        # delay import to not trigger load of Qt components when not running in idaq, i.e., in idalib
+        from capa.ida.plugin.form import CapaExplorerForm
+
         if not self.form:
             self.form = CapaExplorerForm(self.PLUGIN_NAME, arg)
         else:


### PR DESCRIPTION
closes #2752


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
