### PR TITLE
fix(lint): disable rule caching during linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fixes
 - Fixed insecure deserialization vulnerability in YAML loading @0x1622 (#2770)
 - loader: gracefully handle ELF files with unsupported architectures kamranulhaq2002@gmail.com #2800
+- lint: disable rule caching during linting @Maijin #2817
 
 ### capa Explorer Web
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -661,7 +661,9 @@ def get_rules_from_cli(args) -> RuleSet:
     raises:
       ShouldExitError: if the program is invoked incorrectly and should exit.
     """
-    enable_cache: bool = True
+    enable_cache: bool = getattr(args, "enable_cache", True)
+    # this allows calling functions to easily disable rule caching, e.g., used by the rule linter to avoid
+
     try:
         if capa.helpers.is_running_standalone() and args.is_default_rules:
             cache_dir = get_default_root() / "cache"

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1229,6 +1229,7 @@ def main(argv=None):
 
     time0 = time.time()
 
+    args.enable_cache = False
     try:
         rules = capa.main.get_rules_from_cli(args)
     except capa.main.ShouldExitError as e:


### PR DESCRIPTION
- Disabling the rule cache during linting ensures validation runs against the current state of files on disk rather than stale cached data, effectively preventing false positives when rules are renamed or modified.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
