### PR TITLE
render: use default styling for dynamic -vv API/call details so they are easier to see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - loader: handle SegmentationViolation for malformed ELF files @kami922 #2799
 - lint: disable rule caching during linting @Maijin #2817
 - vmray: skip processes with invalid PID or missing filename @EclipseAditya #2807
+- render: use default styling for dynamic -vv API/call details so they are easier to see @devs6186 #1865
 
 ### capa Explorer Web
 

--- a/capa/render/verbose.py
+++ b/capa/render/verbose.py
@@ -159,9 +159,8 @@ def render_call(layout: rd.DynamicLayout, addr: frz.Address) -> str:
     s.append(f"){rest}")
 
     newline = "\n"
-    return (
-        f"{pname}{{pid:{call.thread.process.pid},tid:{call.thread.tid},call:{call.id}}}\n{rutils.mute(newline.join(s))}"
-    )
+    # Use default (non-dim) styling for API details so they remain readable in -vv output
+    return f"{pname}{{pid:{call.thread.process.pid},tid:{call.thread.tid},call:{call.id}}}\n{newline.join(s)}"
 
 
 def render_short_call(layout: rd.DynamicLayout, addr: frz.Address) -> str:
@@ -180,7 +179,8 @@ def render_short_call(layout: rd.DynamicLayout, addr: frz.Address) -> str:
     s.append(f"){rest}")
 
     newline = "\n"
-    return f"call:{call.id}\n{rutils.mute(newline.join(s))}"
+    # Use default (non-dim) styling for API details so they remain readable in -vv output
+    return f"call:{call.id}\n{newline.join(s)}"
 
 
 def render_static_meta(console: Console, meta: rd.StaticMetadata):


### PR DESCRIPTION
closes #1865

In `-vv` dynamic output, `render_call()` and `render_short_call()` wrapped the API function name and arguments in `rutils.mute()`, rendering them in dim/grey color. On dark terminals this makes the most important part of the call details nearly invisible.

### Changes
- Removed the `rutils.mute()` wrapper from the call body in both `render_call()` and `render_short_call()` in `capa/render/verbose.py`.
- The process/thread/call-id prefix is unchanged; only the function name and arguments now use default (non-dim) terminal styling.

### Checklist
- [ ] No CHANGELOG update needed
- [ ] No new tests needed
- [ ] No documentation update needed
- [x] This submission includes AI-generated code and I have provided details in the description.