### PR TITLE
binja: fix mypy "Cannot find implementation" for top-level binaryninja module

### DIFF
--- a/.github/mypy/mypy.ini
+++ b/.github/mypy/mypy.ini
@@ -63,6 +63,9 @@ ignore_missing_imports = True
 [mypy-PyQt5.*]
 ignore_missing_imports = True
 
+[mypy-binaryninja]
+ignore_missing_imports = True
+
 [mypy-binaryninja.*]
 ignore_missing_imports = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 - doc: document that default output shows top-level matches only; -v/-vv show nested matches @devs6186 #1410
 - doc: fix typo in usage.md, add documentation links to README @devs6186 #2274
+- binja: add mypy config for top-level binaryninja module to fix mypy issues @devs6186 #2399
 - ci: deprecate macos-13 runner and use Python v3.13 for testing @mike-hunhoff #2777
 
 ### Raw diffs


### PR DESCRIPTION
closes #2399

mypy reports `Cannot find implementation or library stub for module named 'binaryninja'` for the top-level import. `.github/mypy/mypy.ini` already suppressed `binaryninja.*` (sub-modules) but not the bare `binaryninja` import, so CI mypy checks fail when the Binary Ninja API is not installed.

### Changes
- Added `[mypy-binaryninja]` section with `ignore_missing_imports = True` to `.github/mypy/mypy.ini`, immediately before the existing `[mypy-binaryninja.*]` entry.

### Checklist
- [ ] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.