### PR TITLE
add sequence statement for ordered matching

### DIFF
--- a/capa/render/result_document.py
+++ b/capa/render/result_document.py
@@ -167,7 +167,9 @@ class CompoundStatementType:
     AND = "and"
     OR = "or"
     NOT = "not"
+    NOT = "not"
     OPTIONAL = "optional"
+    SEQUENCE = "sequence"
 
 
 class StatementModel(FrozenModel): ...
@@ -213,7 +215,7 @@ class StatementNode(FrozenModel):
 
 
 def statement_from_capa(node: capa.engine.Statement) -> Statement:
-    if isinstance(node, (capa.engine.And, capa.engine.Or, capa.engine.Not)):
+    if isinstance(node, (capa.engine.And, capa.engine.Or, capa.engine.Not, capa.engine.Sequence)):
         return CompoundStatement(type=node.__class__.__name__.lower(), description=node.description)
 
     elif isinstance(node, capa.engine.Some):
@@ -279,6 +281,9 @@ def node_to_capa(
 
             elif node.statement.type == CompoundStatementType.OPTIONAL:
                 return capa.engine.Some(description=node.statement.description, count=0, children=children)
+
+            elif node.statement.type == CompoundStatementType.SEQUENCE:
+                return capa.engine.Sequence(description=node.statement.description, children=children)
 
             else:
                 assert_never(node.statement.type)

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -635,6 +635,8 @@ def build_statements(d, scopes: Scopes):
         return ceng.And(unique(build_statements(dd, scopes) for dd in d[key]), description=description)
     elif key == "or":
         return ceng.Or(unique(build_statements(dd, scopes) for dd in d[key]), description=description)
+    elif key == "sequence":
+        return ceng.Sequence(unique(build_statements(dd, scopes) for dd in d[key]), description=description)
     elif key == "not":
         if len(d[key]) != 1:
             raise InvalidRule("not statement must have exactly one child statement")
@@ -1698,7 +1700,7 @@ class RuleSet:
                 # feature is found N times
                 return rec(rule_name, node.child)
 
-            elif isinstance(node, ceng.And):
+            elif isinstance(node, (ceng.And, ceng.Sequence)):
                 # When evaluating an AND block, all of the children need to match.
                 #
                 # So when we index rules, we want to pick the most uncommon feature(s)


### PR DESCRIPTION
This PR, thanks to vibe coding, introduces a `sequence` statement to capa's rule language, enabling the enforcement of strict temporal or spatial ordering for matched features. Unlike `and`, which requires only the presence of features, `sequence` mandates that child statements occur in increasing address order (e.g., sequential API calls in dynamic analysis or ordered instructions in static analysis). The implementation leverages a greedy matching strategy to satisfy constraints.

In practice, a rule looks like:
```yaml
rule:
  meta:
    name: persist via Run registry key
    namespace: persistence/registry/run
[...]
  features:
    - sequence:
      - call:
        - and:
          - match: create or open registry key
          - or:
            - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Run/i
            - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders/i
            - string: /Software\\Microsoft\\Windows\\CurrentVersion\\User Shell Folders/i
            - string: /Software\\Microsoft\\Windows\\CurrentVersion\\RunServices/i
            - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run/i
            - string: /Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load/i
            - string: /System\\(ControlSet\d{3}|CurrentControlSet)\\Control\\Session Manager\\BootExecute/i
      - match: set registry value
```

and matches like:
```
persist via Run registry key (2 matches)
namespace  persistence/registry/run                                                                      
author     moritz.raabe@mandiant.com, mehunhoff@google.com                                               
scope      span of calls                                                                                 
att&ck     Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
mbc        Persistence::Registry Run Keys / Startup Folder [F0012]                                       
span of calls @ webcam_plugin.exe (C:\Users\38lTTV5Kii\AppData\Roaming\Microsot_Centre\webcam_plugin.exe){pid:2464,tid:5512,calls:{4756,4757}}
  sequence:
    call:
      and:
        match: create or open registry key
          or:
            api: RegCreateKeyEx @ call:4756
              RegCreateKeyExA(
                hKey: 0x80000002,
                lpSubKey: "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
                Reserved: 0x0,
                lpClass: 0x0,
                dwOptions: 0x0,
                samDesired: 0x20006,
                lpSecurityAttributes: 0x0,
                phkResult: 0x19fe88,
                lpdwDisposition: 0x19fe8c,
              ) -> phkResult: 0x178, lpdwDisposition: 0x2, ret_val: 0x0
        or:
          regex: /Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run/i
            - "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run" @ call:4756
              RegCreateKeyExA(
                hKey: 0x80000002,
                lpSubKey: "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
                Reserved: 0x0,
                lpClass: 0x0,
                dwOptions: 0x0,
                samDesired: 0x20006,
                lpSecurityAttributes: 0x0,
                phkResult: 0x19fe88,
                lpdwDisposition: 0x19fe8c,
              ) -> phkResult: 0x178, lpdwDisposition: 0x2, ret_val: 0x0
    match: set registry value
      or:
        or:
          api: RegSetValueEx @ call:4757
            RegSetValueExA(
              hKey: 0x178,
              lpValueName: "IExploreupdate",
              Reserved: 0x0,
              dwType: 0x1,
              lpData: "C:\\Users\\38lTTV5Kii\\AppData\\Roaming\\Microsot_Centre\\kscribexq.exe",
              cbData: 0x42,
            ) -> lpData: "C:\\Users\\38lTTV5Kii\\AppData\\Roaming\\Microsot_Centre\\kscribexq.exe", ret_val: 0x0
```

versus current results:

```
persist via Run registry key (2 matches)
namespace  persistence/registry/run                                                                      
author     moritz.raabe@mandiant.com, mehunhoff@google.com                                               
scope      span of calls                                                                                 
att&ck     Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
mbc        Persistence::Registry Run Keys / Startup Folder [F0012]                                       
span of calls @ webcam_plugin.exe (C:\Users\38lTTV5Kii\AppData\Roaming\Microsot_Centre\webcam_plugin.exe){pid:2464,tid:5512,calls:{4742,4756}}
  and:
    or:
      match: set registry value
        or:
          and:
            or:
              api: RegSetValueEx @ call:4742
                RegSetValueExA(
                  hKey: 0x178,
                  lpValueName: "KeyData",
                  Reserved: 0x0,
                  dwType: 0x1,
                  lpData: "1768590918",
                  cbData: 0xb,
                ) -> lpData: "1768590918", ret_val: 0x0
    or:
      regex: /Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run/i
        - "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run" @ call:4756
          RegCreateKeyExA(
            hKey: 0x80000002,
            lpSubKey: "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
            Reserved: 0x0,
            lpClass: 0x0,
            dwOptions: 0x0,
            samDesired: 0x20006,
            lpSecurityAttributes: 0x0,
            phkResult: 0x19fe88,
            lpdwDisposition: 0x19fe8c,
          ) -> phkResult: 0x178, lpdwDisposition: 0x2, ret_val: 0x0
```