### PR TITLE
tests: import capa.render.default in test_render

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -22,6 +22,7 @@ import capa.rules
 import capa.render.utils
 import capa.features.file
 import capa.features.insn
+import capa.render.default
 import capa.features.common
 import capa.features.freeze
 import capa.render.vverbose
@@ -29,7 +30,6 @@ import capa.features.address
 import capa.features.basicblock
 import capa.render.result_document
 import capa.render.result_document as rd
-import capa.render.default
 import capa.features.freeze.features
 from capa.render.utils import Console
 


### PR DESCRIPTION
# Summary

While running focused tests specifically `test_render.py` I encountered the following problem:

 ```
       AttributeError: module 'capa.render' has no attribute 'default'

tests\test_render.py:153: AttributeError
============================ short test summary info ============================ 
FAILED tests/test_render.py::test_render_meta_maec - AttributeError: module 'capa.render' has no attribute 'default'
========================= 1 failed, 29 passed in 0.32s ========================== 
```

To fix this I added missing `capa.render.default` in the `test_render.py`.

## Changes

- Add explicit `import capa.render.default` in `tests/test_render.py`.

### Checklist

- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.
