### PR TITLE
fix: resolve mypy type error in dumps_dynamic by using actual field name

### DIFF
--- a/capa/features/freeze/__init__.py
+++ b/capa/features/freeze/__init__.py
@@ -490,11 +490,10 @@ def dumps_dynamic(extractor: DynamicFeatureExtractor) -> str:
             taddr = Address.from_capa(t.address)
             tfeatures = [
                 ThreadFeature(
-                    basic_block=taddr,
+                    thread=taddr,
                     address=Address.from_capa(addr),
                     feature=feature_from_capa(feature),
-                )  # type: ignore
-                # Mypy is unable to recognise `basic_block` as an argument due to alias
+                )
                 for feature, addr in extractor.extract_thread_features(p, t)
             ]
 


### PR DESCRIPTION
## Description
This PR resolves a Mypy typing error within the `dumps_dynamic` function and removes the need for a `# type: ignore` bypass. 

## Problem
Previously, `ThreadFeature` was being instantiated using the Pydantic alias `basic_block`. While Pydantic handles this during serialization, Mypy's type checker strictly looks for the actual Python field name, causing it to fail and requiring a `# type: ignore` comment.

## Solution
Changed the initialization argument in `ThreadFeature` from the alias (`basic_block`) to the actual model field name (`thread`). 

This satisfies Mypy's static analysis out of the box while preserving the correct JSON serialization behavior via Pydantic's alias setup.

## Changes Made
* Updated `ThreadFeature` instantiation in `dumps_dynamic` to use `thread=taddr` instead of `basic_block=taddr`.
* Removed the obsolete `# type: ignore` comment.

### Checklist

- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [ ] This submission includes AI-generated code and I have provided details in the description.
