### PR TITLE
docs: add Scalene profiling guide for developer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Download stable releases of the standalone capa binaries [here](https://github.c
 
 To use capa as a library or integrate with another tool, see [doc/installation.md](https://github.com/mandiant/capa/blob/master/doc/installation.md) for further setup instructions.
 
-**Documentation:** [Usage and tips](doc/usage.md) · [Installation](doc/installation.md) · [Limitations](doc/limitations.md) · [FAQ](doc/faq.md)
+**Documentation:** [Usage and tips](doc/usage.md) · [Installation](doc/installation.md) · [Limitations](doc/limitations.md) · [FAQ](doc/faq.md) · [Profiling](doc/profiling.md)
 
 # capa Explorer Web
 The [capa Explorer Web](https://mandiant.github.io/capa/explorer/) enables you to interactively explore capa results in your web browser. Besides the online version you can download a standalone HTML file for local offline usage.
@@ -315,6 +315,7 @@ You can also run capa from the command line using the [Ghidra backend](https://g
 - [Installation](https://github.com/mandiant/capa/blob/master/doc/installation.md)
 - [Usage](https://github.com/mandiant/capa/blob/master/doc/usage.md)
 - [Limitations](https://github.com/mandiant/capa/blob/master/doc/limitations.md)
+- [Profiling](https://github.com/mandiant/capa/blob/master/doc/profiling.md)
 - [Contributing Guide](https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md)
 
 ## capa rules

--- a/doc/profiling.md
+++ b/doc/profiling.md
@@ -1,0 +1,40 @@
+# Profiling capa
+
+This document describes a developer workflow for profiling capa runtime and memory.
+
+We intentionally do **not** expose a dedicated `capa --profile` flag or `capa profile` subcommand. Profiling is a developer/research workflow and should not affect normal user-facing CLI behavior.
+
+## Existing profiling helpers
+
+- `scripts/profile-time.py` repeats capability matching and reports timing/evaluation counts.
+- `scripts/profile-memory.py` runs repeated analyses and reports memory behavior.
+
+These scripts are useful for establishing a baseline before and after a change.
+
+## Profiling with Scalene
+
+Use Scalene directly against the capa module:
+
+```bash
+python -m scalene -m capa.main --format freeze --backend vivisect /path/to/sample
+```
+
+Or run a profiling helper under Scalene for repeated measurements:
+
+```bash
+python -m scalene scripts/profile-time.py --number 3 --repeat 10 /path/to/sample
+```
+
+### Suggested workflow
+
+1. Capture a baseline profile on representative samples.
+2. Identify hotspots that are stable across runs.
+3. Implement behavior-preserving optimizations.
+4. Re-run the same profile commands and compare output.
+
+When sharing results in PRs/issues, include:
+
+- command line used,
+- sample(s) analyzed,
+- before/after timing or memory summaries,
+- confirmation that capa output remains unchanged.


### PR DESCRIPTION
**Solved :** https://github.com/mandiant/capa/issues/2880

**Description**
Add doc/profiling.md describing existing profiling helpers, Scalene invocation examples, and a suggested workflow, and update README.md to link to the new profiling guide.