### PR TITLE
fix(range): correct unbounded max sentinel precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - loader: handle struct.error from dnfile and show clear CorruptFile message @devs6186 #2442
 - address: fix TypeError when sorting locations containing mixed address types @devs6186 #2195
 - loader: skip PE files with unrealistically large section virtual sizes to prevent resource exhaustion @devs6186 #1989
+- engine/render: fix unbounded range sentinel precedence so `count(...): N or more` uses explicit `((1 << 64) - 1)` @blenbot #2936
 
 ### capa Explorer Web
 - webui: fix 404 for "View rule in capa-rules" by using encodeURIComponent for rule name in URL @devs6186 #2482

--- a/capa/engine.py
+++ b/capa/engine.py
@@ -227,7 +227,7 @@ class Range(Statement):
         super().__init__(description=description)
         self.child = child
         self.min = min if min is not None else 0
-        self.max = max if max is not None else (1 << 64 - 1)
+        self.max = max if max is not None else ((1 << 64) - 1)
 
     def evaluate(self, features: FeatureSet, short_circuit=True):
         capa.perf.counters["evaluate.feature"] += 1
@@ -240,7 +240,7 @@ class Range(Statement):
         return Result(self.min <= count <= self.max, self, [], locations=features.get(self.child))
 
     def __str__(self):
-        if self.max == (1 << 64 - 1):
+        if self.max == ((1 << 64) - 1):
             return f"range({str(self.child)}, min={self.min}, max=infinity)"
         else:
             return f"range({str(self.child)}, min={self.min}, max={self.max})"

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -403,7 +403,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
                 display += f"{statement.min}"
             elif statement.min == 0:
                 display += f"{statement.max} or fewer"
-            elif statement.max == (1 << 64 - 1):
+            elif statement.max == ((1 << 64) - 1):
                 display += f"{statement.min} or more"
             else:
                 display += f"between {statement.min} and {statement.max}"

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -172,7 +172,7 @@ def render_statement(console: Console, layout: rd.Layout, match: rd.Match, state
             console.write(f"{statement.min}")
         elif statement.min == 0:
             console.write(f"{statement.max} or fewer")
-        elif statement.max == (1 << 64 - 1):
+        elif statement.max == ((1 << 64) - 1):
             console.write(f"{statement.min} or more")
         else:
             console.write(f"between {statement.min} and {statement.max}")


### PR DESCRIPTION
# Summary

This PR fixes a precedence bug in the range “infinity” sentinel by replacing 1 << 64 - 1 with ((1 << 64) - 1).

### Motivation

In Python, 1 << 64 - 1 is parsed as 1 << (64 - 1) (i.e., 2^63), not 2^64 - 1.
This sentinel is used in:

- `Range` default max assignment
- `Range.__str__` infinity check
- verbose renderer “or more” check
- IDA plugin renderer “or more” check

So logic and rendering should share the same corrected explicit value.


### Checklist

- [x] CHANGELOG updated
- [x] No new tests needed
- [x] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.

### Issue link

fixes #2936 