### PR TITLE
ci: fix ZIP_NAME environment variable in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,8 @@ jobs:
             artifact_name: capa
           - asset_name: macos-arm64
             artifact_name: capa
+    env:
+      ZIP_NAME: capa-${{ github.event.release.tag_name }}-${{ matrix.asset_name }}.zip
     steps:
       - name: Download ${{ matrix.asset_name }}
         uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
@@ -164,13 +166,11 @@ jobs:
           name: ${{ matrix.asset_name }}
       - name: Set executable flag
         run: chmod +x ${{ matrix.artifact_name }}
-      - name: Set zip name
-        run: echo "zip_name=capa-${GITHUB_REF#refs/tags/}-${{ matrix.asset_name }}.zip" >> $GITHUB_ENV
-      - name: Zip ${{ matrix.artifact_name }} into ${{ env.zip_name }}
+      - name: Zip ${{ matrix.artifact_name }} into ${{ env.ZIP_NAME }}
         run: zip ${ZIP_NAME} ${{ matrix.artifact_name }}
-      - name: Upload ${{ env.zip_name }} to GH Release
+      - name: Upload ${{ env.ZIP_NAME }} to GH Release
         uses: svenstaro/upload-release-action@2728235f7dc9ff598bd86ce3c274b74f802d2208 # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN}}
-          file: ${{ env.zip_name }}
+          file: ${{ env.ZIP_NAME }}
           tag: ${{ github.ref }}


### PR DESCRIPTION
Fixes a bug where ZIP_NAME was empty in the shell command due to a case sensitivity mismatch. Refactored to use a job-level env block for better consistency.

[x] No CHANGELOG update needed