### PR TITLE
render: escape sample-controlled strings to prevent rich MarkupError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 -
 
 ### Bug Fixes
+- render: escape sample-controlled strings before passing to Rich to prevent MarkupError @devs6186 #2699
 - Fixed insecure deserialization vulnerability in YAML loading @0x1622 (#2770)
 - loader: gracefully handle ELF files with unsupported architectures kamranulhaq2002@gmail.com #2800
 - loader: handle SegmentationViolation for malformed ELF files @kami922 #2799

--- a/capa/render/utils.py
+++ b/capa/render/utils.py
@@ -17,6 +17,7 @@ import io
 from typing import Union, Iterator, Optional
 
 import rich.console
+from rich.markup import escape
 from rich.progress import Text
 
 import capa.render.result_document as rd
@@ -24,21 +25,21 @@ import capa.render.result_document as rd
 
 def bold(s: str) -> Text:
     """draw attention to the given string"""
-    return Text.from_markup(f"[cyan]{s}")
+    return Text.from_markup(f"[cyan]{escape(s)}")
 
 
 def bold2(s: str) -> Text:
     """draw attention to the given string, within a `bold` section"""
-    return Text.from_markup(f"[green]{s}")
+    return Text.from_markup(f"[green]{escape(s)}")
 
 
 def mute(s: str) -> Text:
     """draw attention away from the given string"""
-    return Text.from_markup(f"[dim]{s}")
+    return Text.from_markup(f"[dim]{escape(s)}")
 
 
 def warn(s: str) -> Text:
-    return Text.from_markup(f"[yellow]{s}")
+    return Text.from_markup(f"[yellow]{escape(s)}")
 
 
 def format_parts_id(data: Union[rd.AttackSpec, rd.MBCSpec]):


### PR DESCRIPTION
closes #2699

Strings extracted from analyzed samples may contain bracket characters that Rich interprets as markup (e.g. `[/\xe1\xa5\xf9\x96_/x\xecJ@]`). When these are embedded directly in markup templates like `f"[dim]{s}"`, Rich raises a `MarkupError` if the brackets form an invalid or unclosed tag.

As noted in the issue, this is also a minor security concern: a crafted sample could embed Rich-style link markup that might render as a clickable hyperlink in the terminal output, potentially misleading analysts.

**Fix:** Import `rich.markup.escape()` and apply it to all user-controlled strings before embedding them in Rich markup templates in `bold()`, `bold2()`, `mute()`, and `warn()`.

### Checklist
- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.