### PR TITLE
Run ruff linter on all files in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
         pip install -r requirements.txt
         pip install -e .[dev,scripts]
     - name: Lint with ruff
-      run: pre-commit run ruff
+      run: pre-commit run ruff --all-files
     - name: Lint with isort
       run: pre-commit run isort --show-diff-on-failure
     - name: Lint with black


### PR DESCRIPTION
This PR updates the CI workflow to run Ruff on all files.

- Uses `pre-commit run ruff --all-files` in CI
- Ensures Ruff checks the entire codebase instead of only staged files

This improves consistency between local development and CI behavior.

Closes #2945

### Checklist

- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed
- [ ] This submission includes AI-generated code and I have provided details in the description.