### PR TITLE
doc: fix typo in usage.md and add documentation links to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Development
 
+- doc: fix typo in usage.md, add documentation links to README @devs6186 #2274
 - ci: deprecate macos-13 runner and use Python v3.13 for testing @mike-hunhoff #2777
 
 ### Raw diffs

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Download stable releases of the standalone capa binaries [here](https://github.c
 
 To use capa as a library or integrate with another tool, see [doc/installation.md](https://github.com/mandiant/capa/blob/master/doc/installation.md) for further setup instructions.
 
+**Documentation:** [Usage and tips](doc/usage.md) · [Installation](doc/installation.md) · [Limitations](doc/limitations.md) · [FAQ](doc/faq.md)
+
 # capa Explorer Web
 The [capa Explorer Web](https://mandiant.github.io/capa/explorer/) enables you to interactively explore capa results in your web browser. Besides the online version you can download a standalone HTML file for local offline usage.
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,7 +11,7 @@ For example, `capa -t william.ballenthin@mandiant.com` runs rules that reference
 
 ### only analyze selected functions
 Use the `--restrict-to-functions` option to extract capabilities from only a selected set of functions. This is useful for analyzing 
-large functions and figuring out their capabilities and their address of occurance; for example: PEB access, RC4 encryption, etc.
+large functions and figuring out their capabilities and their address of occurrence; for example: PEB access, RC4 encryption, etc.
 
 To use this, you can copy the virtual addresses from your favorite disassembler and pass them to capa as follows:
 `capa sample.exe --restrict-to-functions 0x4019C0,0x401CD0`. If you add the `-v` option then capa will extract the interesting parts of a function for you.


### PR DESCRIPTION
closes #2274

Two small improvements to project documentation:

1. **Typo fix** in `doc/usage.md`: "occurance" → "occurrence" in the `--restrict-to-functions` tip.
2. **README discoverability**: Added a "Documentation" line in `README.md` with direct links to Usage, Installation, Limitations, and FAQ so users can find the right doc page without having to browse the repo.

### Checklist
- [ ] No CHANGELOG update needed
- [x] No new tests needed
- [ ] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.