### PR TITLE
fix(freeze): use get_base_address in dumps_dynamic

### DIFF
--- a/capa/features/freeze/__init__.py
+++ b/capa/features/freeze/__init__.py
@@ -543,7 +543,7 @@ def dumps_dynamic(extractor: DynamicFeatureExtractor) -> str:
     # Mypy is unable to recognise `global_` as an argument due to alias
 
     # workaround around mypy issue: https://github.com/python/mypy/issues/1424
-    get_base_addr = getattr(extractor, "get_base_addr", None)
+    get_base_addr = getattr(extractor, "get_base_address", None)
     base_addr = get_base_addr() if get_base_addr else capa.features.address.NO_ADDRESS
 
     freeze = Freeze(


### PR DESCRIPTION
# Summary

While going through `freeze` in `__init__.py` I found that `dumps_dynamic` expects a `DynamicFeatureExtractor` and it was doing this to get `base_address`: `get_base_addr = getattr(extractor, "get_base_addr", None)` but upon examining extractors(`cape`, `drakvuf`, `vmray`) which subclasses `DynamicFeatureExtractor`, I noticed all of them have an attribute named `get_base_address` not `get_base_addr`.

### Problem

- This caused fallback to `NO_ADDRESS` in all cases and loss of base address information.

### Changes

- Update dynamic freeze serialization to call/use `get_base_address()`.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [ ] This submission includes AI-generated code and I have provided details in the description.
