### PR TITLE
ci: auto-format dependabot PRs using existing black configuration

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,43 @@
+name: format
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .[dev,scripts]
+
+      - name: Run black
+        run: pre-commit run black --all-files
+
+      - name: Commit changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -u
+            git commit -m "style: auto-format with black"
+            git push origin HEAD:${{ github.head_ref }}
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
This PR adds a workflow that automatically runs Black on Dependabot PRs and commits formatting changes back to the same branch when required.

### Motivation

When Dependabot updates Black (or other dependencies affecting formatting), CI can fail due to formatting differences. Reviewers currently need to manually run Black and push a follow-up commit. This workflow removes that friction by auto-formatting the PR using the project's existing configuration.

### Implementation Details

- Runs only on `dependabot[bot]` pull requests.
- Reuses the existing Black configuration via `pre-commit run black`, ensuring consistency with the `tests.yml` CI job.
- Uses pinned action SHAs, following repository workflow conventions.
- Installs dependencies the same way as `tests.yml` to maintain environment parity.
- Commits changes only if formatting differences are detected.
- Does not affect human-authored PRs.

Closes #2827

---

### Checklist

- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
