### PR TITLE
main: add project links and verbosity hint to CLI help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- main: add GitHub, documentation, and issue reporting links to CLI help text @Xavrir #1686
+- main: add verbosity hint to CLI help epilog @Xavrir #1686
 - ghidra: support PyGhidra @mike-hunhoff #2788
 - vmray: extract number features from whitelisted void_ptr parameters (hKey, hKeyRoot) @adeboyedn #2835
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -972,6 +972,12 @@ def main(argv: Optional[list[str]] = None):
 
           filter rules by meta fields, e.g. rule name or namespace
             capa -t "create TCP socket" suspicious.exe
+
+        Use -v/--verbose and -vv/--vverbose for increasingly detailed output.
+
+        GitHub:        https://github.com/mandiant/capa
+        Documentation: https://github.com/mandiant/capa/tree/master/doc
+        Report issues: https://github.com/mandiant/capa/issues
          """)
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## Summary

Addresses suggestions from #1686 (review [clig.dev](https://clig.dev/) for CLI guidelines):

- Add GitHub repository, documentation, and issue reporting links to the CLI help epilog, following [clig.dev's recommendation](https://clig.dev/#help) to include a support path in top-level help text
- Add a hint about `-v`/`--verbose` and `-vv`/`--vverbose` flags so users know how to get more detailed output

These are the changes that were explicitly discussed and approved in #1686 (GitHub link approved by @mr-tz, verbosity hint suggested by @williballenthin).

## Changes

**`capa/main.py`**: Added 6 lines to the CLI help epilog:
- Verbosity hint line
- Three labeled links (GitHub, Documentation, Report issues)

**`CHANGELOG.md`**: Added two entries under New Features.

## Test plan

- [x] `black --check` passes (no formatting changes needed)
- [ ] Verify `capa --help` displays the new links and hint correctly at the bottom of the help text
- [ ] CI passes

Closes #1686