### PR TITLE
render: buffer Console writes to reduce console.print overhead

### DIFF
--- a/capa/render/utils.py
+++ b/capa/render/utils.py
@@ -99,14 +99,41 @@ class StringIO(io.StringIO):
 
 
 class Console(rich.console.Console):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._line_buffer: list[Union[str, Text, rich.console.RenderableType]] = []
+
     def writeln(self, *args, **kwargs) -> None:
-        """
-        prints the text with a new line at the end.
-        """
-        return self.print(*args, **kwargs)
+        if args:
+            self._line_buffer.append(args[0])
+        self._flush_line_buffer(**kwargs)
 
     def write(self, *args, **kwargs) -> None:
-        """
-        prints the text without a new line at the end.
-        """
-        return self.print(*args, **kwargs, end="")
+        if args:
+            self._line_buffer.append(args[0])
+
+    def _flush_line_buffer(self, **kwargs) -> None:
+        if not self._line_buffer:
+            self.print(**kwargs)
+            return
+
+        renderables_present = any(not isinstance(item, (str, Text)) for item in self._line_buffer)
+
+        if renderables_present:
+            for item in self._line_buffer:
+                if isinstance(item, (str, Text)):
+                    self.print(item, end="", **kwargs)
+                else:
+                    self.print(item, **kwargs)
+            self._line_buffer.clear()
+            self.print(**kwargs)
+            return
+
+        line = Text()
+        for item in self._line_buffer:
+            if isinstance(item, Text):
+                line.append_text(item)
+            else:
+                line.append(str(item))
+        self._line_buffer.clear()
+        self.print(line, **kwargs)


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
closes #2559
## Optimize rendering performance by buffering Console writes

### Context

When rendering verbose (`-v`) and very verbose (`-vv`) output, capa experiences a significant performance bottleneck caused by the excessive number of `rich.console.print()` calls. As identified by @williballenthin using `line-profiler`, the `render_feature` function is one of the most expensive operations during output rendering — not because of the string construction, but because each fragment of a line triggers a separate `rich.console.print()` invocation.

The root cause is in the `Console` wrapper class in `capa/render/utils.py`. Both `write()` and `writeln()` directly delegate to `self.print()`:

```python
# Before: every call triggers a full Rich console.print:
class Console(rich.console.Console):
    def writeln(self, *args, **kwargs) -> None:
        return self.print(*args, **kwargs)

    def write(self, *args, **kwargs) -> None:
        return self.print(*args, **kwargs, end="")
```

In `vverbose.py`, a single `render_feature()` call makes **5–8 separate `console.write()` calls** (indent, key, colon, value, description, locations). Across thousands of matched features, this creates thousands of expensive Rich print operations. @williballenthin measured `console.print()` to be approximately **100x slower** than intermediate string construction, and confirmed that redirecting to `StringIO` does not help — the overhead is within Rich's `print` implementation itself.

### The Approach

Instead of calling `rich.console.print()` on every `write()`, the refactored `Console` class **buffers** all `write()` content into an internal list and only flushes to `console.print()` once per complete line when `writeln()` is called.

```python
# After: writes are buffered, flushed once per line:
class Console(rich.console.Console):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self._line_buffer: list[Union[str, Text, rich.console.RenderableType]] = []

    def writeln(self, *args, **kwargs) -> None:
        if args:
            self._line_buffer.append(args[0])
        self._flush_line_buffer(**kwargs)

    def write(self, *args, **kwargs) -> None:
        if args:
            self._line_buffer.append(args[0])
        # ... logic to flush on writeln
```

Key design decisions:

- **`write()` appends to `_line_buffer`** without any `console.print()` call — zero overhead per fragment
- **`writeln()` flushes the buffer**: joins all `str` and `Text` items into a single `Text` object via `append_text()`, then calls `console.print()` once
- **Rich renderables** (e.g., `Table` objects) are printed individually as a fallback
- **Zero changes to `verbose.py`, `vverbose.py`, or any other file** — the optimization is entirely self-contained.

### Impact

Performance testing confirms that buffering fragments into a single `writeln` call reduces `console.print()` overhead from 5–8 calls per feature down to 1. This results in a ~5–8x reduction in expensive Rich print operations, directly addressing the performance bottleneck identified in #2559.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->

- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [ ] This submission includes AI-generated code and I have provided details in the description.
