### PR TITLE
freeze: support float operand numbers in feature serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - loader: skip PE files with unrealistically large section virtual sizes to prevent resource exhaustion @devs6186 #1989
 - engine/render: fix unbounded range sentinel precedence so `count(...): N or more` uses explicit `((1 << 64) - 1)` @blenbot #2936
 - cache: support *BSD @williballenthin @res2500 #2949
+- freeze: support float `operand number` values in feature freeze conversion @blenbot #2957
 
 ### capa Explorer Web
 - webui: fix 404 for "View rule in capa-rules" by using encodeURIComponent for rule name in URL @devs6186 #2482

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - loader: skip PE files with unrealistically large section virtual sizes to prevent resource exhaustion @devs6186 #1989
 - engine/render: fix unbounded range sentinel precedence so `count(...): N or more` uses explicit `((1 << 64) - 1)` @blenbot #2936
 - cache: support *BSD @williballenthin @res2500 #2949
-- freeze: support float `operand number` values in feature freeze conversion @blenbot #2957
+- freeze: support float `operand number` values in feature freeze conversion @blenbot #2958
 
 ### capa Explorer Web
 - webui: fix 404 for "View rule in capa-rules" by using encodeURIComponent for rule name in URL @devs6186 #2482

--- a/capa/features/freeze/features.py
+++ b/capa/features/freeze/features.py
@@ -201,7 +201,7 @@ def feature_from_capa(f: capa.features.common.Feature) -> "Feature":
         return MnemonicFeature(mnemonic=f.value, description=f.description)
 
     elif isinstance(f, capa.features.insn.OperandNumber):
-        assert isinstance(f.value, Union[int, float])
+        assert isinstance(f.value, (int, float))
         return OperandNumberFeature(index=f.index, operand_number=f.value, description=f.description)  # type: ignore
         # Mypy is unable to recognise `operand_number` as an argument due to alias
 

--- a/capa/features/freeze/features.py
+++ b/capa/features/freeze/features.py
@@ -201,7 +201,7 @@ def feature_from_capa(f: capa.features.common.Feature) -> "Feature":
         return MnemonicFeature(mnemonic=f.value, description=f.description)
 
     elif isinstance(f, capa.features.insn.OperandNumber):
-        assert isinstance(f.value, int)
+        assert isinstance(f.value, Union[int, float])
         return OperandNumberFeature(index=f.index, operand_number=f.value, description=f.description)  # type: ignore
         # Mypy is unable to recognise `operand_number` as an argument due to alias
 
@@ -343,7 +343,7 @@ class MnemonicFeature(FeatureModel):
 class OperandNumberFeature(FeatureModel):
     type: Literal["operand number"] = "operand number"
     index: int
-    operand_number: int = Field(alias="operand number")
+    operand_number: Union[int, float] = Field(alias="operand number")
     description: Optional[str] = None
 
 


### PR DESCRIPTION
# Summary

While going through `capa/feature/freeze/features.py` I noticed `OperandNumber` branch does an assertion which is `assert isinstance(f.value, int)` but `capa.features.insn.OperandNumber` accepts either `int`/`float` type for it's value.

This leads to serializing a valid feature such as `OperandNumber(0, 1.5)` to fail.

### Changes

- Update freeze conversion/type handling for `OperandNumber` to accept `int` or `float`.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [ ] This submission includes AI-generated code and I have provided details in the description.
