### PR TITLE
tests: migrate to data-driven fixtures for feature presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@ This release includes Ghidra PyGhidra support, performance improvements, depende
 - rules: pre-filter extracted bytes with 4-byte prefixes for faster candidate selection instead of linear scan #2128
 - ci: deprecate macos-13 runner and use Python v3.13 for testing @mike-hunhoff #2777
 - ci: pin pip-audit action SHAs and update to v1.1.0 @kami922 #1131
+- tests: use data-driven fixtures to declare feature tests @williballenthin #2743
 
 ### Raw diffs
 - [capa v9.3.1...v9.4.0](https://github.com/mandiant/capa/compare/v9.3.1...v9.4.0)

--- a/capa/features/extractors/ida/extractor.py
+++ b/capa/features/extractors/ida/extractor.py
@@ -16,19 +16,19 @@ from typing import Iterator
 
 import idaapi
 
-import capa.features.extractors.ida.basicblock
-import capa.features.extractors.ida.file
-import capa.features.extractors.ida.function
-import capa.features.extractors.ida.global_
-import capa.features.extractors.ida.insn
 import capa.ida.helpers
-from capa.features.address import AbsoluteVirtualAddress, Address
+import capa.features.extractors.ida.file
+import capa.features.extractors.ida.insn
+import capa.features.extractors.ida.global_
+import capa.features.extractors.ida.function
+import capa.features.extractors.ida.basicblock
 from capa.features.common import Feature
+from capa.features.address import Address, AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import (
     BBHandle,
-    FunctionHandle,
     InsnHandle,
     SampleHashes,
+    FunctionHandle,
     StaticFeatureExtractor,
 )
 
@@ -43,9 +43,7 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
             )
         )
         self.global_features: list[tuple[Feature, Address]] = []
-        self.global_features.extend(
-            capa.features.extractors.ida.file.extract_file_format()
-        )
+        self.global_features.extend(capa.features.extractors.ida.file.extract_file_format())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_os())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_arch())
 
@@ -69,9 +67,7 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
         f = idaapi.get_func(ea)
         return FunctionHandle(address=AbsoluteVirtualAddress(f.start_ea), inner=f)
 
-    def extract_function_features(
-        self, fh: FunctionHandle
-    ) -> Iterator[tuple[Feature, Address]]:
+    def extract_function_features(self, fh: FunctionHandle) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.ida.function.extract_features(fh)
 
     def get_basic_blocks(self, fh: FunctionHandle) -> Iterator[BBHandle]:
@@ -80,19 +76,13 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
         for bb in ida_helpers.get_function_blocks(fh.inner):
             yield BBHandle(address=AbsoluteVirtualAddress(bb.start_ea), inner=bb)
 
-    def extract_basic_block_features(
-        self, fh: FunctionHandle, bbh: BBHandle
-    ) -> Iterator[tuple[Feature, Address]]:
+    def extract_basic_block_features(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.ida.basicblock.extract_features(fh, bbh)
 
-    def get_instructions(
-        self, fh: FunctionHandle, bbh: BBHandle
-    ) -> Iterator[InsnHandle]:
+    def get_instructions(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[InsnHandle]:
         import capa.features.extractors.ida.helpers as ida_helpers
 
-        for insn in ida_helpers.get_instructions_in_range(
-            bbh.inner.start_ea, bbh.inner.end_ea
-        ):
+        for insn in ida_helpers.get_instructions_in_range(bbh.inner.start_ea, bbh.inner.end_ea):
             yield InsnHandle(address=AbsoluteVirtualAddress(insn.ea), inner=insn)
 
     def extract_insn_features(self, fh: FunctionHandle, bbh: BBHandle, ih: InsnHandle):

--- a/capa/features/extractors/ida/extractor.py
+++ b/capa/features/extractors/ida/extractor.py
@@ -16,19 +16,19 @@ from typing import Iterator
 
 import idaapi
 
-import capa.ida.helpers
-import capa.features.extractors.ida.file
-import capa.features.extractors.ida.insn
-import capa.features.extractors.ida.global_
-import capa.features.extractors.ida.function
 import capa.features.extractors.ida.basicblock
+import capa.features.extractors.ida.file
+import capa.features.extractors.ida.function
+import capa.features.extractors.ida.global_
+import capa.features.extractors.ida.insn
+import capa.ida.helpers
+from capa.features.address import AbsoluteVirtualAddress, Address
 from capa.features.common import Feature
-from capa.features.address import Address, AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import (
     BBHandle,
+    FunctionHandle,
     InsnHandle,
     SampleHashes,
-    FunctionHandle,
     StaticFeatureExtractor,
 )
 
@@ -43,7 +43,9 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
             )
         )
         self.global_features: list[tuple[Feature, Address]] = []
-        self.global_features.extend(capa.features.extractors.ida.file.extract_file_format())
+        self.global_features.extend(
+            capa.features.extractors.ida.file.extract_file_format()
+        )
         self.global_features.extend(capa.features.extractors.ida.global_.extract_os())
         self.global_features.extend(capa.features.extractors.ida.global_.extract_arch())
 
@@ -67,7 +69,9 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
         f = idaapi.get_func(ea)
         return FunctionHandle(address=AbsoluteVirtualAddress(f.start_ea), inner=f)
 
-    def extract_function_features(self, fh: FunctionHandle) -> Iterator[tuple[Feature, Address]]:
+    def extract_function_features(
+        self, fh: FunctionHandle
+    ) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.ida.function.extract_features(fh)
 
     def get_basic_blocks(self, fh: FunctionHandle) -> Iterator[BBHandle]:
@@ -76,13 +80,19 @@ class IdaFeatureExtractor(StaticFeatureExtractor):
         for bb in ida_helpers.get_function_blocks(fh.inner):
             yield BBHandle(address=AbsoluteVirtualAddress(bb.start_ea), inner=bb)
 
-    def extract_basic_block_features(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[tuple[Feature, Address]]:
+    def extract_basic_block_features(
+        self, fh: FunctionHandle, bbh: BBHandle
+    ) -> Iterator[tuple[Feature, Address]]:
         yield from capa.features.extractors.ida.basicblock.extract_features(fh, bbh)
 
-    def get_instructions(self, fh: FunctionHandle, bbh: BBHandle) -> Iterator[InsnHandle]:
+    def get_instructions(
+        self, fh: FunctionHandle, bbh: BBHandle
+    ) -> Iterator[InsnHandle]:
         import capa.features.extractors.ida.helpers as ida_helpers
 
-        for insn in ida_helpers.get_instructions_in_range(bbh.inner.start_ea, bbh.inner.end_ea):
+        for insn in ida_helpers.get_instructions_in_range(
+            bbh.inner.start_ea, bbh.inner.end_ea
+        ):
             yield InsnHandle(address=AbsoluteVirtualAddress(insn.ea), inner=insn)
 
     def extract_insn_features(self, fh: FunctionHandle, bbh: BBHandle, ih: InsnHandle):

--- a/capa/features/extractors/ida/idalib.py
+++ b/capa/features/extractors/ida/idalib.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
-import json
 import logging
 import importlib.util
-from typing import Optional
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -28,97 +23,3 @@ def is_idalib_installed() -> bool:
         return importlib.util.find_spec("idapro") is not None
     except ModuleNotFoundError:
         return False
-
-
-def get_idalib_user_config_path() -> Optional[Path]:
-    """Get the path to the user's config file based on platform following IDA's user directories."""
-    # derived from `py-activate-idalib.py` from IDA v9.0 Beta 4
-
-    if sys.platform == "win32":
-        # On Windows, use the %APPDATA%\Hex-Rays\IDA Pro directory
-        config_dir = Path(os.getenv("APPDATA")) / "Hex-Rays" / "IDA Pro"
-    else:
-        # On macOS and Linux, use ~/.idapro
-        config_dir = Path.home() / ".idapro"
-
-    # Return the full path to the config file (now in JSON format)
-    user_config_path = config_dir / "ida-config.json"
-    if not user_config_path.exists():
-        return None
-    return user_config_path
-
-
-def find_idalib() -> Optional[Path]:
-    config_path = get_idalib_user_config_path()
-    if not config_path:
-        logger.error("IDA Pro user configuration does not exist, please make sure you've installed idalib properly.")
-        return None
-
-    config = json.loads(config_path.read_text(encoding="utf-8"))
-
-    try:
-        ida_install_dir = Path(config["Paths"]["ida-install-dir"])
-    except KeyError:
-        logger.error(
-            "IDA Pro user configuration does not contain location of IDA Pro installation, please make sure you've installed idalib properly."
-        )
-        return None
-
-    if not ida_install_dir.exists():
-        return None
-
-    libname = {
-        "win32": "idalib.dll",
-        "linux": "libidalib.so",
-        "linux2": "libidalib.so",
-        "darwin": "libidalib.dylib",
-    }[sys.platform]
-
-    if not (ida_install_dir / "ida.hlp").is_file():
-        return None
-
-    if not (ida_install_dir / libname).is_file():
-        return None
-
-    idalib_path = ida_install_dir / "idalib" / "python"
-    if not idalib_path.exists():
-        return None
-
-    if not (idalib_path / "idapro" / "__init__.py").is_file():
-        return None
-
-    return idalib_path
-
-
-def has_idalib() -> bool:
-    if is_idalib_installed():
-        logger.debug("found installed IDA idalib API")
-        return True
-
-    logger.debug("IDA idalib API not installed, searching...")
-
-    idalib_path = find_idalib()
-    if not idalib_path:
-        logger.debug("failed to find IDA idalib installation")
-
-    logger.debug("found IDA idalib API: %s", idalib_path)
-    return idalib_path is not None
-
-
-def load_idalib() -> bool:
-    try:
-        import idapro
-
-        return True
-    except ImportError:
-        idalib_path = find_idalib()
-        if not idalib_path:
-            return False
-
-        sys.path.append(idalib_path.absolute().as_posix())
-        try:
-            import idapro  # noqa: F401 unused import
-
-            return True
-        except ImportError:
-            return False

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -386,11 +386,8 @@ def get_extractor(
     elif backend == BACKEND_IDA:
         import capa.features.extractors.ida.idalib as idalib
 
-        if not idalib.has_idalib():
-            raise RuntimeError("cannot find IDA idalib module.")
-
-        if not idalib.load_idalib():
-            raise RuntimeError("failed to load IDA idalib module.")
+        if not idalib.is_idalib_installed():
+            raise RuntimeError("idalib not available.")
 
         import idapro
         import ida_auto

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -360,7 +360,7 @@ def translate_com_feature(com_name: str, com_type: ComType) -> ceng.Statement:
 
 
 def parse_int(s: str) -> int:
-    if s.startswith("0x"):
+    if s.startswith(("0x", "-0x")):
         return int(s, 0x10)
     else:
         return int(s, 10)
@@ -623,6 +623,213 @@ def is_subscope_compatible(scope: Scope | None, subscope: Scope) -> bool:
         raise ValueError("unexpected scope")
 
 
+def build_feature(
+    key: str, initial_value: str | int, initial_description: str | None = None
+) -> Feature | ceng.Range | ceng.Statement:
+    """
+    from a key-value pair, like ("number": "12 = Foo"), return a Feature (or Range or Statement).
+    parses the description from the value, or uses the initial_description if provided.
+
+    returns: Feature usually, or Range for count(...) features, or Statement for COM-derived featues.
+    """
+    if key.startswith("count(") and key.endswith(")"):
+        # e.g.:
+        #
+        #     count(basic block)
+        #     count(mnemonic(mov))
+        #     count(characteristic(nzxor))
+
+        term = key[len("count(") : -len(")")]
+
+        # when looking for the existence of such a feature, our rule might look like:
+        #     - mnemonic: mov
+        #
+        # but here we deal with the form: `mnemonic(mov)`.
+        term, _, arg = term.partition("(")
+        Feature = parse_feature(term)
+
+        if arg:
+            arg = arg[: -len(")")]
+            # can't rely on yaml parsing ints embedded within strings
+            # like:
+            #
+            #     count(offset(0xC))
+            #     count(number(0x11223344))
+            #     count(number(0x100 = description))
+            if term != "string":
+                value, description = parse_description(arg, term)
+
+                if term == "api":
+                    if not isinstance(value, str):
+                        raise InvalidRule(f"unexpected {term} value type: {type(value)}")
+                    value = trim_dll_part(value)
+
+                feature = Feature(value, description=description)  # type: ignore[call-arg]  # Feature is a runtime union; constructor args vary per subclass
+            else:
+                # arg is string (which doesn't support inline descriptions), like:
+                #
+                #     count(string(error))
+                #
+                # known problem that embedded newlines may not work here?
+                # this may become a problem (or not), so address it when encountered.
+                feature = Feature(arg)
+        else:
+            feature = Feature()  # type: ignore[call-arg]  # Feature is a runtime union; constructor args vary per subclass
+
+        # initial value might be things like:
+        #   - 10
+        #   - "10"
+        #   - "10 or more"
+        count: int | str = initial_value
+
+        if isinstance(count, int):
+            return ceng.Range(feature, min=count, max=count, description=initial_description)
+        elif count.endswith(" or more"):
+            min = parse_int(count[: -len(" or more")])
+            max = None
+            return ceng.Range(feature, min=min, max=max, description=initial_description)
+        elif count.endswith(" or fewer"):
+            min = None
+            max = parse_int(count[: -len(" or fewer")])
+            return ceng.Range(feature, min=min, max=max, description=initial_description)
+        elif count.startswith("("):
+            min, max = parse_range(count)
+            return ceng.Range(feature, min=min, max=max, description=initial_description)
+        else:
+            try:
+                # convert "10" -> 10
+                count = parse_int(count)
+            except ValueError:
+                raise InvalidRule(f"unexpected range: {count}")
+            return ceng.Range(feature, min=count, max=count, description=initial_description)
+
+    elif key == "string" and not isinstance(initial_value, str):
+        raise InvalidRule(f"ambiguous string value {initial_value}, must be defined as explicit string")
+
+    elif key.startswith("operand[") and key.endswith("].number"):
+        try:
+            index = int(key[len("operand[") : -len("].number")])
+        except ValueError as e:
+            raise InvalidRule("operand index must be an integer") from e
+
+        value, description = parse_description(initial_value, key, description=initial_description)
+        assert isinstance(value, int)
+        try:
+            feature = capa.features.insn.OperandNumber(index, value, description=description)
+        except ValueError as e:
+            raise InvalidRule(str(e)) from e
+        return feature
+
+    elif key.startswith("operand[") and key.endswith("].offset"):
+        try:
+            index = int(key[len("operand[") : -len("].offset")])
+        except ValueError as e:
+            raise InvalidRule("operand index must be an integer") from e
+
+        value, description = parse_description(initial_value, key, description=initial_description)
+        assert isinstance(value, int)
+        try:
+            feature = capa.features.insn.OperandOffset(index, value, description=description)
+        except ValueError as e:
+            raise InvalidRule(str(e)) from e
+        return feature
+
+    elif (
+        (key == "os" and initial_value not in capa.features.common.VALID_OS)
+        or (key == "format" and initial_value not in capa.features.common.VALID_FORMAT)
+        or (key == "arch" and initial_value not in capa.features.common.VALID_ARCH)
+    ):
+        raise InvalidRule(f"unexpected {key} value {initial_value}")
+
+    elif key.startswith("property/"):
+        access = key[len("property/") :]
+        if access not in capa.features.common.VALID_FEATURE_ACCESS:
+            raise InvalidRule(f"unexpected {key} access {access}")
+
+        value, description = parse_description(initial_value, key, description=initial_description)
+        if not isinstance(value, str):
+            raise InvalidRule(f"unexpected {key} value type: {type(value)}")
+        try:
+            feature = capa.features.insn.Property(value, access=access, description=description)
+        except ValueError as e:
+            raise InvalidRule(str(e)) from e
+        return feature
+
+    elif key.startswith("com/"):
+        com_type_name = str(key[len("com/") :])
+        try:
+            com_type = ComType(com_type_name)
+        except ValueError:
+            raise InvalidRule(f"unexpected COM type: {com_type_name}")
+        value, description = parse_description(initial_value, key, description=initial_description)
+        if not isinstance(value, str):
+            raise InvalidRule(f"unexpected {key} value type: {type(value)}")
+        return translate_com_feature(value, com_type)
+
+    else:
+        Feature = parse_feature(key)
+        value, description = parse_description(initial_value, key, description=initial_description)
+
+        try:
+            match Feature:
+                case capa.features.insn.OperandNumber | capa.features.insn.OperandOffset:
+                    raise RuntimeError("should be impossible")
+
+                case capa.features.insn.Offset | capa.features.insn.Number:
+                    assert isinstance(value, int)
+                    return Feature(value, description=description)
+
+                case capa.features.insn.API:
+                    assert isinstance(value, str)
+                    # users can specify an API name with or without the DLL part (e.g. `CreateFileA` or `kernel32.CreateFileA`)
+                    # and capa matches only the API name part, not the DLL part.
+                    # the DLL name is ignored, its essentially just for human-oriented documentation.
+                    # see #1824
+                    value = trim_dll_part(value)
+                    return Feature(value, description=description)
+
+                case capa.features.insn.Mnemonic:
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.basicblock.BasicBlock:
+                    return Feature(description=description)
+
+                case (
+                    capa.features.file.Export
+                    | capa.features.file.Import
+                    | capa.features.file.Section
+                    | capa.features.file.FunctionName
+                ):
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.common.MatchedRule | capa.features.common.Characteristic:
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.common.StringFactory | capa.features.common.Substring:
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.common.Class | capa.features.common.Namespace | capa.features.insn.Property:
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.common.Arch | capa.features.common.OS | capa.features.common.Format:
+                    assert isinstance(value, str)
+                    return Feature(value, description=description)
+
+                case capa.features.common.Bytes:
+                    assert isinstance(value, bytes)
+                    return Feature(value, description=description)
+
+                case _ as unreachable:
+                    assert_never(unreachable)
+        except ValueError as e:
+            raise InvalidRule(str(e)) from e
+
+
 def build_statements(d, scopes: Scopes):
     if len(d.keys()) > 2:
         raise InvalidRule("too many statements")
@@ -761,149 +968,19 @@ def build_statements(d, scopes: Scopes):
 
         return ceng.Subscope(Scope.INSTRUCTION, statements, description=description)
 
-    elif key.startswith("count(") and key.endswith(")"):
-        # e.g.:
-        #
-        #     count(basic block)
-        #     count(mnemonic(mov))
-        #     count(characteristic(nzxor))
-
-        term = key[len("count(") : -len(")")]
-
-        # when looking for the existence of such a feature, our rule might look like:
-        #     - mnemonic: mov
-        #
-        # but here we deal with the form: `mnemonic(mov)`.
-        term, _, arg = term.partition("(")
-        Feature = parse_feature(term)
-
-        if arg:
-            arg = arg[: -len(")")]
-            # can't rely on yaml parsing ints embedded within strings
-            # like:
-            #
-            #     count(offset(0xC))
-            #     count(number(0x11223344))
-            #     count(number(0x100 = description))
-            if term != "string":
-                value, description = parse_description(arg, term)
-
-                if term == "api":
-                    if not isinstance(value, str):
-                        raise InvalidRule(f"unexpected {term} value type: {type(value)}")
-                    value = trim_dll_part(value)
-
-                feature = Feature(value, description=description)  # type: ignore[call-arg]  # Feature is a runtime union; constructor args vary per subclass
-            else:
-                # arg is string (which doesn't support inline descriptions), like:
-                #
-                #     count(string(error))
-                #
-                # known problem that embedded newlines may not work here?
-                # this may become a problem (or not), so address it when encountered.
-                feature = Feature(arg)
-        else:
-            feature = Feature()  # type: ignore[call-arg]  # Feature is a runtime union; constructor args vary per subclass
-        ensure_feature_valid_for_scopes(scopes, feature)  # type: ignore[arg-type]  # StringFactory.__new__ returns Feature subclass at runtime
-
-        count = d[key]
-        if isinstance(count, int):
-            return ceng.Range(feature, min=count, max=count, description=description)
-        elif count.endswith(" or more"):
-            min = parse_int(count[: -len(" or more")])
-            max = None
-            return ceng.Range(feature, min=min, max=max, description=description)
-        elif count.endswith(" or fewer"):
-            min = None
-            max = parse_int(count[: -len(" or fewer")])
-            return ceng.Range(feature, min=min, max=max, description=description)
-        elif count.startswith("("):
-            min, max = parse_range(count)
-            return ceng.Range(feature, min=min, max=max, description=description)
-        else:
-            raise InvalidRule(f"unexpected range: {count}")
-    elif key == "string" and not isinstance(d[key], str):
-        raise InvalidRule(f"ambiguous string value {d[key]}, must be defined as explicit string")
-
-    elif key.startswith("operand[") and key.endswith("].number"):
-        index = key[len("operand[") : -len("].number")]
-        try:
-            index = int(index)
-        except ValueError as e:
-            raise InvalidRule("operand index must be an integer") from e
-
-        value, description = parse_description(d[key], key, d.get("description"))
-        assert isinstance(value, int)
-        try:
-            feature = capa.features.insn.OperandNumber(index, value, description=description)
-        except ValueError as e:
-            raise InvalidRule(str(e)) from e
-        ensure_feature_valid_for_scopes(scopes, feature)
-        return feature
-
-    elif key.startswith("operand[") and key.endswith("].offset"):
-        index = key[len("operand[") : -len("].offset")]
-        try:
-            index = int(index)
-        except ValueError as e:
-            raise InvalidRule("operand index must be an integer") from e
-
-        value, description = parse_description(d[key], key, d.get("description"))
-        assert isinstance(value, int)
-        try:
-            feature = capa.features.insn.OperandOffset(index, value, description=description)
-        except ValueError as e:
-            raise InvalidRule(str(e)) from e
-        ensure_feature_valid_for_scopes(scopes, feature)
-        return feature
-
-    elif (
-        (key == "os" and d[key] not in capa.features.common.VALID_OS)
-        or (key == "format" and d[key] not in capa.features.common.VALID_FORMAT)
-        or (key == "arch" and d[key] not in capa.features.common.VALID_ARCH)
-    ):
-        raise InvalidRule(f"unexpected {key} value {d[key]}")
-
-    elif key.startswith("property/"):
-        access = key[len("property/") :]
-        if access not in capa.features.common.VALID_FEATURE_ACCESS:
-            raise InvalidRule(f"unexpected {key} access {access}")
-
-        value, description = parse_description(d[key], key, d.get("description"))
-        if not isinstance(value, str):
-            raise InvalidRule(f"unexpected {key} value type: {type(value)}")
-        try:
-            feature = capa.features.insn.Property(value, access=access, description=description)
-        except ValueError as e:
-            raise InvalidRule(str(e)) from e
-        ensure_feature_valid_for_scopes(scopes, feature)
-        return feature
-
-    elif key.startswith("com/"):
-        com_type_name = str(key[len("com/") :])
-        try:
-            com_type = ComType(com_type_name)
-        except ValueError:
-            raise InvalidRule(f"unexpected COM type: {com_type_name}")
-        value, description = parse_description(d[key], key, d.get("description"))
-        if not isinstance(value, str):
-            raise InvalidRule(f"unexpected {key} value type: {type(value)}")
-        return translate_com_feature(value, com_type)
-
     else:
-        Feature = parse_feature(key)
-        value, description = parse_description(d[key], key, d.get("description"))
+        initial_value = d[key]
+        initial_description = d.get("description")
 
-        if key == "api":
-            if not isinstance(value, str):
-                raise InvalidRule(f"unexpected {key} value type: {type(value)}")
-            value = trim_dll_part(value)
+        feature = build_feature(key, initial_value, initial_description)
 
-        try:
-            feature = Feature(value, description=description)  # type: ignore[misc]  # Feature is a runtime union; constructor args vary per subclass
-        except ValueError as e:
-            raise InvalidRule(str(e)) from e
-        ensure_feature_valid_for_scopes(scopes, feature)  # type: ignore[arg-type]  # StringFactory.__new__ returns Feature subclass at runtime
+        # for count(...) features, validate the inner feature rather than the Range wrapper.
+        # for com/... features, translate_com_feature returns a compound Or(String, Bytes) Statement;
+        if isinstance(feature, ceng.Range):
+            ensure_feature_valid_for_scopes(scopes, feature.child)
+        elif isinstance(feature, Feature):
+            ensure_feature_valid_for_scopes(scopes, feature)
+
         return feature
 
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -815,7 +815,14 @@ def build_feature(
                     assert isinstance(value, str)
                     return Feature(value, description=description)
 
-                case capa.features.common.StringFactory | capa.features.common.Substring:
+                case capa.features.common.StringFactory:
+                    assert isinstance(value, str)
+                    return cast(
+                        capa.features.common.Feature,
+                        capa.features.common.StringFactory(value, description=description),
+                    )
+
+                case capa.features.common.Substring:
                     assert isinstance(value, str)
                     return Feature(value, description=description)
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -21,6 +21,7 @@ import uuid
 import struct
 import logging
 import binascii
+import functools
 import collections
 from enum import Enum
 from typing import Any, Union, Callable, Iterator, Optional, cast
@@ -444,6 +445,12 @@ def parse_feature(key: str):
         return capa.features.common.Namespace
     elif key == "property":
         return capa.features.insn.Property
+    elif key.startswith("operand[") and key.endswith("].number"):
+        index = int(key[len("operand[") : -len("].number")])
+        return functools.partial(capa.features.insn.OperandNumber, index)
+    elif key.startswith("operand[") and key.endswith("].offset"):
+        index = int(key[len("operand[") : -len("].offset")])
+        return functools.partial(capa.features.insn.OperandOffset, index)
     else:
         raise InvalidRule(f"unexpected statement: {key}")
 

--- a/scripts/detect-backends.py
+++ b/scripts/detect-backends.py
@@ -22,7 +22,7 @@ import rich
 import rich.table
 
 import capa.main
-from capa.features.extractors.ida.idalib import find_idalib, load_idalib, is_idalib_installed
+from capa.features.extractors.ida.idalib import is_idalib_installed
 from capa.features.extractors.binja.find_binja_api import find_binaryninja, load_binaryninja, is_binaryninja_installed
 
 logger = logging.getLogger(__name__)
@@ -101,9 +101,14 @@ def main(argv=None):
             row.append("-")
         else:
             row.append("False")
-            row.append(str(find_idalib() is not None))
+            row.append("False")
 
-        row.append(str(load_idalib()))
+        does_idalib_load = False
+        try:
+            import idapro  # noqa: F401 [imported but unused]
+        except ImportError:
+            does_idalib_load = True
+        row.append(str(does_idalib_load))
         table.add_row(*row)
 
     rich.print(table)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,3 @@
 # https://www.revsys.com/tidbits/pytest-fixtures-are-magic/
 # https://lobste.rs/s/j8xgym/pytest_fixtures_are_magic
 from fixtures import *  # noqa: F403 [unable to detect undefined names]
-from fixtures import _692f_dotnetfile_extractor  # noqa: F401 [imported but unused]
-from fixtures import _1c444_dotnetfile_extractor  # noqa: F401 [imported but unused]
-from fixtures import _039a6_dotnetfile_extractor  # noqa: F401 [imported but unused]
-from fixtures import _0953c_dotnetfile_extractor  # noqa: F401 [imported but unused]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -25,7 +25,6 @@ import pytest
 
 import capa.rules
 import capa.engine as ceng
-import capa.loader
 import capa.render.result_document
 from capa.features.common import OS_AUTO, FORMAT_AUTO, Feature
 from capa.features.address import Address
@@ -44,8 +43,7 @@ from capa.features.extractors.dnfile.extractor import DnfileFeatureExtractor
 logger = logging.getLogger(__name__)
 CD = Path(__file__).resolve().parent
 FIXTURE_MANIFEST_DIR = CD / "fixtures" / "features"
-DOTNET_DIR = CD / "data" / "dotnet"
-DNFILE_TESTFILES = DOTNET_DIR / "dnfile-testfiles"
+DNFILE_TESTFILES = CD / "data" / "dotnet" / "dnfile-testfiles"
 
 
 def parse_feature_string(s: str) -> Feature | ceng.Range | ceng.Statement:
@@ -102,7 +100,6 @@ KNOWN_FIXTURE_TAGS: set[str] = (
         "dotnet",  # .NET format
         "elf",  # ELF format
         "flirt",  # requires FLIRT signature matching
-        "symtab",  # requires ELF symbol table parsing  TODO: can we remove this?
         "binja-db",  # Binary Ninja database format
         "binexport",  # BinExport2 format
         "aarch64",  # AArch64 architecture
@@ -364,44 +361,6 @@ def run_feature_fixture(
     else:
         msg = f"{fixture.statement} should not match in {fixture.location}"
     assert actual == fixture.expected, msg
-
-
-@contextlib.contextmanager
-def xfail(condition, reason: str = ""):
-    """
-    context manager that wraps a block that is expected to fail in some cases.
-    when it does fail (and is expected), then mark this as pytest.xfail.
-    if its unexpected, raise an exception, so the test fails.
-
-    example::
-
-        # this test:
-        #  - passes on Linux if foo() works
-        #  - fails  on Linux if foo() fails
-        #  - xfails on Windows if foo() fails
-        #  - fails  on Windows if foo() works
-        with xfail(sys.platform == "win32", reason="doesn't work on Windows"):
-            foo()
-    """
-    try:
-        # do the block
-        yield
-    except Exception:
-        if condition:
-            # we expected the test to fail, so raise and register this via pytest
-            pytest.xfail(reason or "")
-        else:
-            # we don't expect an exception, so the test should fail
-            raise
-    else:
-        if not condition:
-            # here we expect the block to run successfully,
-            # and we've received no exception,
-            # so this is good
-            pass
-        else:
-            # we expected an exception, but didn't find one. that's an error.
-            raise RuntimeError("expected to fail, but didn't")
 
 
 def extract_global_features(extractor):
@@ -671,11 +630,6 @@ def resolve_scope(scope):
         raise ValueError("unexpected scope fixture")
 
 
-@pytest.fixture
-def scope(request):
-    return resolve_scope(request.param)
-
-
 def make_test_id(values):
     return "-".join(map(str, values))
 
@@ -690,29 +644,6 @@ def parametrize(params, values, **kwargs):
     """
     ids = list(map(make_test_id, values))
     return pytest.mark.parametrize(params, values, ids=ids, **kwargs)
-
-
-FEATURE_COUNT_TESTS_BE2_INTEL = [
-    (
-        "mimikatz",
-        "function=0x40105d,bb=0x401125,insn=0x401125",
-        capa.features.insn.Offset(0),
-        1,
-    ),
-    (
-        "mimikatz",
-        "function=0x40105d,bb=0x401125,insn=0x401125",
-        capa.features.insn.OperandOffset(1, 0),
-        1,
-    ),
-]
-
-
-def do_test_feature_count(get_extractor, sample, scope, feature, expected):
-    extractor = get_extractor(sample)
-    features = scope(extractor)
-    assert features.get(feature, set()) != set(), f"{feature} should be found in {scope.__name__}"
-    assert len(features[feature]) == expected, f"{feature} should be found {expected} times in {scope.__name__}"
 
 
 def get_result_doc(path: Path):
@@ -766,14 +697,13 @@ def dynamic_a0000a6_rd():
 
 
 PMA1601 = CD / "data" / "Practical Malware Analysis Lab 16-01.exe_"
-z9324 = CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_"
 
 
 # used by test_viv_features
 # as well as some fixtures below
 @functools.lru_cache(maxsize=1)
 def get_viv_extractor(path: Path):
-    import capa.main
+    import capa.loader
     import capa.features.extractors.viv.extractor
 
     sigpaths = [
@@ -809,7 +739,7 @@ def get_viv_extractor(path: Path):
 
 @pytest.fixture
 def z9324d_extractor():
-    return get_viv_extractor(z9324)
+    return get_viv_extractor(CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
 
 
 @pytest.fixture
@@ -902,6 +832,7 @@ def get_ghidra_extractor(path: Path):
     if not pyghidra.started():
         pyghidra.start()
 
+    import capa.loader
     import capa.features.extractors.ghidra.context
 
     if path in GHIDRA_CACHE:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import contextlib
 import collections
@@ -20,6 +21,9 @@ from functools import lru_cache
 
 import pytest
 
+import capa.rules
+import capa.engine as ceng
+import capa.loader
 import capa.features.file
 import capa.features.insn
 import capa.features.common
@@ -57,6 +61,109 @@ logger = logging.getLogger(__name__)
 CD = Path(__file__).resolve().parent
 DOTNET_DIR = CD / "data" / "dotnet"
 DNFILE_TESTFILES = DOTNET_DIR / "dnfile-testfiles"
+
+
+def parse_feature_string(s: str) -> Feature | ceng.Range | ceng.Statement:
+    key, _, value = s.partition(": ")
+    return capa.rules.build_feature(key, value, initial_description=None)
+
+
+FEATURE_MARKS: dict[tuple[str, str, str], list[dict]] = {}
+
+
+def _load_feature_tests() -> tuple[list[tuple], list[tuple], list[tuple], list[tuple], list[tuple], list[tuple]]:
+    with (CD / "fixtures" / "feature-presence.json").open("r") as f:
+        data = json.load(f)
+
+    presence_tests = []
+    symtab_tests = []
+    count_tests = []
+    ghidra_count_tests = []
+    dotnet_presence_tests = []
+    dotnet_count_tests = []
+
+    for entry in data["features"]:
+        feature_str = entry["feature"]
+        tags = entry.get("tags", [])
+
+        if "marks" in entry:
+            FEATURE_MARKS[(entry["file"], entry["location"], feature_str)] = entry["marks"]
+
+        if feature_str.startswith("count("):
+            key, _, value_str = feature_str.partition(": ")
+            count = int(value_str)
+            range_obj = capa.rules.build_feature(key, count, initial_description=None)
+            inner_feature = range_obj.child
+            test_tuple = (entry["file"], entry["location"], inner_feature, count)
+
+            if "ghidra" in tags:
+                ghidra_count_tests.append(test_tuple)
+            elif "dotnet" in tags:
+                dotnet_count_tests.append(test_tuple)
+            else:
+                count_tests.append(test_tuple)
+        else:
+            feature = parse_feature_string(feature_str)
+            test_tuple = (entry["file"], entry["location"], feature, entry["expected"])
+
+            if "symtab" in tags:
+                symtab_tests.append(test_tuple)
+            elif "dotnet" in tags:
+                dotnet_presence_tests.append(test_tuple)
+            else:
+                presence_tests.append(test_tuple)
+
+    presence_tests.sort(key=lambda t: (t[0], t[1]))
+    symtab_tests.sort(key=lambda t: (t[0], t[1]))
+    count_tests.sort(key=lambda t: (t[0], t[1]))
+    ghidra_count_tests.sort(key=lambda t: (t[0], t[1]))
+    dotnet_presence_tests.sort(key=lambda t: (t[0], t[1]))
+    dotnet_count_tests.sort(key=lambda t: (t[0], t[1]))
+    return (
+        presence_tests,
+        symtab_tests,
+        count_tests,
+        ghidra_count_tests,
+        dotnet_presence_tests,
+        dotnet_count_tests,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_fixture_file_paths() -> dict[str, Path]:
+    with (CD / "fixtures" / "feature-presence.json").open("r") as f:
+        data = json.load(f)
+    return {entry["key"]: CD / entry["path"] for entry in data["files"]}
+
+
+def get_fixture_file_path(key: str) -> Path:
+    paths = _load_fixture_file_paths()
+    if key not in paths:
+        raise ValueError(f"unknown fixture file key: {key}")
+    return paths[key]
+
+
+def apply_backend_marks(backend: str, sample_key: str, feature: Feature):
+    """Apply skip/xfail marks from fixtures for a specific backend.
+
+    Args:
+        backend: backend name matching marks in fixtures (e.g. "idalib", "freeze")
+        sample_key: the file key from fixtures (e.g. "mimikatz", "pma12-04")
+        feature: the parsed Feature object to match against
+    """
+    for (mk, _ml, mf), marks in FEATURE_MARKS.items():
+        if mk != sample_key:
+            continue
+        if parse_feature_string(mf) != feature:
+            continue
+        for m in marks:
+            if m["backend"] != backend:
+                continue
+            if m["mark"] == "skip":
+                pytest.skip(m["reason"])
+            elif m["mark"] == "xfail":
+                pytest.xfail(m["reason"])
+        return
 
 
 @contextlib.contextmanager
@@ -234,7 +341,9 @@ def get_idalib_extractor(path: Path):
     #   -1 - Generic errors (database already open, auto-analysis failed, etc.)
     #   -2 - User cancelled operation
     ret = idapro.open_database(
-        str(path), run_auto_analysis=True, args="-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R"
+        str(path),
+        run_auto_analysis=True,
+        args="-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R",
     )
     if ret != 0:
         raise RuntimeError("failed to analyze input file")
@@ -318,7 +427,12 @@ def get_ghidra_extractor(path: Path):
     # We use a larger cache size to avoid re-opening the same file multiple times
     # which is very slow with Ghidra.
     extractor = capa.loader.get_extractor(
-        path, FORMAT_AUTO, OS_AUTO, capa.loader.BACKEND_GHIDRA, [], disable_progress=True
+        path,
+        FORMAT_AUTO,
+        OS_AUTO,
+        capa.loader.BACKEND_GHIDRA,
+        [],
+        disable_progress=True,
     )
 
     ctx = capa.features.extractors.ghidra.context.get_context()
@@ -469,6 +583,10 @@ def get_data_path_by_name(name) -> Path:
         return CD / "data" / "3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_"
     elif name == "7351f.elf":
         return CD / "data" / "7351f8a40c5450557b24622417fc478d.elf_"
+    elif name == "055da8e6.elf":
+        return CD / "data" / "055da8e6ccfe5a9380231ea04b850e18.elf_"
+    elif name == "bb38149.elf":
+        return CD / "data" / "bb38149ff4b5c95722b83f24ca27a42b.elf_"
     elif name.startswith("79abd"):
         return CD / "data" / "79abd17391adc6251ecdc58d13d76baf.dll_"
     elif name.startswith("946a9"):
@@ -499,6 +617,8 @@ def get_data_path_by_name(name) -> Path:
         return CD / "data" / "294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
     elif name.startswith("2bf18d"):
         return CD / "data" / "2bf18d0403677378adad9001b1243211.elf_"
+    elif name.startswith("2d3edc"):
+        return CD / "data" / "2d3edc218a90f03089cc01715a9f047f.exe_"
     elif name.startswith("0000a657"):
         return (
             CD
@@ -633,6 +753,8 @@ def get_sample_md5_by_name(name):
         return "3db3e55b16a7b1b1afb970d5e77c5d98"
     elif name.startswith("2bf18d"):
         return "2bf18d0403677378adad9001b1243211"
+    elif name.startswith("2d3edc"):
+        return "2d3edc218a90f03089cc01715a9f047f"
     elif name.startswith("ea2876"):
         return "76fa734236daa023444dec26863401dc"
     else:
@@ -858,659 +980,15 @@ def parametrize(params, values, **kwargs):
     return pytest.mark.parametrize(params, values, ids=ids, **kwargs)
 
 
-FEATURE_PRESENCE_TESTS = sorted(
-    [
-        # file/characteristic("embedded pe")
-        ("pma12-04", "file", capa.features.common.Characteristic("embedded pe"), True),
-        # file/string
-        ("mimikatz", "file", capa.features.common.String("SCardControl"), True),
-        ("mimikatz", "file", capa.features.common.String("SCardTransmit"), True),
-        ("mimikatz", "file", capa.features.common.String("ACR  > "), True),
-        ("mimikatz", "file", capa.features.common.String("nope"), False),
-        # file/sections
-        ("mimikatz", "file", capa.features.file.Section(".text"), True),
-        ("mimikatz", "file", capa.features.file.Section(".nope"), False),
-        # IDA doesn't extract unmapped sections by default
-        # ("mimikatz", "file", capa.features.file.Section(".rsrc"), True),
-        # file/exports
-        ("kernel32", "file", capa.features.file.Export("BaseThreadInitThunk"), True),
-        ("kernel32", "file", capa.features.file.Export("lstrlenW"), True),
-        ("kernel32", "file", capa.features.file.Export("nope"), False),
-        # forwarded export
-        ("ea2876", "file", capa.features.file.Export("vresion.GetFileVersionInfoA"), True),
-        # file/imports
-        ("mimikatz", "file", capa.features.file.Import("advapi32.CryptSetHashParam"), True),
-        ("mimikatz", "file", capa.features.file.Import("CryptSetHashParam"), True),
-        ("mimikatz", "file", capa.features.file.Import("kernel32.IsWow64Process"), True),
-        ("mimikatz", "file", capa.features.file.Import("IsWow64Process"), True),
-        ("mimikatz", "file", capa.features.file.Import("msvcrt.exit"), True),
-        ("mimikatz", "file", capa.features.file.Import("cabinet.#11"), True),
-        ("mimikatz", "file", capa.features.file.Import("#11"), False),
-        ("mimikatz", "file", capa.features.file.Import("#nope"), False),
-        ("mimikatz", "file", capa.features.file.Import("nope"), False),
-        ("mimikatz", "file", capa.features.file.Import("advapi32.CryptAcquireContextW"), True),
-        ("mimikatz", "file", capa.features.file.Import("advapi32.CryptAcquireContext"), True),
-        ("mimikatz", "file", capa.features.file.Import("CryptAcquireContextW"), True),
-        ("mimikatz", "file", capa.features.file.Import("CryptAcquireContext"), True),
-        # function/characteristic(loop)
-        ("mimikatz", "function=0x401517", capa.features.common.Characteristic("loop"), True),
-        ("mimikatz", "function=0x401000", capa.features.common.Characteristic("loop"), False),
-        # bb/characteristic(tight loop)
-        ("mimikatz", "function=0x402EC4", capa.features.common.Characteristic("tight loop"), True),
-        ("mimikatz", "function=0x401000", capa.features.common.Characteristic("tight loop"), False),
-        # bb/characteristic(stack string)
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("stack string"), True),
-        ("mimikatz", "function=0x401000", capa.features.common.Characteristic("stack string"), False),
-        # bb/characteristic(tight loop)
-        ("mimikatz", "function=0x402EC4,bb=0x402F8E", capa.features.common.Characteristic("tight loop"), True),
-        ("mimikatz", "function=0x401000,bb=0x401000", capa.features.common.Characteristic("tight loop"), False),
-        # insn/mnemonic
-        ("mimikatz", "function=0x40105D", capa.features.insn.Mnemonic("push"), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Mnemonic("movzx"), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Mnemonic("xor"), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Mnemonic("in"), False),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Mnemonic("out"), False),
-        # insn/operand.number
-        ("mimikatz", "function=0x40105D,bb=0x401073", capa.features.insn.OperandNumber(1, 0xFF), True),
-        ("mimikatz", "function=0x40105D,bb=0x401073", capa.features.insn.OperandNumber(0, 0xFF), False),
-        # insn/operand.offset
-        ("mimikatz", "function=0x40105D,bb=0x4010B0", capa.features.insn.OperandOffset(0, 4), True),
-        ("mimikatz", "function=0x40105D,bb=0x4010B0", capa.features.insn.OperandOffset(1, 4), False),
-        # insn/number
-        ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xFF), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Number(0x3136B0), True),
-        ("mimikatz", "function=0x401000", capa.features.insn.Number(0x0), True),
-        # insn/number: stack adjustments
-        ("mimikatz", "function=0x40105D", capa.features.insn.Number(0xC), False),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Number(0x10), False),
-        # insn/number: negative
-        ("mimikatz", "function=0x401553", capa.features.insn.Number(0xFFFFFFFF), True),
-        ("mimikatz", "function=0x43e543", capa.features.insn.Number(0xFFFFFFF0), True),
-        # insn/offset
-        ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x0), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x4), True),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0xC), True),
-        # insn/offset, issue #276
-        ("64d9f", "function=0x10001510,bb=0x100015B0", capa.features.insn.Offset(0x4000), True),
-        # insn/offset: stack references
-        ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x8), False),
-        ("mimikatz", "function=0x40105D", capa.features.insn.Offset(0x10), False),
-        # insn/offset: negative
-        # 0x4012b4  MOVZX       ECX, [EAX+0xFFFFFFFFFFFFFFFF]
-        ("mimikatz", "function=0x4011FB", capa.features.insn.Offset(-0x1), True),
-        # 0x4012b8  MOVZX       EAX, [EAX+0xFFFFFFFFFFFFFFFE]
-        ("mimikatz", "function=0x4011FB", capa.features.insn.Offset(-0x2), True),
-        #
-        # insn/offset from mnemonic: add
-        #
-        # should not be considered, too big for an offset:
-        #    .text:00401D85 81 C1 00 00 00 80       add     ecx, 80000000h
-        ("mimikatz", "function=0x401D64,bb=0x401D73,insn=0x401D85", capa.features.insn.Offset(0x80000000), False),
-        # should not be considered, relative to stack:
-        #    .text:00401CF6 83 C4 10                add     esp, 10h
-        ("mimikatz", "function=0x401CC7,bb=0x401CDE,insn=0x401CF6", capa.features.insn.Offset(0x10), False),
-        # yes, this is also a offset (imagine eax is a pointer):
-        #    .text:0040223C 83 C0 04                add     eax, 4
-        ("mimikatz", "function=0x402203,bb=0x402221,insn=0x40223C", capa.features.insn.Offset(0x4), True),
-        #
-        # insn/number from mnemonic: lea
-        #
-        # should not be considered, lea operand invalid encoding
-        #    .text:00471EE6 8D 1C 81                lea     ebx, [ecx+eax*4]
-        ("mimikatz", "function=0x471EAB,bb=0x471ED8,insn=0x471EE6", capa.features.insn.Number(0x4), False),
-        # should not be considered, lea operand invalid encoding
-        #    .text:004717B1 8D 4C 31 D0             lea     ecx, [ecx+esi-30h]
-        ("mimikatz", "function=0x47153B,bb=0x4717AB,insn=0x4717B1", capa.features.insn.Number(-0x30), False),
-        # yes, this is also a number (imagine ebx is zero):
-        #    .text:004018C0 8D 4B 02                lea     ecx, [ebx+2]
-        ("mimikatz", "function=0x401873,bb=0x4018B2,insn=0x4018C0", capa.features.insn.Number(0x2), True),
-        # insn/api
-        # not extracting dll anymore
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.CryptAcquireContextW"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.CryptAcquireContext"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.CryptGenKey"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.CryptImportKey"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.CryptDestroyKey"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("CryptAcquireContextW"), True),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("CryptAcquireContext"), True),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("CryptGenKey"), True),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("CryptImportKey"), True),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("CryptDestroyKey"), True),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("Nope"), False),
-        ("mimikatz", "function=0x403BAC", capa.features.insn.API("advapi32.Nope"), False),
-        # insn/api: thunk
-        # not extracting dll anymore
-        ("mimikatz", "function=0x4556E5", capa.features.insn.API("advapi32.LsaQueryInformationPolicy"), False),
-        ("mimikatz", "function=0x4556E5", capa.features.insn.API("LsaQueryInformationPolicy"), True),
-        # insn/api: x64
-        ("kernel32-64", "function=0x180001010", capa.features.insn.API("RtlVirtualUnwind"), True),
-        # insn/api: x64 thunk
-        ("kernel32-64", "function=0x1800202B0", capa.features.insn.API("RtlCaptureContext"), True),
-        # insn/api: x64 nested thunk
-        ("al-khaser x64", "function=0x14004B4F0", capa.features.insn.API("__vcrt_GetModuleHandle"), True),
-        # insn/api: call via jmp
-        ("mimikatz", "function=0x40B3C6", capa.features.insn.API("LocalFree"), True),
-        ("c91887...", "function=0x40156F", capa.features.insn.API("CloseClipboard"), True),
-        # insn/api: resolve indirect calls
-        # not extracting dll anymore
-        ("c91887...", "function=0x401A77", capa.features.insn.API("kernel32.CreatePipe"), False),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("kernel32.SetHandleInformation"), False),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("kernel32.CloseHandle"), False),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("kernel32.WriteFile"), False),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("CreatePipe"), True),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("SetHandleInformation"), True),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("CloseHandle"), True),
-        ("c91887...", "function=0x401A77", capa.features.insn.API("WriteFile"), True),
-        # insn/string
-        ("mimikatz", "function=0x40105D", capa.features.common.String("SCardControl"), True),
-        ("mimikatz", "function=0x40105D", capa.features.common.String("SCardTransmit"), True),
-        ("mimikatz", "function=0x40105D", capa.features.common.String("ACR  > "), True),
-        ("mimikatz", "function=0x40105D", capa.features.common.String("nope"), False),
-        ("773290...", "function=0x140001140", capa.features.common.String(r"%s:\\OfficePackagesForWDAG"), True),
-        # overlapping string, see #1271
-        ("294b8d...", "function=0x404970,bb=0x404970,insn=0x40499F", capa.features.common.String("\r\n\x00:ht"), False),
-        # insn/regex
-        ("pma16-01", "function=0x4021B0", capa.features.common.Regex("HTTP/1.0"), True),
-        ("pma16-01", "function=0x402F40", capa.features.common.Regex("www.practicalmalwareanalysis.com"), True),
-        ("pma16-01", "function=0x402F40", capa.features.common.Substring("practicalmalwareanalysis.com"), True),
-        # insn/string, pointer to string
-        ("mimikatz", "function=0x44EDEF", capa.features.common.String("INPUTEVENT"), True),
-        # insn/string, direct memory reference
-        ("mimikatz", "function=0x46D6CE", capa.features.common.String("(null)"), True),
-        # insn/bytes
-        ("mimikatz", "function=0x401517", capa.features.common.Bytes(bytes.fromhex("CA3B0E000000F8AF47")), True),
-        ("mimikatz", "function=0x404414", capa.features.common.Bytes(bytes.fromhex("0180000040EA4700")), True),
-        # don't extract byte features for obvious strings
-        ("mimikatz", "function=0x40105D", capa.features.common.Bytes("SCardControl".encode("utf-16le")), False),
-        ("mimikatz", "function=0x40105D", capa.features.common.Bytes("SCardTransmit".encode("utf-16le")), False),
-        ("mimikatz", "function=0x40105D", capa.features.common.Bytes("ACR  > ".encode("utf-16le")), False),
-        ("mimikatz", "function=0x40105D", capa.features.common.Bytes("nope".encode("ascii")), False),
-        # push    offset aAcsAcr1220 ; "ACS..." -> where ACS == 41 00 43 00 == valid pointer to middle of instruction
-        ("mimikatz", "function=0x401000", capa.features.common.Bytes(bytes.fromhex("FDFF59F647")), False),
-        # IDA features included byte sequences read from invalid memory, fixed in #409
-        ("mimikatz", "function=0x44570F", capa.features.common.Bytes(bytes.fromhex("FF" * 256)), False),
-        # insn/bytes, pointer to string bytes
-        ("mimikatz", "function=0x44EDEF", capa.features.common.Bytes("INPUTEVENT".encode("utf-16le")), False),
-        # insn/characteristic(nzxor)
-        ("mimikatz", "function=0x410DFC", capa.features.common.Characteristic("nzxor"), True),
-        ("mimikatz", "function=0x40105D", capa.features.common.Characteristic("nzxor"), False),
-        # insn/characteristic(nzxor): no security cookies
-        ("mimikatz", "function=0x46D534", capa.features.common.Characteristic("nzxor"), False),
-        # insn/characteristic(nzxor): xorps
-        # viv needs fixup to recognize function, see above
-        ("mimikatz", "function=0x410dfc", capa.features.common.Characteristic("nzxor"), True),
-        # insn/characteristic(peb access)
-        ("kernel32-64", "function=0x1800017D0", capa.features.common.Characteristic("peb access"), True),
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("peb access"), False),
-        # insn/characteristic(gs access)
-        ("kernel32-64", "function=0x180001068", capa.features.common.Characteristic("gs access"), True),
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("gs access"), False),
-        # insn/characteristic(cross section flow)
-        ("a1982...", "function=0x4014D0", capa.features.common.Characteristic("cross section flow"), True),
-        # insn/characteristic(cross section flow): imports don't count
-        ("kernel32-64", "function=0x180001068", capa.features.common.Characteristic("cross section flow"), False),
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("cross section flow"), False),
-        # insn/characteristic(recursive call)
-        ("mimikatz", "function=0x40640e", capa.features.common.Characteristic("recursive call"), True),
-        # before this we used ambiguous (0x4556E5, False), which has a data reference / indirect recursive call, see #386
-        ("mimikatz", "function=0x4175FF", capa.features.common.Characteristic("recursive call"), False),
-        # insn/characteristic(indirect call)
-        ("mimikatz", "function=0x4175FF", capa.features.common.Characteristic("indirect call"), True),
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("indirect call"), False),
-        # insn/characteristic(calls from)
-        ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("calls from"), True),
-        ("mimikatz", "function=0x4702FD", capa.features.common.Characteristic("calls from"), False),
-        # function/characteristic(calls to)
-        ("mimikatz", "function=0x40105D", capa.features.common.Characteristic("calls to"), True),
-        # function/characteristic(forwarded export)
-        ("ea2876", "file", capa.features.common.Characteristic("forwarded export"), True),
-        # before this we used ambiguous (0x4556E5, False), which has a data reference / indirect recursive call, see #386
-        ("mimikatz", "function=0x456BB9", capa.features.common.Characteristic("calls to"), False),
-        # file/function-name
-        ("pma16-01", "file", capa.features.file.FunctionName("__aulldiv"), True),
-        # os & format & arch
-        ("pma16-01", "file", OS(OS_WINDOWS), True),
-        ("pma16-01", "file", OS(OS_LINUX), False),
-        ("mimikatz", "file", OS(OS_WINDOWS), True),
-        ("pma16-01", "function=0x401100", OS(OS_WINDOWS), True),
-        ("pma16-01", "function=0x401100,bb=0x401130", OS(OS_WINDOWS), True),
-        ("mimikatz", "function=0x40105D", OS(OS_WINDOWS), True),
-        ("pma16-01", "file", Arch(ARCH_I386), True),
-        ("pma16-01", "file", Arch(ARCH_AMD64), False),
-        ("mimikatz", "file", Arch(ARCH_I386), True),
-        ("pma16-01", "function=0x401100", Arch(ARCH_I386), True),
-        ("pma16-01", "function=0x401100,bb=0x401130", Arch(ARCH_I386), True),
-        ("mimikatz", "function=0x40105D", Arch(ARCH_I386), True),
-        ("pma16-01", "file", Format(FORMAT_PE), True),
-        ("pma16-01", "file", Format(FORMAT_ELF), False),
-        ("mimikatz", "file", Format(FORMAT_PE), True),
-        # format is also a global feature
-        ("pma16-01", "function=0x401100", Format(FORMAT_PE), True),
-        ("mimikatz", "function=0x456BB9", Format(FORMAT_PE), True),
-        # elf support
-        ("7351f.elf", "file", OS(OS_LINUX), True),
-        ("7351f.elf", "file", OS(OS_WINDOWS), False),
-        ("7351f.elf", "file", Format(FORMAT_ELF), True),
-        ("7351f.elf", "file", Format(FORMAT_PE), False),
-        ("7351f.elf", "file", Arch(ARCH_I386), False),
-        ("7351f.elf", "file", Arch(ARCH_AMD64), True),
-        ("7351f.elf", "function=0x408753", capa.features.common.String("/dev/null"), True),
-        ("7351f.elf", "function=0x408753,bb=0x408781", capa.features.insn.API("open"), True),
-        ("79abd...", "function=0x10002385,bb=0x10002385", capa.features.common.Characteristic("call $+5"), True),
-        ("946a9...", "function=0x10001510,bb=0x100015c0", capa.features.common.Characteristic("call $+5"), True),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
-)
+(
+    FEATURE_PRESENCE_TESTS,
+    FEATURE_SYMTAB_FUNC_TESTS,
+    FEATURE_COUNT_TESTS,
+    FEATURE_COUNT_TESTS_GHIDRA,
+    FEATURE_PRESENCE_TESTS_DOTNET,
+    FEATURE_COUNT_TESTS_DOTNET,
+) = _load_feature_tests()
 
-# this list should be merged into the one above (FEATURE_PRESENSE_TESTS)
-# once the debug symbol functionality has been added to all backends
-FEATURE_SYMTAB_FUNC_TESTS = [
-    (
-        "2bf18d",
-        "function=0x4027b3,bb=0x402861,insn=0x40286d",
-        capa.features.insn.API("__GI_connect"),
-        True,
-    ),
-    (
-        "2bf18d",
-        "function=0x4027b3,bb=0x402861,insn=0x40286d",
-        capa.features.insn.API("connect"),
-        True,
-    ),
-    (
-        "2bf18d",
-        "function=0x4027b3,bb=0x402861,insn=0x40286d",
-        capa.features.insn.API("__libc_connect"),
-        True,
-    ),
-    (
-        "2bf18d",
-        "function=0x4088a4",
-        capa.features.file.FunctionName("__GI_connect"),
-        True,
-    ),
-    (
-        "2bf18d",
-        "function=0x4088a4",
-        capa.features.file.FunctionName("connect"),
-        True,
-    ),
-    (
-        "2bf18d",
-        "function=0x4088a4",
-        capa.features.file.FunctionName("__libc_connect"),
-        True,
-    ),
-]
-
-FEATURE_PRESENCE_TESTS_DOTNET = sorted(
-    [
-        ("b9f5b", "file", Arch(ARCH_I386), True),
-        ("b9f5b", "file", Arch(ARCH_AMD64), False),
-        ("mixed-mode-64", "file", Arch(ARCH_AMD64), True),
-        ("mixed-mode-64", "file", Arch(ARCH_I386), False),
-        ("mixed-mode-64", "file", capa.features.common.Characteristic("mixed mode"), True),
-        ("hello-world", "file", capa.features.common.Characteristic("mixed mode"), False),
-        ("b9f5b", "file", OS(OS_ANY), True),
-        ("b9f5b", "file", Format(FORMAT_PE), True),
-        ("b9f5b", "file", Format(FORMAT_DOTNET), True),
-        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::Main"), True),
-        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::ctor"), True),
-        ("hello-world", "file", capa.features.file.FunctionName("HelloWorld::cctor"), False),
-        ("hello-world", "file", capa.features.common.String("Hello World!"), True),
-        ("hello-world", "file", capa.features.common.Class("HelloWorld"), True),
-        ("hello-world", "file", capa.features.common.Class("System.Console"), True),
-        ("hello-world", "file", capa.features.common.Namespace("System.Diagnostics"), True),
-        ("hello-world", "function=0x250", capa.features.common.String("Hello World!"), True),
-        ("hello-world", "function=0x250, bb=0x250, insn=0x252", capa.features.common.String("Hello World!"), True),
-        ("hello-world", "function=0x250, bb=0x250, insn=0x257", capa.features.common.Class("System.Console"), True),
-        ("hello-world", "function=0x250, bb=0x250, insn=0x257", capa.features.common.Namespace("System"), True),
-        ("hello-world", "function=0x250", capa.features.insn.API("System.Console::WriteLine"), True),
-        ("hello-world", "file", capa.features.file.Import("System.Console::WriteLine"), True),
-        ("_1c444", "file", capa.features.common.String(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"), True),
-        ("_1c444", "file", capa.features.common.String("get_IsAlive"), True),
-        ("_1c444", "file", capa.features.file.Import("gdi32.CreateCompatibleBitmap"), True),
-        ("_1c444", "file", capa.features.file.Import("CreateCompatibleBitmap"), True),
-        ("_1c444", "file", capa.features.file.Import("gdi32::CreateCompatibleBitmap"), False),
-        ("_1c444", "function=0x1F68", capa.features.insn.API("GetWindowDC"), True),
-        # not extracting dll anymore
-        ("_1c444", "function=0x1F68", capa.features.insn.API("user32.GetWindowDC"), False),
-        ("_1c444", "function=0x1F68", capa.features.insn.Number(0xCC0020), True),
-        ("_1c444", "token=0x600001D", capa.features.common.Characteristic("calls to"), True),
-        ("_1c444", "token=0x6000018", capa.features.common.Characteristic("calls to"), False),
-        ("_1c444", "token=0x600001D", capa.features.common.Characteristic("calls from"), True),
-        ("_1c444", "token=0x600000F", capa.features.common.Characteristic("calls from"), False),
-        ("_1c444", "token=0x600001D", capa.features.common.Characteristic("loop"), True),
-        ("_1c444", "token=0x6000001", capa.features.common.Characteristic("loop"), False),
-        ("_1c444", "function=0x1F68", capa.features.insn.Number(0x0), True),
-        ("_1c444", "function=0x1F68", capa.features.insn.Number(0x1), False),
-        (
-            "_692f",
-            "token=0x6000004",
-            capa.features.insn.API("System.Linq.Enumerable::First"),
-            True,
-        ),  # generic method
-        (
-            "_692f",
-            "token=0x6000004",
-            capa.features.insn.Property("System.Linq.Enumerable::First"),
-            False,
-        ),  # generic method
-        (
-            "_692f",
-            "token=0x6000004",
-            capa.features.common.Namespace("System.Linq"),
-            True,
-        ),  # generic method
-        (
-            "_692f",
-            "token=0x6000004",
-            capa.features.common.Class("System.Linq.Enumerable"),
-            True,
-        ),  # generic method
-        (
-            "_1c444",
-            "token=0x6000020",
-            capa.features.common.Namespace("Reqss"),
-            True,
-        ),  # ldftn
-        (
-            "_1c444",
-            "token=0x6000020",
-            capa.features.common.Class("Reqss.Reqss"),
-            True,
-        ),  # ldftn
-        (
-            "_1c444",
-            "function=0x1F59, bb=0x1F59, insn=0x1F5B",
-            capa.features.common.Characteristic("unmanaged call"),
-            True,
-        ),
-        ("_1c444", "function=0x2544", capa.features.common.Characteristic("unmanaged call"), False),
-        # same as above but using token instead of function
-        ("_1c444", "token=0x6000088", capa.features.common.Characteristic("unmanaged call"), False),
-        (
-            "_1c444",
-            "function=0x1F68, bb=0x1F68, insn=0x1FF9",
-            capa.features.insn.API("System.Drawing.Image::FromHbitmap"),
-            True,
-        ),
-        ("_1c444", "function=0x1F68, bb=0x1F68, insn=0x1FF9", capa.features.insn.API("FromHbitmap"), False),
-        (
-            "_1c444",
-            "token=0x600002B",
-            capa.features.insn.Property("System.IO.FileInfo::Length", access=FeatureAccess.READ),
-            True,
-        ),  # MemberRef property access
-        (
-            "_1c444",
-            "token=0x600002B",
-            capa.features.insn.Property("System.IO.FileInfo::Length"),
-            True,
-        ),  # MemberRef property access
-        (
-            "_1c444",
-            "token=0x6000081",
-            capa.features.insn.API("System.Diagnostics.Process::Start"),
-            True,
-        ),  # MemberRef property access
-        (
-            "_1c444",
-            "token=0x6000081",
-            capa.features.insn.Property(
-                "System.Diagnostics.ProcessStartInfo::UseShellExecute",
-                access=FeatureAccess.WRITE,
-            ),  # MemberRef property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x6000081",
-            capa.features.insn.Property(
-                "System.Diagnostics.ProcessStartInfo::WorkingDirectory",
-                access=FeatureAccess.WRITE,
-            ),  # MemberRef property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x6000081",
-            capa.features.insn.Property(
-                "System.Diagnostics.ProcessStartInfo::FileName",
-                access=FeatureAccess.WRITE,
-            ),  # MemberRef property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x6000087",
-            capa.features.insn.Property(
-                "Sockets.MySocket::reConnectionDelay", access=FeatureAccess.WRITE
-            ),  # Field property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x600008A",
-            capa.features.insn.Property(
-                "Sockets.MySocket::isConnected", access=FeatureAccess.WRITE
-            ),  # Field property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x600008A",
-            capa.features.common.Class("Sockets.MySocket"),  # Field property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x600008A",
-            capa.features.common.Namespace("Sockets"),  # Field property access
-            True,
-        ),
-        (
-            "_1c444",
-            "token=0x600008A",
-            capa.features.insn.Property(
-                "Sockets.MySocket::onConnected", access=FeatureAccess.READ
-            ),  # Field property access
-            True,
-        ),
-        (
-            "_0953c",
-            "token=0x6000004",
-            capa.features.insn.Property(
-                "System.Diagnostics.Debugger::IsAttached", access=FeatureAccess.READ
-            ),  # MemberRef property access
-            True,
-        ),
-        (
-            "_0953c",
-            "token=0x6000004",
-            capa.features.common.Class("System.Diagnostics.Debugger"),  # MemberRef property access
-            True,
-        ),
-        (
-            "_0953c",
-            "token=0x6000004",
-            capa.features.common.Namespace("System.Diagnostics"),  # MemberRef property access
-            True,
-        ),
-        (
-            "_692f",
-            "token=0x6000006",
-            capa.features.insn.Property(
-                "System.Management.Automation.PowerShell::Streams",
-                access=FeatureAccess.READ,
-            ),  # MemberRef property access
-            False,
-        ),
-        (
-            "_387f15",
-            "token=0x600009E",
-            capa.features.insn.Property(
-                "Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE::geoplugin_countryCode",
-                access=FeatureAccess.READ,
-            ),  # MethodDef property access
-            True,
-        ),
-        (
-            "_387f15",
-            "token=0x600009E",
-            capa.features.common.Class(
-                "Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE"
-            ),  # MethodDef property access
-            True,
-        ),
-        (
-            "_387f15",
-            "token=0x600009E",
-            capa.features.common.Namespace("Modulo"),  # MethodDef property access
-            True,
-        ),
-        (
-            "_039a6",
-            "token=0x6000007",
-            capa.features.insn.API("System.Reflection.Assembly::Load"),
-            True,
-        ),
-        (
-            "_039a6",
-            "token=0x600001D",
-            capa.features.insn.Property("StagelessHollow.Arac::Marka", access=FeatureAccess.READ),  # MethodDef method
-            True,
-        ),
-        (
-            "_039a6",
-            "token=0x600001C",
-            capa.features.insn.Property("StagelessHollow.Arac::Marka", access=FeatureAccess.READ),  # MethodDef method
-            False,
-        ),
-        (
-            "_039a6",
-            "token=0x6000023",
-            capa.features.insn.Property(
-                "System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Task",
-                access=FeatureAccess.READ,
-            ),  # MemberRef method
-            False,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer0"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer1"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer0/myclass_inner0_0"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer0/myclass_inner0_1"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer1/myclass_inner1_0"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer1/myclass_inner1_1"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("mynamespace.myclass_outer1/myclass_inner1_0/myclass_inner_inner"),
-            True,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("myclass_inner_inner"),
-            False,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("myclass_inner1_0"),
-            False,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("myclass_inner1_1"),
-            False,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("myclass_inner0_0"),
-            False,
-        ),
-        (
-            "nested_typedef",
-            "file",
-            capa.features.common.Class("myclass_inner0_1"),
-            False,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Android.OS.Build/VERSION::SdkInt"),
-            True,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Android.Media.Image/Plane::Buffer"),
-            True,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Android.Provider.Telephony/Sent/Sent::ContentUri"),
-            True,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Android.OS.Build::SdkInt"),
-            False,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Plane::Buffer"),
-            False,
-        ),
-        (
-            "nested_typeref",
-            "file",
-            capa.features.file.Import("Sent::ContentUri"),
-            False,
-        ),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
-)
 
 FEATURE_PRESENCE_TESTS_IDA = [
     # file/imports
@@ -1521,7 +999,12 @@ FEATURE_PRESENCE_TESTS_IDA = [
 FEATURE_BINJA_DATABASE_TESTS = sorted(
     [
         # insn/regex
-        ("pma16-01_binja_db", "function=0x4021B0", capa.features.common.Regex("HTTP/1.0"), True),
+        (
+            "pma16-01_binja_db",
+            "function=0x4021B0",
+            capa.features.common.Regex("HTTP/1.0"),
+            True,
+        ),
         (
             "pma16-01_binja_db",
             "function=0x402F40",
@@ -1534,7 +1017,12 @@ FEATURE_BINJA_DATABASE_TESTS = sorted(
             capa.features.common.Substring("practicalmalwareanalysis.com"),
             True,
         ),
-        ("pma16-01_binja_db", "file", capa.features.file.FunctionName("__aulldiv"), True),
+        (
+            "pma16-01_binja_db",
+            "file",
+            capa.features.file.FunctionName("__aulldiv"),
+            True,
+        ),
         # os & format & arch
         ("pma16-01_binja_db", "file", OS(OS_WINDOWS), True),
         ("pma16-01_binja_db", "file", OS(OS_LINUX), False),
@@ -1555,30 +1043,8 @@ FEATURE_BINJA_DATABASE_TESTS = sorted(
 )
 
 
-FEATURE_COUNT_TESTS = [
-    ("mimikatz", "function=0x40E5C2", capa.features.basicblock.BasicBlock(), 7),
-    ("mimikatz", "function=0x4702FD", capa.features.common.Characteristic("calls from"), 0),
-    ("mimikatz", "function=0x40E5C2", capa.features.common.Characteristic("calls from"), 3),
-    ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("calls to"), 0),
-    ("mimikatz", "function=0x40B1F1", capa.features.common.Characteristic("calls to"), 3),
-]
-
-
-FEATURE_COUNT_TESTS_DOTNET = [
-    ("_1c444", "token=0x600001D", capa.features.common.Characteristic("calls to"), 1),
-    ("_1c444", "token=0x600001D", capa.features.common.Characteristic("calls from"), 9),
-]
-
-
-FEATURE_COUNT_TESTS_GHIDRA = [
-    # Ghidra may render functions as labels, as well as provide differing amounts of call references
-    ("mimikatz", "function=0x4702FD", capa.features.common.Characteristic("calls from"), 0),
-    ("mimikatz", "function=0x401bf1", capa.features.common.Characteristic("calls to"), 2),
-    ("mimikatz", "function=0x401000", capa.features.basicblock.BasicBlock(), 3),
-]
 
 FEATURE_COUNT_TESTS_BE2_INTEL = [
-    # 0x401125: MOV [EDI], CX  -- matches OFFSET_ZERO_PATTERNS, must yield Offset(0) exactly once
     (
         "mimikatz",
         "function=0x40105d,bb=0x401125,insn=0x401125",
@@ -1592,6 +1058,7 @@ FEATURE_COUNT_TESTS_BE2_INTEL = [
         1,
     ),
 ]
+
 
 
 def do_test_feature_presence(get_extractor, sample, scope, feature, expected):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,32 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
-import contextlib
-import functools
 import json
 import logging
-from dataclasses import dataclass, field
+import functools
+import contextlib
+import collections
+from typing import Union, Literal, Optional
 from pathlib import Path
-from typing import Literal, Optional, Union
+from dataclasses import field, dataclass
 
 import pytest
 
+import capa.rules
 import capa.engine as ceng
 import capa.loader
-import capa.rules
 import capa.render.result_document
+from capa.features.common import OS_AUTO, FORMAT_AUTO, Feature
 from capa.features.address import Address
-from capa.features.common import FORMAT_AUTO, OS_AUTO, Feature
 from capa.features.extractors.base_extractor import (
     BBHandle,
     CallHandle,
-    DynamicFeatureExtractor,
-    FunctionHandle,
     InsnHandle,
-    ProcessHandle,
-    StaticFeatureExtractor,
     ThreadHandle,
+    ProcessHandle,
+    FunctionHandle,
+    StaticFeatureExtractor,
+    DynamicFeatureExtractor,
 )
 from capa.features.extractors.dnfile.extractor import DnfileFeatureExtractor
 
@@ -207,16 +207,12 @@ def load_fixture_file_references() -> dict[str, FixtureFile]:
         for entry in data["files"]:
             key = entry["key"]
             if key in files:
-                raise ValueError(
-                    f"duplicate fixture file key {key!r} in {file_sources[key]} and {manifest_path}"
-                )
+                raise ValueError(f"duplicate fixture file key {key!r} in {file_sources[key]} and {manifest_path}")
 
             tags = frozenset(entry.get("tags", []))
             unknown = tags - KNOWN_FIXTURE_TAGS
             if unknown:
-                raise ValueError(
-                    f"unknown fixture tag(s) on file {key!r} in {manifest_path}: {sorted(unknown)}"
-                )
+                raise ValueError(f"unknown fixture tag(s) on file {key!r} in {manifest_path}: {sorted(unknown)}")
             files[key] = FixtureFile(
                 key=key,
                 path=CD / entry["path"],
@@ -320,14 +316,12 @@ def _fixture_test_id(fixture: FeatureFixture) -> str:
 
     mirrors the legacy `make_test_id` shape: sample-location-statement-expected.
     """
-    return "-".join(
-        [
-            fixture.sample_key,
-            fixture.location,
-            str(fixture.statement),
-            str(fixture.expected),
-        ]
-    )
+    return "-".join([
+        fixture.sample_key,
+        fixture.location,
+        str(fixture.statement),
+        str(fixture.expected),
+    ])
 
 
 def parametrize_backend_feature_fixtures(policy: BackendFeaturePolicy):
@@ -349,9 +343,7 @@ def parametrize_backend_feature_fixtures(policy: BackendFeaturePolicy):
             elif mark.mark == "xfail":
                 marks.append(pytest.mark.xfail(reason=mark.reason))
             else:
-                raise ValueError(
-                    f"unknown mark {mark.mark!r} for backend {policy.name!r}"
-                )
+                raise ValueError(f"unknown mark {mark.mark!r} for backend {policy.name!r}")
         params.append(pytest.param(fixture, marks=marks, id=_fixture_test_id(fixture)))
     return pytest.mark.parametrize("feature_fixture", params)
 
@@ -419,7 +411,7 @@ def extract_global_features(extractor):
     return features
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def extract_file_features(extractor):
     features = collections.defaultdict(set)
     for feature, va in extractor.extract_file_features():
@@ -540,9 +532,7 @@ def get_basic_block(extractor, fh: FunctionHandle, va: int) -> BBHandle:
     raise ValueError("basic block not found")
 
 
-def get_instruction(
-    extractor, fh: FunctionHandle, bbh: BBHandle, va: int
-) -> InsnHandle:
+def get_instruction(extractor, fh: FunctionHandle, bbh: BBHandle, va: int) -> InsnHandle:
     for ih in extractor.get_instructions(fh, bbh):
         if isinstance(extractor, DnfileFeatureExtractor):
             addr = ih.inner.offset
@@ -732,26 +722,20 @@ def get_result_doc(path: Path):
 @pytest.fixture
 def pma0101_rd():
     # python -m capa.main tests/data/Practical\ Malware\ Analysis\ Lab\ 01-01.dll_ --json > tests/data/rd/Practical\ Malware\ Analysis\ Lab\ 01-01.dll_.json
-    return get_result_doc(
-        CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
-    )
+    return get_result_doc(CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json")
 
 
 @pytest.fixture
 def dotnet_1c444e_rd():
     # .NET sample
     # python -m capa.main tests/data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_ --json > tests/data/rd/1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json
-    return get_result_doc(
-        CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json"
-    )
+    return get_result_doc(CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json")
 
 
 @pytest.fixture
 def a3f3bbc_rd():
     # python -m capa.main tests/data/3f3bbcf8fd90bdcdcdc5494314ed4225.exe_ --json > tests/data/rd/3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json
-    return get_result_doc(
-        CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json"
-    )
+    return get_result_doc(CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json")
 
 
 @pytest.fixture
@@ -769,9 +753,7 @@ def al_khaserx64_rd():
 @pytest.fixture
 def a076114_rd():
     # python -m capa.main tests/data/0761142efbda6c4b1e801223de723578.dll_ --json > tests/data/rd/0761142efbda6c4b1e801223de723578.dll_.json
-    return get_result_doc(
-        CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json"
-    )
+    return get_result_doc(CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json")
 
 
 @pytest.fixture
@@ -779,10 +761,7 @@ def dynamic_a0000a6_rd():
     # python -m capa.main tests/data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json --json > tests/data/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json
     # gzip tests/data/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json
     return get_result_doc(
-        CD
-        / "data"
-        / "rd"
-        / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+        CD / "data" / "rd" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
     )
 
 
@@ -794,8 +773,8 @@ z9324 = CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_"
 # as well as some fixtures below
 @functools.lru_cache(maxsize=1)
 def get_viv_extractor(path: Path):
-    import capa.features.extractors.viv.extractor
     import capa.main
+    import capa.features.extractors.viv.extractor
 
     sigpaths = [
         CD / "data" / "sigs" / "test_aulldiv.pat",
@@ -813,13 +792,11 @@ def get_viv_extractor(path: Path):
         vw = capa.loader.get_workspace(path, FORMAT_AUTO, sigpaths=sigpaths)
     vw.saveWorkspace()
 
-    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(
-        vw, path, OS_AUTO
-    )
+    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(vw, path, OS_AUTO)
 
     #
     # fixups to overcome differences between backends
-    # 
+    #
     if "3b13b" in path.name:
         # vivisect only recognizes calling thunk function at 0x10001573
         extractor.vw.makeFunction(0x10006860)
@@ -983,8 +960,8 @@ def get_idalib_extractor(path: Path):
     import shutil
     import tempfile
 
-    import capa.features.extractors.ida.extractor
     import capa.features.extractors.ida.idalib as idalib
+    import capa.features.extractors.ida.extractor
 
     if not idalib.has_idalib():
         raise RuntimeError("cannot find IDA idalib module.")
@@ -1056,11 +1033,7 @@ def get_binexport_extractor(path):
 
     be2 = capa.features.extractors.binexport2.get_binexport2(path)
     search_paths = [CD / "data", CD / "data" / "aarch64"]
-    path = capa.features.extractors.binexport2.get_sample_from_binexport2(
-        path, be2, search_paths
-    )
+    path = capa.features.extractors.binexport2.get_sample_from_binexport2(path, be2, search_paths)
     buf = path.read_bytes()
 
-    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(
-        be2, buf
-    )
+    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(be2, buf)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -962,7 +962,27 @@ def _fixup_idalib(path: Path, extractor):
         remove_library_id_flag(0x14004B4F0)
 
 
+IDA_UNPACKED_EXTENSIONS = (".id0", ".id1", ".id2", ".nam", ".til")
+
+
+def _check_stale_idalib_files(path: Path):
+    i64_path = Path(str(path) + ".i64")
+    for ext in IDA_UNPACKED_EXTENSIONS:
+        component = i64_path.with_suffix(ext)
+        if component.exists():
+            stale = ", ".join(i64_path.with_suffix(e).name for e in IDA_UNPACKED_EXTENSIONS)
+            raise RuntimeError(
+                f"stale IDA database component files detected (e.g., {component.name}). "
+                f"a previous analysis was likely interrupted. "
+                f"remove files like {stale} from {path.parent} before re-running tests."
+            )
+
+
+@contextlib.contextmanager
 def get_idalib_extractor(path: Path):
+    import shutil
+    import tempfile
+
     import capa.features.extractors.ida.extractor
     import capa.features.extractors.ida.idalib as idalib
 
@@ -972,27 +992,58 @@ def get_idalib_extractor(path: Path):
     if not idalib.load_idalib():
         raise RuntimeError("failed to load IDA idalib module.")
 
+    _check_stale_idalib_files(path)
+
     import idapro
     import ida_auto
 
-    logger.debug("idalib: opening database...")
-    idapro.enable_console_messages(False)
+    i64_path = Path(str(path) + ".i64")
+    had_i64 = i64_path.exists()
 
-    ret = idapro.open_database(
-        str(path),
-        run_auto_analysis=True,
-        args="-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R",
-    )
-    if ret != 0:
-        raise RuntimeError("failed to analyze input file")
+    with tempfile.TemporaryDirectory(prefix="capa-idalib-") as tmp:
+        tmp_dir = Path(tmp)
+        tmp_sample = tmp_dir / path.name
+        shutil.copy2(path, tmp_sample)
 
-    logger.debug("idalib: waiting for analysis...")
-    ida_auto.auto_wait()
-    logger.debug("idalib: opened database.")
+        if had_i64:
+            shutil.copy2(i64_path, tmp_dir / i64_path.name)
 
-    extractor = capa.features.extractors.ida.extractor.IdaFeatureExtractor()
-    _fixup_idalib(path, extractor)
-    return extractor
+        logger.debug("idalib: opening database...")
+        idapro.enable_console_messages(False)
+
+        # -R (load resources) is only valid when creating a new database.
+        # when reopening an existing .i64, IDA rejects it.
+        if had_i64:
+            args = "-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0"
+        else:
+            args = "-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R"
+
+        ret = idapro.open_database(
+            str(tmp_sample),
+            run_auto_analysis=True,
+            args=args,
+        )
+        if ret != 0:
+            raise RuntimeError("failed to analyze input file")
+
+        logger.debug("idalib: waiting for analysis...")
+        ida_auto.auto_wait()
+        logger.debug("idalib: opened database.")
+
+        extractor = capa.features.extractors.ida.extractor.IdaFeatureExtractor()
+        _fixup_idalib(path, extractor)
+
+        try:
+            yield extractor
+        finally:
+            logger.debug("closing database...")
+            idapro.close_database(save=(not had_i64))
+            logger.debug("closed database.")
+
+            if not had_i64:
+                tmp_i64 = tmp_dir / i64_path.name
+                if tmp_i64.exists():
+                    shutil.copy2(tmp_i64, i64_path)
 
 
 # used by both:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -894,11 +894,8 @@ def get_idalib_extractor(path: Path):
     import capa.features.extractors.ida.idalib as idalib
     import capa.features.extractors.ida.extractor
 
-    if not idalib.has_idalib():
-        raise RuntimeError("cannot find IDA idalib module.")
-
-    if not idalib.load_idalib():
-        raise RuntimeError("failed to load IDA idalib module.")
+    if not idalib.is_idalib_installed():
+        raise RuntimeError("idalib is not available.")
 
     _check_stale_idalib_files(path)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,49 +14,29 @@
 
 import collections
 import contextlib
+import functools
 import json
 import logging
 from dataclasses import dataclass, field
-from functools import lru_cache
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Literal, Optional, Union
 
 import pytest
 
 import capa.engine as ceng
-import capa.features.basicblock
-import capa.features.common
-import capa.features.file
-import capa.features.insn
-import capa.features.common
-import capa.features.basicblock
 import capa.loader
 import capa.rules
 import capa.render.result_document
 from capa.features.address import Address
-from capa.features.common import (
-    ARCH_AMD64,
-    ARCH_I386,
-    FORMAT_AUTO,
-    FORMAT_DOTNET,
-    FORMAT_ELF,
-    FORMAT_PE,
-    OS,
-    OS_ANY,
-    OS_AUTO,
-    OS_LINUX,
-    OS_WINDOWS,
-    Arch,
-    Feature,
-    FeatureAccess,
-    Format,
-)
+from capa.features.common import FORMAT_AUTO, OS_AUTO, Feature
 from capa.features.extractors.base_extractor import (
     BBHandle,
     CallHandle,
+    DynamicFeatureExtractor,
     FunctionHandle,
     InsnHandle,
     ProcessHandle,
+    StaticFeatureExtractor,
     ThreadHandle,
 )
 from capa.features.extractors.dnfile.extractor import DnfileFeatureExtractor
@@ -70,171 +50,110 @@ DNFILE_TESTFILES = DOTNET_DIR / "dnfile-testfiles"
 
 def parse_feature_string(s: str) -> Feature | ceng.Range | ceng.Statement:
     """
-    parse a fixture feature string into a Feature, Range, or Statement.
+    parse a feature from a single string
+    no extra description is assigned.
 
-    count(...) fixtures have a string integer value in the JSON
-    (e.g. `count(basic blocks): 7`). translate that to an int so
-    `build_feature` returns a Range rather than raising on an
-    unrecognized range expression.
+    examples:
+        "mnemonic: mov"
+        "string: /foo/"
+        "count(basic blocks): 7"
+
+    returns: Range if the feature is a count, and generated Statement for COM features, otherwise Feature.
     """
     key, _, value = s.partition(": ")
-    initial_value: str | int = value
-    if key.startswith("count(") and key.endswith(")"):
-        try:
-            initial_value = int(value)
-        except ValueError:
-            # leave as string so that `build_feature` can handle
-            # "N or more"/"N or fewer"/"(N, M)" range expressions.
-            initial_value = value
-    return capa.rules.build_feature(key, initial_value, initial_description=None)
+    return capa.rules.build_feature(key, value, initial_description=None)
 
 
-# scope-kind tags are derived from the fixture location and inserted
-# into the fixture's tag set. backends that only support a subset of
-# scopes (e.g., pefile is file-only) can exclude the others via tags.
-SCOPE_KIND_TAGS: frozenset[str] = frozenset(
+KNOWN_FEATURE_NAMES = {
+    "api",
+    "arch",
+    "basic blocks",
+    "bytes",
+    "characteristic",
+    "class",
+    "export",
+    "format",
+    "function-name",
+    "import",
+    "mnemonic",
+    "namespace",
+    "number",
+    "offset",
+    "operand[0].number",
+    "operand[0].offset",
+    "operand[1].number",
+    "operand[1].offset",
+    "operand[2].offset",
+    "os",
+    "property",
+    "property/read",
+    "property/write",
+    "section",
+    "string",
+    "substring",
+}
+
+KNOWN_SCOPE_NAMES = capa.rules.STATIC_SCOPES | capa.rules.DYNAMIC_SCOPES
+
+KNOWN_FIXTURE_TAGS: set[str] = (
     {
-        "file",
-        "function",
-        "basic-block",
-        "instruction",
-        "process",
-        "thread",
-        "call",
+        "static",  # static analysis test, PE/ELF format.
+        "dynamic",  # dynamic analysis test
+        "dotnet",  # .NET format
+        "elf",  # ELF format
+        "flirt",  # requires FLIRT signature matching
+        "symtab",  # requires ELF symbol table parsing  TODO: can we remove this?
+        "binja-db",  # Binary Ninja database format
+        "binexport",  # BinExport2 format
+        "aarch64",  # AArch64 architecture
+        "cape",  # CAPE analysis
+        "drakvuf",  # Drakvuf analysis
+        "vmray",  # VMRay analysis
     }
-)
-
-# feature-type tags are derived from the fixture feature string's key
-# and inserted into the fixture's tag set. backends that don't support
-# a feature type (e.g., pefile has no function-name features) can
-# exclude by tag rather than by Python class.
-#
-# values come from `capa.rules.parse_feature` keys so the tag names
-# align with the textual rule syntax.
-FEATURE_TYPE_TAGS: frozenset[str] = frozenset(
-    {
-        "api",
-        "string",
-        "substring",
-        "bytes",
-        "number",
-        "offset",
-        "mnemonic",
-        "basic blocks",
-        "characteristic",
-        "export",
-        "import",
-        "section",
-        "match",
-        "function-name",
-        "os",
-        "format",
-        "arch",
-        "class",
-        "namespace",
-        "property",
-        # operand[N].X is collapsed to operand.X (index-independent)
-        "operand.number",
-        "operand.offset",
-    }
-)
-
-# known fixture tags used for backend selection.
-# merged tags that are not listed here will fail collection, to catch typos.
-KNOWN_FIXTURE_TAGS: frozenset[str] = (
-    frozenset(
-        {
-            "static",
-            "dynamic",
-            "dotnet",
-            "elf",
-            "flirt",
-            "symtab",
-            "ghidra",
-            "binja-db",
-            "binexport",
-            "aarch64",
-            "cape",
-            "drakvuf",
-            "vmray",
-        }
-    )
-    | SCOPE_KIND_TAGS
-    | FEATURE_TYPE_TAGS
+    | KNOWN_SCOPE_NAMES
+    | KNOWN_FEATURE_NAMES
 )
 
 
-def get_scope_kind(location: str) -> str:
+def get_scope_from_location(location: str) -> capa.rules.Scope:
     """
     classify a fixture location string into a scope kind.
 
     reuses the same location grammar handled by `resolve_scope()`.
     """
     if location == "file":
-        return "file"
+        return capa.rules.Scope.FILE
     if "insn=" in location:
-        return "instruction"
+        return capa.rules.Scope.INSTRUCTION
     if "bb=" in location:
-        return "basic-block"
+        return capa.rules.Scope.BASIC_BLOCK
     if "call=" in location:
-        return "call"
+        return capa.rules.Scope.CALL
     if "thread=" in location:
-        return "thread"
+        return capa.rules.Scope.THREAD
     if "process=" in location:
-        return "process"
+        return capa.rules.Scope.PROCESS
     if location.startswith(("function", "token")):
-        return "function"
+        return capa.rules.Scope.FUNCTION
     raise ValueError(f"unexpected scope location: {location}")
-
-
-def get_feature_type_tag(feature_str: str) -> str:
-    """
-    extract the feature-type tag from a fixture feature string.
-
-    examples:
-      `api: CryptSetHashParam`         -> `api`
-      `function-name: __aulldiv`       -> `function-name`
-      `count(basic blocks): 7`         -> `basic blocks`
-      `count(mnemonic(mov)): 3`        -> `mnemonic`
-      `count(characteristic(nzxor))`   -> `characteristic`
-      `operand[1].number: 0xFF`        -> `operand.number`
-      `property/read: Foo.Bar`         -> `property`
-    """
-    if feature_str.startswith("count("):
-        # find the matching close-paren for the outer `count(` so that
-        # nested parens and colons inside the argument (e.g. strings with
-        # `:` or `(`) don't confuse a naive partition.
-        depth = 0
-        for i, c in enumerate(feature_str):
-            if c == "(":
-                depth += 1
-            elif c == ")":
-                depth -= 1
-                if depth == 0:
-                    inner = feature_str[len("count(") : i]
-                    # collapse nested arg: `mnemonic(mov)` -> `mnemonic`
-                    inner, _, _ = inner.partition("(")
-                    return _normalize_feature_key(inner.strip())
-        raise ValueError(f"unbalanced parentheses in feature string: {feature_str!r}")
-    key, _, _ = feature_str.partition(":")
-    return _normalize_feature_key(key.strip())
-
-
-def _normalize_feature_key(key: str) -> str:
-    # collapse `operand[N].X` -> `operand.X` so the tag is index-independent
-    if key.startswith("operand[") and "]." in key:
-        _, _, suffix = key.partition("].")
-        return f"operand.{suffix}"
-    # collapse `property/read` and `property/write` -> `property`
-    if key.startswith("property/"):
-        return "property"
-    return key
 
 
 @dataclass(frozen=True)
 class FixtureMark:
-    backend: str
-    mark: str
+    backend: (
+        Literal["vivisect"]
+        | Literal["dotnet"]
+        | Literal["binja"]
+        | Literal["pefile"]
+        | Literal["cape"]
+        | Literal["drakvuf"]
+        | Literal["vmray"]
+        | Literal["freeze"]
+        | Literal["binexport2"]
+        | Literal["ida"]
+        | Literal["ghidra"]
+    )
+    mark: Literal["skip"] | Literal["xfail"]
     reason: str
 
 
@@ -250,29 +169,22 @@ class FeatureFixture:
     sample_key: str
     sample_path: Path
     location: str
-    scope_kind: str
+    scope: capa.rules.Scope
     statement: Union[Feature, ceng.Range, ceng.Statement]
     expected: bool = True
     tags: frozenset[str] = frozenset()
     marks: tuple[FixtureMark, ...] = ()
     explanation: Optional[str] = None
-    comment: Optional[str] = None
 
 
 @dataclass(frozen=True)
 class BackendFeaturePolicy:
     name: str
-    get_extractor: Callable[[Path], object]
-    include_tags: frozenset[str] = field(default_factory=frozenset)
-    exclude_tags: frozenset[str] = field(default_factory=frozenset)
-
-    def __post_init__(self):
-        object.__setattr__(self, "include_tags", frozenset(self.include_tags))
-        object.__setattr__(self, "exclude_tags", frozenset(self.exclude_tags))
+    include_tags: set[str] = field(default_factory=set)
+    exclude_tags: set[str] = field(default_factory=set)
 
 
-@lru_cache(maxsize=1)
-def _load_feature_fixture_manifests() -> tuple[tuple[Path, dict], ...]:
+def get_fixture_files() -> tuple[tuple[Path, dict], ...]:
     manifests = []
     for path in sorted(FIXTURE_MANIFEST_DIR.glob("*.json")):
         with path.open("r") as f:
@@ -282,20 +194,7 @@ def _load_feature_fixture_manifests() -> tuple[tuple[Path, dict], ...]:
     return tuple(manifests)
 
 
-@lru_cache(maxsize=1)
-def _load_fixture_file_paths() -> dict[str, Path]:
-    return {key: file.path for key, file in load_feature_fixture_files().items()}
-
-
-def get_fixture_file_path(key: str) -> Path:
-    paths = _load_fixture_file_paths()
-    if key not in paths:
-        raise ValueError(f"unknown fixture file key: {key}")
-    return paths[key]
-
-
-@lru_cache(maxsize=1)
-def load_feature_fixture_files() -> dict[str, FixtureFile]:
+def load_fixture_file_references() -> dict[str, FixtureFile]:
     """
     load the combined `files` tables from `tests/fixtures/features/*.json`.
 
@@ -304,7 +203,7 @@ def load_feature_fixture_files() -> dict[str, FixtureFile]:
     """
     files: dict[str, FixtureFile] = {}
     file_sources: dict[str, Path] = {}
-    for manifest_path, data in _load_feature_fixture_manifests():
+    for manifest_path, data in get_fixture_files():
         for entry in data["files"]:
             key = entry["key"]
             if key in files:
@@ -327,7 +226,6 @@ def load_feature_fixture_files() -> dict[str, FixtureFile]:
     return files
 
 
-@lru_cache(maxsize=1)
 def load_feature_fixtures() -> tuple[FeatureFixture, ...]:
     """
     load the full list of feature fixtures from `tests/fixtures/features/*.json`.
@@ -336,66 +234,60 @@ def load_feature_fixtures() -> tuple[FeatureFixture, ...]:
     the known registry, parses the statement (including `count(...)`), and
     defaults `expected` to True.
     """
-    files = load_feature_fixture_files()
+    fixture_file_references = load_fixture_file_references()
     fixtures_: list[FeatureFixture] = []
-    for manifest_path, data in _load_feature_fixture_manifests():
-        for entry in data["features"]:
-            key = entry["file"]
-            if key not in files:
+    for fixture_file_path, fixture_file_data in get_fixture_files():
+        for fixture_file_entry in fixture_file_data["features"]:
+            fixture_file_reference = fixture_file_entry["file"]
+            if fixture_file_reference not in fixture_file_references:
                 raise ValueError(
-                    f"unknown fixture file key referenced by feature in {manifest_path}: {key!r}"
+                    f"unknown fixture file key referenced by feature in {fixture_file_path}: {fixture_file_reference!r}"
                 )
-            file = files[key]
+            fixture_file = fixture_file_references[fixture_file_reference]
 
-            feature_str: str = entry["feature"]
-            feature_tags = frozenset(entry.get("tags", []))
-            merged_tags = file.tags | feature_tags
-            unknown = merged_tags - KNOWN_FIXTURE_TAGS
+            feature_str: str = fixture_file_entry["feature"]
+            tags = frozenset(fixture_file_entry.get("tags", [])) | fixture_file.tags
+            unknown = tags - KNOWN_FIXTURE_TAGS
             if unknown:
                 raise ValueError(
-                    f"unknown fixture tag(s) on feature {feature_str!r} for file {key!r} in {manifest_path}: {sorted(unknown)}"
+                    f"unknown fixture tag(s) on feature {feature_str!r} for file {fixture_file_reference!r} in {fixture_file_path}: {sorted(unknown)}"
                 )
 
-            location = entry["location"]
+            location = fixture_file_entry["location"]
             statement = parse_feature_string(feature_str)
-            scope_kind = get_scope_kind(location)
-            feature_type_tag = get_feature_type_tag(feature_str)
+            scope = get_scope_from_location(location)
             # scope-kind and feature-type tags are auto-derived so that
             # backend policies can include/exclude scopes and feature types
             # purely via `include_tags`/`exclude_tags`. they're drawn from
             # the known-tag registry so no re-validation is needed here.
-            merged_tags = merged_tags | {scope_kind, feature_type_tag}
-            expected = entry.get("expected", True)
+            tags = tags | {scope.value}
+            if isinstance(statement, Feature):
+                tags = tags | {statement.name}
+                # technically we're not extracting the feature name for COM and count features
+                # but i think thats ok for now, since no tests rely on include/excluding those.
+
+            expected = fixture_file_entry.get("expected", True)
             marks = tuple(
                 FixtureMark(backend=m["backend"], mark=m["mark"], reason=m["reason"])
-                for m in entry.get("marks", [])
+                for m in fixture_file_entry.get("marks", [])
             )
 
             fixtures_.append(
                 FeatureFixture(
-                    sample_key=key,
-                    sample_path=file.path,
+                    sample_key=fixture_file_reference,
+                    sample_path=fixture_file.path,
                     location=location,
-                    scope_kind=scope_kind,
+                    scope=scope,
                     statement=statement,
                     expected=expected,
-                    tags=merged_tags,
+                    tags=tags,
                     marks=marks,
-                    explanation=entry.get("explanation"),
-                    comment=entry.get("comment"),
+                    explanation=fixture_file_entry.get("explanation"),
                 )
             )
 
     fixtures_.sort(key=lambda f: (f.sample_key, f.location))
     return tuple(fixtures_)
-
-
-@dataclass(frozen=True)
-class FixtureSelectionSummary:
-    total: int
-    selected: int
-    excluded: int
-    excluded_by_tag: dict[str, int]
 
 
 def _fixture_is_included(policy: BackendFeaturePolicy, fixture: FeatureFixture) -> bool:
@@ -420,31 +312,6 @@ def select_feature_fixtures(policy: BackendFeaturePolicy) -> list[FeatureFixture
     a policy can restrict scope or feature type via `exclude_tags` too.
     """
     return [f for f in load_feature_fixtures() if _fixture_is_included(policy, f)]
-
-
-def summarize_feature_selection(
-    policy: BackendFeaturePolicy,
-) -> FixtureSelectionSummary:
-    """
-    summarize the effect of a policy's fixture selection.
-
-    useful for debug output and maintenance scripts.
-    """
-    all_fixtures = load_feature_fixtures()
-    excluded_by_tag: dict[str, int] = collections.defaultdict(int)
-    selected = 0
-    for fixture in all_fixtures:
-        if _fixture_is_included(policy, fixture):
-            selected += 1
-            continue
-        for tag in sorted(fixture.tags):
-            excluded_by_tag[tag] += 1
-    return FixtureSelectionSummary(
-        total=len(all_fixtures),
-        selected=selected,
-        excluded=len(all_fixtures) - selected,
-        excluded_by_tag=dict(excluded_by_tag),
-    )
 
 
 def _fixture_test_id(fixture: FeatureFixture) -> str:
@@ -489,14 +356,13 @@ def parametrize_backend_feature_fixtures(policy: BackendFeaturePolicy):
     return pytest.mark.parametrize("feature_fixture", params)
 
 
-def run_feature_fixture(policy: BackendFeaturePolicy, fixture: FeatureFixture) -> None:
+def run_feature_fixture(
+    extractor: StaticFeatureExtractor | DynamicFeatureExtractor,
+    fixture: FeatureFixture,
+) -> None:
     """
     generic runner that evaluates a feature fixture against a backend.
-
-    handles both plain features and `count(...)` statements via one
-    `evaluate` path, comparing the boolean result to `fixture.expected`.
     """
-    extractor = policy.get_extractor(fixture.sample_path)
     scope = resolve_scope(fixture.location)
     features = scope(extractor)
     result = fixture.statement.evaluate(features)
@@ -531,7 +397,7 @@ def xfail(condition, reason: str = ""):
     except Exception:
         if condition:
             # we expected the test to fail, so raise and register this via pytest
-            pytest.xfail(reason)
+            pytest.xfail(reason or "")
         else:
             # we don't expect an exception, so the test should fail
             raise
@@ -546,262 +412,6 @@ def xfail(condition, reason: str = ""):
             raise RuntimeError("expected to fail, but didn't")
 
 
-# need to limit cache size so GitHub Actions doesn't run out of memory, see #545
-@lru_cache(maxsize=1)
-def get_viv_extractor(path: Path):
-    import capa.loader
-    import capa.features.extractors.viv.extractor
-    import capa.main
-
-    sigpaths = [
-        CD / "data" / "sigs" / "test_aulldiv.pat",
-        CD / "data" / "sigs" / "test_aullrem.pat.gz",
-        CD.parent / "sigs" / "1_flare_msvc_rtf_32_64.sig",
-        CD.parent / "sigs" / "2_flare_msvc_atlmfc_32_64.sig",
-        CD.parent / "sigs" / "3_flare_common_libs.sig",
-    ]
-
-    if "raw32" in path.name:
-        vw = capa.loader.get_workspace(path, "sc32", sigpaths=sigpaths)
-    elif "raw64" in path.name:
-        vw = capa.loader.get_workspace(path, "sc64", sigpaths=sigpaths)
-    else:
-        vw = capa.loader.get_workspace(path, FORMAT_AUTO, sigpaths=sigpaths)
-    vw.saveWorkspace()
-    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(
-        vw, path, OS_AUTO
-    )
-    fixup_viv(path, extractor)
-    return extractor
-
-
-def fixup_viv(path: Path, extractor):
-    """
-    vivisect fixups to overcome differences between backends
-    """
-    if "3b13b" in path.name:
-        # vivisect only recognizes calling thunk function at 0x10001573
-        extractor.vw.makeFunction(0x10006860)
-    if "294b8d" in path.name:
-        # see vivisect/#561
-        extractor.vw.makeFunction(0x404970)
-
-
-@lru_cache(maxsize=1)
-def get_pefile_extractor(path: Path):
-    import capa.features.extractors.pefile
-
-    extractor = capa.features.extractors.pefile.PefileFeatureExtractor(path)
-
-    # overload the extractor so that the fixture exposes `extractor.path`
-    setattr(extractor, "path", path.as_posix())
-
-    return extractor
-
-
-@lru_cache(maxsize=1)
-def get_dnfile_extractor(path: Path):
-    import capa.features.extractors.dnfile.extractor
-
-    extractor = capa.features.extractors.dnfile.extractor.DnfileFeatureExtractor(path)
-
-    # overload the extractor so that the fixture exposes `extractor.path`
-    setattr(extractor, "path", path.as_posix())
-
-    return extractor
-
-
-@lru_cache(maxsize=1)
-def get_dotnetfile_extractor(path: Path):
-    import capa.features.extractors.dotnetfile
-
-    extractor = capa.features.extractors.dotnetfile.DotnetFileFeatureExtractor(path)
-
-    # overload the extractor so that the fixture exposes `extractor.path`
-    setattr(extractor, "path", path.as_posix())
-
-    return extractor
-
-
-@lru_cache(maxsize=1)
-def get_binja_extractor(path: Path):
-    import binaryninja
-    from binaryninja import Settings
-
-    import capa.features.extractors.binja.extractor
-
-    # Workaround for a BN bug: https://github.com/Vector35/binaryninja-api/issues/4051
-    settings = Settings()
-    if path.name.endswith("kernel32-64.dll_"):
-        old_pdb = settings.get_bool("pdb.loadGlobalSymbols")
-        settings.set_bool("pdb.loadGlobalSymbols", False)
-        bv = binaryninja.load(str(path))
-        settings.set_bool("pdb.loadGlobalSymbols", old_pdb)
-    else:
-        bv = binaryninja.load(str(path))
-
-    # TODO(xusheng6): Temporary fix for https://github.com/mandiant/capa/issues/2507. Remove this once it is fixed in
-    # binja
-    if "al-khaser_x64.exe_" in path.name:
-        bv.create_user_function(0x14004B4F0)
-        bv.update_analysis_and_wait()
-
-    extractor = capa.features.extractors.binja.extractor.BinjaFeatureExtractor(bv)
-
-    # overload the extractor so that the fixture exposes `extractor.path`
-    setattr(extractor, "path", path.as_posix())
-
-    return extractor
-
-
-# we can't easily cache this because the extractor relies on global state (the opened database)
-# which also has to be closed elsewhere. so, the idalib tests will just take a little bit to run.
-def get_idalib_extractor(path: Path):
-    import capa.features.extractors.ida.idalib as idalib
-
-    if not idalib.has_idalib():
-        raise RuntimeError("cannot find IDA idalib module.")
-
-    if not idalib.load_idalib():
-        raise RuntimeError("failed to load IDA idalib module.")
-
-    import ida_auto
-    import idapro
-
-    import capa.features.extractors.ida.extractor
-
-    logger.debug("idalib: opening database...")
-
-    idapro.enable_console_messages(False)
-
-    # we set the primary and secondary Lumina servers to 0.0.0.0 to disable Lumina,
-    # which sometimes provides bad names, including overwriting names from debug info.
-    #
-    # use -R to load resources, which can help us embedded PE files.
-    #
-    # return values from open_database:
-    #   0 - Success
-    #   2 - User cancelled or 32-64 bit conversion failed
-    #   4 - Database initialization failed
-    #   -1 - Generic errors (database already open, auto-analysis failed, etc.)
-    #   -2 - User cancelled operation
-    ret = idapro.open_database(
-        str(path),
-        run_auto_analysis=True,
-        args="-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R",
-    )
-    if ret != 0:
-        raise RuntimeError("failed to analyze input file")
-
-    logger.debug("idalib: waiting for analysis...")
-    ida_auto.auto_wait()
-    logger.debug("idalib: opened database.")
-
-    extractor = capa.features.extractors.ida.extractor.IdaFeatureExtractor()
-    fixup_idalib(path, extractor)
-    return extractor
-
-
-def fixup_idalib(path: Path, extractor):
-    """
-    IDA fixups to overcome differences between backends
-    """
-    import ida_funcs
-    import idaapi
-
-    def remove_library_id_flag(fva):
-        f = idaapi.get_func(fva)
-        f.flags &= ~ida_funcs.FUNC_LIB
-        ida_funcs.update_func(f)
-
-    if "kernel32-64" in path.name:
-        # remove (correct) library function id, so we can test x64 thunk
-        remove_library_id_flag(0x1800202B0)
-
-    if "al-khaser_x64" in path.name:
-        # remove (correct) library function id, so we can test x64 nested thunk
-        remove_library_id_flag(0x14004B4F0)
-
-
-@lru_cache(maxsize=1)
-def get_cape_extractor(path):
-    from capa.features.extractors.cape.extractor import CapeExtractor
-    from capa.helpers import load_json_from_path
-
-    report = load_json_from_path(path)
-
-    return CapeExtractor.from_report(report)
-
-
-@lru_cache(maxsize=1)
-def get_drakvuf_extractor(path):
-    from capa.features.extractors.drakvuf.extractor import DrakvufExtractor
-    from capa.helpers import load_jsonl_from_path
-
-    report = load_jsonl_from_path(path)
-
-    return DrakvufExtractor.from_report(report)
-
-
-@lru_cache(maxsize=1)
-def get_vmray_extractor(path):
-    from capa.features.extractors.vmray.extractor import VMRayExtractor
-
-    return VMRayExtractor.from_zipfile(path)
-
-
-GHIDRA_CACHE: dict[Path, tuple] = {}
-
-
-def get_ghidra_extractor(path: Path):
-    # we need to start PyGhidra before importing the extractor
-    # because the extractor imports Ghidra modules that are only available after PyGhidra is started
-    import pyghidra
-
-    if not pyghidra.started():
-        pyghidra.start()
-
-    import capa.loader
-    import capa.features.extractors.ghidra.context
-
-    if path in GHIDRA_CACHE:
-        extractor, program, flat_api, monitor = GHIDRA_CACHE[path]
-        capa.features.extractors.ghidra.context.set_context(program, flat_api, monitor)
-        return extractor
-
-    # We use a larger cache size to avoid re-opening the same file multiple times
-    # which is very slow with Ghidra.
-    extractor = capa.loader.get_extractor(
-        path,
-        FORMAT_AUTO,
-        OS_AUTO,
-        capa.loader.BACKEND_GHIDRA,
-        [],
-        disable_progress=True,
-    )
-
-    ctx = capa.features.extractors.ghidra.context.get_context()
-    GHIDRA_CACHE[path] = (extractor, ctx.program, ctx.flat_api, ctx.monitor)
-    return extractor
-
-
-@lru_cache(maxsize=1)
-def get_binexport_extractor(path):
-    import capa.features.extractors.binexport2
-    import capa.features.extractors.binexport2.extractor
-
-    be2 = capa.features.extractors.binexport2.get_binexport2(path)
-    search_paths = [CD / "data", CD / "data" / "aarch64"]
-    path = capa.features.extractors.binexport2.get_sample_from_binexport2(
-        path, be2, search_paths
-    )
-    buf = path.read_bytes()
-
-    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(
-        be2, buf
-    )
-
-
 def extract_global_features(extractor):
     features = collections.defaultdict(set)
     for feature, va in extractor.extract_global_features():
@@ -809,7 +419,7 @@ def extract_global_features(extractor):
     return features
 
 
-@lru_cache
+@functools.lru_cache()
 def extract_file_features(extractor):
     features = collections.defaultdict(set)
     for feature, va in extractor.extract_file_features():
@@ -847,7 +457,7 @@ def extract_call_features(extractor, ph, th, ch):
     return features
 
 
-# f may not be hashable (e.g. ida func_t) so cannot @lru_cache this
+# f may not be hashable (e.g. ida func_t) so cannot @functools.lru_cache this
 def extract_function_features(extractor, fh):
     features = collections.defaultdict(set)
     for bb in extractor.get_basic_blocks(fh):
@@ -861,7 +471,7 @@ def extract_function_features(extractor, fh):
     return features
 
 
-# f may not be hashable (e.g. ida func_t) so cannot @lru_cache this
+# f may not be hashable (e.g. ida func_t) so cannot @functools.lru_cache this
 def extract_basic_block_features(extractor, fh, bbh):
     features = collections.defaultdict(set)
     for insn in extractor.get_instructions(fh, bbh):
@@ -872,307 +482,12 @@ def extract_basic_block_features(extractor, fh, bbh):
     return features
 
 
-# f may not be hashable (e.g. ida func_t) so cannot @lru_cache this
+# f may not be hashable (e.g. ida func_t) so cannot @functools.lru_cache this
 def extract_instruction_features(extractor, fh, bbh, ih) -> dict[Feature, set[Address]]:
     features = collections.defaultdict(set)
     for feature, addr in extractor.extract_insn_features(fh, bbh, ih):
         features[feature].add(addr)
     return features
-
-
-# note: to reduce the testing time it's recommended to reuse already existing test samples, if possible
-def get_data_path_by_name(name) -> Path:
-    # prefer the fixture manifest registry; fall back to the legacy hard-coded
-    # branches below for any keys not yet migrated.
-    lookup_key = name[:-3] if name.endswith("...") else name
-    json_paths = _load_fixture_file_paths()
-    if lookup_key in json_paths:
-        return json_paths[lookup_key]
-
-    if name == "mimikatz":
-        return CD / "data" / "mimikatz.exe_"
-    elif name == "kernel32":
-        return CD / "data" / "kernel32.dll_"
-    elif name == "kernel32-64":
-        return CD / "data" / "kernel32-64.dll_"
-    elif name == "pma01-01":
-        return CD / "data" / "Practical Malware Analysis Lab 01-01.dll_"
-    elif name == "pma01-01-rd":
-        return CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
-    elif name == "pma12-04":
-        return CD / "data" / "Practical Malware Analysis Lab 12-04.exe_"
-    elif name == "pma16-01":
-        return CD / "data" / "Practical Malware Analysis Lab 16-01.exe_"
-    elif name == "pma16-01_binja_db":
-        return CD / "data" / "Practical Malware Analysis Lab 16-01.exe_.bndb"
-    elif name == "pma21-01":
-        return CD / "data" / "Practical Malware Analysis Lab 21-01.exe_"
-    elif name == "al-khaser x86":
-        return CD / "data" / "al-khaser_x86.exe_"
-    elif name == "al-khaser x64":
-        return CD / "data" / "al-khaser_x64.exe_"
-    elif name.startswith("39c05"):
-        return (
-            CD
-            / "data"
-            / "39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_"
-        )
-    elif name.startswith("499c2"):
-        return CD / "data" / "499c2a85f6e8142c3f48d4251c9c7cd6.raw32"
-    elif name.startswith("9324d"):
-        return CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_"
-    elif name.startswith("395eb"):
-        return CD / "data" / "395eb0ddd99d2c9e37b6d0b73485ee9c.exe_"
-    elif name.startswith("a1982"):
-        return CD / "data" / "a198216798ca38f280dc413f8c57f2c2.exe_"
-    elif name.startswith("a933a"):
-        return CD / "data" / "a933a1a402775cfa94b6bee0963f4b46.dll_"
-    elif name.startswith("bfb9b"):
-        return CD / "data" / "bfb9b5391a13d0afd787e87ab90f14f5.dll_"
-    elif name.startswith("c9188"):
-        return CD / "data" / "c91887d861d9bd4a5872249b641bc9f9.exe_"
-    elif name.startswith("64d9f"):
-        return CD / "data" / "64d9f7d96b99467f36e22fada623c3bb.dll_"
-    elif name.startswith("82bf6"):
-        return CD / "data" / "82BF6347ACF15E5D883715DC289D8A2B.exe_"
-    elif name.startswith("pingtaest"):
-        return CD / "data" / "ping_täst.exe_"
-    elif name.startswith("77329"):
-        return CD / "data" / "773290480d5445f11d3dc1b800728966.exe_"
-    elif name.startswith("3b13b"):
-        return (
-            CD
-            / "data"
-            / "3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_"
-        )
-    elif name == "7351f.elf":
-        return CD / "data" / "7351f8a40c5450557b24622417fc478d.elf_"
-    elif name == "055da8e6.elf":
-        return CD / "data" / "055da8e6ccfe5a9380231ea04b850e18.elf_"
-    elif name == "bb38149.elf":
-        return CD / "data" / "bb38149ff4b5c95722b83f24ca27a42b.elf_"
-    elif name.startswith("79abd"):
-        return CD / "data" / "79abd17391adc6251ecdc58d13d76baf.dll_"
-    elif name.startswith("946a9"):
-        return CD / "data" / "946a99f36a46d335dec080d9a4371940.dll_"
-    elif name.startswith("2f7f5f"):
-        return CD / "data" / "2f7f5fb5de175e770d7eae87666f9831.elf_"
-    elif name.startswith("b9f5b"):
-        return CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_"
-    elif name.startswith("mixed-mode-64"):
-        return (
-            DNFILE_TESTFILES
-            / "mixed-mode"
-            / "ModuleCode"
-            / "bin"
-            / "ModuleCode_amd64.exe"
-        )
-    elif name.startswith("hello-world"):
-        return DNFILE_TESTFILES / "hello-world" / "hello-world.exe"
-    elif name.startswith("_1c444"):
-        return DOTNET_DIR / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_"
-    elif name.startswith("_387f15"):
-        return (
-            DOTNET_DIR
-            / "387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_"
-        )
-    elif name.startswith("_692f"):
-        return DOTNET_DIR / "692f7fd6d198e804d6af98eb9e390d61.exe_"
-    elif name.startswith("_0953c"):
-        return (
-            CD
-            / "data"
-            / "0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_"
-        )
-    elif name.startswith("_039a6"):
-        return (
-            CD
-            / "data"
-            / "039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_"
-        )
-    elif name.startswith("b5f052"):
-        return (
-            CD
-            / "data"
-            / "b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_"
-        )
-    elif name.startswith("bf7a9c"):
-        return (
-            CD
-            / "data"
-            / "bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_"
-        )
-    elif name.startswith("294b8d"):
-        return (
-            CD
-            / "data"
-            / "294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
-        )
-    elif name.startswith("2bf18d"):
-        return CD / "data" / "2bf18d0403677378adad9001b1243211.elf_"
-    elif name.startswith("2d3edc"):
-        return CD / "data" / "2d3edc218a90f03089cc01715a9f047f.exe_"
-    elif name.startswith("0000a657"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "cape"
-            / "v2.2"
-            / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
-        )
-    elif name.startswith("d46900"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "cape"
-            / "v2.2"
-            / "d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz"
-        )
-    elif name.startswith("93b2d1-drakvuf"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "drakvuf"
-            / "93b2d1840566f45fab674ebc79a9d19c88993bcb645e0357f3cb584d16e7c795.log.gz"
-        )
-    elif name.startswith("93b2d1-vmray"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "vmray"
-            / "93b2d1840566f45fab674ebc79a9d19c88993bcb645e0357f3cb584d16e7c795_min_archive.zip"
-        )
-    elif name.startswith("2f8a79-vmray"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "vmray"
-            / "2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip"
-        )
-    elif name.startswith("eb1287-vmray"):
-        return (
-            CD
-            / "data"
-            / "dynamic"
-            / "vmray"
-            / "eb12873c0ce3e9ea109c2a447956cbd10ca2c3e86936e526b2c6e28764999f21_min_archive.zip"
-        )
-    elif name.startswith("ea2876"):
-        return (
-            CD
-            / "data"
-            / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
-        )
-    elif name.startswith("1038a2"):
-        return (
-            CD
-            / "data"
-            / "1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_"
-        )
-    elif name.startswith("3da7c"):
-        return (
-            CD
-            / "data"
-            / "3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_"
-        )
-    elif name.startswith("nested_typedef"):
-        return CD / "data" / "dotnet" / "dd9098ff91717f4906afe9dafdfa2f52.exe_"
-    elif name.startswith("nested_typeref"):
-        return CD / "data" / "dotnet" / "2c7d60f77812607dec5085973ff76cea.dll_"
-    elif name.startswith("687e79.ghidra.be2"):
-        return (
-            CD
-            / "data"
-            / "binexport2"
-            / "687e79cde5b0ced75ac229465835054931f9ec438816f2827a8be5f3bd474929.elf_.ghidra.BinExport"
-        )
-    elif name.startswith("d1e650.ghidra.be2"):
-        return (
-            CD
-            / "data"
-            / "binexport2"
-            / "d1e6506964edbfffb08c0dd32e1486b11fbced7a4bd870ffe79f110298f0efb8.elf_.ghidra.BinExport"
-        )
-    else:
-        raise ValueError(f"unexpected sample fixture: {name}")
-
-
-def get_sample_md5_by_name(name):
-    """used by IDA tests to ensure the correct IDB is loaded"""
-    if name == "mimikatz":
-        return "5f66b82558ca92e54e77f216ef4c066c"
-    elif name == "kernel32":
-        return "e80758cf485db142fca1ee03a34ead05"
-    elif name == "kernel32-64":
-        return "a8565440629ac87f6fef7d588fe3ff0f"
-    elif name == "pma12-04":
-        return "56bed8249e7c2982a90e54e1e55391a2"
-    elif name == "pma16-01":
-        return "7faafc7e4a5c736ebfee6abbbc812d80"
-    elif name == "pma01-01":
-        return "290934c61de9176ad682ffdd65f0a669"
-    elif name == "pma21-01":
-        return "c8403fb05244e23a7931c766409b5e22"
-    elif name == "al-khaser x86":
-        return "db648cd247281954344f1d810c6fd590"
-    elif name == "al-khaser x64":
-        return "3cb21ae76ff3da4b7e02d77ff76e82be"
-    elif name.startswith("39c05"):
-        return "b7841b9d5dc1f511a93cc7576672ec0c"
-    elif name.startswith("499c2"):
-        return "499c2a85f6e8142c3f48d4251c9c7cd6"
-    elif name.startswith("9324d"):
-        return "9324d1a8ae37a36ae560c37448c9705a"
-    elif name.startswith("a1982"):
-        return "a198216798ca38f280dc413f8c57f2c2"
-    elif name.startswith("a933a"):
-        return "a933a1a402775cfa94b6bee0963f4b46"
-    elif name.startswith("bfb9b"):
-        return "bfb9b5391a13d0afd787e87ab90f14f5"
-    elif name.startswith("c9188"):
-        return "c91887d861d9bd4a5872249b641bc9f9"
-    elif name.startswith("64d9f"):
-        return "64d9f7d96b99467f36e22fada623c3bb"
-    elif name.startswith("82bf6"):
-        return "82bf6347acf15e5d883715dc289d8a2b"
-    elif name.startswith("77329"):
-        return "773290480d5445f11d3dc1b800728966"
-    elif name.startswith("3b13b"):
-        # file name is SHA256 hash
-        return "56a6ffe6a02941028cc8235204eef31d"
-    elif name.startswith("7351f"):
-        return "7351f8a40c5450557b24622417fc478d"
-    elif name.startswith("79abd"):
-        return "79abd17391adc6251ecdc58d13d76baf"
-    elif name.startswith("946a9"):
-        return "946a99f36a46d335dec080d9a4371940"
-    elif name.startswith("b9f5b"):
-        return "b9f5bd514485fb06da39beff051b9fdc"
-    elif name.startswith("294b8d"):
-        # file name is SHA256 hash
-        return "3db3e55b16a7b1b1afb970d5e77c5d98"
-    elif name.startswith("2bf18d"):
-        return "2bf18d0403677378adad9001b1243211"
-    elif name.startswith("2d3edc"):
-        return "2d3edc218a90f03089cc01715a9f047f"
-    elif name.startswith("ea2876"):
-        return "76fa734236daa023444dec26863401dc"
-    else:
-        raise ValueError(f"unexpected sample fixture: {name}")
-
-
-def resolve_sample(sample):
-    return get_data_path_by_name(sample)
-
-
-@pytest.fixture
-def sample(request):
-    return resolve_sample(request.param)
 
 
 def get_process(extractor, ppid: int, pid: int) -> ProcessHandle:
@@ -1387,33 +702,6 @@ def parametrize(params, values, **kwargs):
     return pytest.mark.parametrize(params, values, ids=ids, **kwargs)
 
 
-# legacy tuple-of-tuples lists still needed by `test_binexport_features.py`,
-# which rewrites a mimikatz sample path to its `.ghidra.BinExport` counterpart
-# at test time.
-#
-# built from the new `load_feature_fixtures()` so the JSON manifests remain the
-# single source of truth for fixture data.
-FEATURE_PRESENCE_TESTS: list[tuple] = sorted(
-    (
-        (f.sample_key, f.location, f.statement, f.expected)
-        for f in load_feature_fixtures()
-        if not isinstance(f.statement, ceng.Range)
-        and not (f.tags & frozenset({"dotnet", "symtab"}))
-    ),
-    key=lambda t: (t[0], t[1]),
-)
-
-FEATURE_COUNT_TESTS_GHIDRA: list[tuple] = sorted(
-    (
-        (f.sample_key, f.location, f.statement.child, f.statement.min)
-        for f in load_feature_fixtures()
-        if isinstance(f.statement, ceng.Range) and "ghidra" in f.tags
-    ),
-    key=lambda t: (t[0], t[1]),
-)
-
-
-
 FEATURE_COUNT_TESTS_BE2_INTEL = [
     (
         "mimikatz",
@@ -1430,139 +718,11 @@ FEATURE_COUNT_TESTS_BE2_INTEL = [
 ]
 
 
-
-def do_test_feature_presence(get_extractor, sample, scope, feature, expected):
-    extractor = get_extractor(sample)
-    features = scope(extractor)
-    if expected:
-        msg = f"{str(feature)} should be found in {scope.__name__}"
-    else:
-        msg = f"{str(feature)} should not be found in {scope.__name__}"
-    assert feature.evaluate(features) == expected, msg
-
-
 def do_test_feature_count(get_extractor, sample, scope, feature, expected):
     extractor = get_extractor(sample)
     features = scope(extractor)
-    msg = f"{str(feature)} should be found {expected} times in {scope.__name__}, found: {len(features[feature])}"
-    assert len(features[feature]) == expected, msg
-
-
-def get_extractor(path: Path):
-    extractor = get_viv_extractor(path)
-    # overload the extractor so that the fixture exposes `extractor.path`
-    setattr(extractor, "path", path.as_posix())
-    return extractor
-
-
-@pytest.fixture
-def mimikatz_extractor():
-    return get_extractor(get_data_path_by_name("mimikatz"))
-
-
-@pytest.fixture
-def a933a_extractor():
-    return get_extractor(get_data_path_by_name("a933a..."))
-
-
-@pytest.fixture
-def kernel32_extractor():
-    return get_extractor(get_data_path_by_name("kernel32"))
-
-
-@pytest.fixture
-def a1982_extractor():
-    return get_extractor(get_data_path_by_name("a1982..."))
-
-
-@pytest.fixture
-def z9324d_extractor():
-    return get_extractor(get_data_path_by_name("9324d..."))
-
-
-@pytest.fixture
-def z395eb_extractor():
-    return get_extractor(get_data_path_by_name("395eb..."))
-
-
-@pytest.fixture
-def pma12_04_extractor():
-    return get_extractor(get_data_path_by_name("pma12-04"))
-
-
-@pytest.fixture
-def pma16_01_extractor():
-    return get_extractor(get_data_path_by_name("pma16-01"))
-
-
-@pytest.fixture
-def bfb9b_extractor():
-    return get_extractor(get_data_path_by_name("bfb9b..."))
-
-
-@pytest.fixture
-def pma21_01_extractor():
-    return get_extractor(get_data_path_by_name("pma21-01"))
-
-
-@pytest.fixture
-def c9188_extractor():
-    return get_extractor(get_data_path_by_name("c9188..."))
-
-
-@pytest.fixture
-def z39c05_extractor():
-    return get_extractor(get_data_path_by_name("39c05..."))
-
-
-@pytest.fixture
-def z499c2_extractor():
-    return get_extractor(get_data_path_by_name("499c2..."))
-
-
-@pytest.fixture
-def al_khaser_x86_extractor():
-    return get_extractor(get_data_path_by_name("al-khaser x86"))
-
-
-@pytest.fixture
-def pingtaest_extractor():
-    return get_extractor(get_data_path_by_name("pingtaest"))
-
-
-@pytest.fixture
-def b9f5b_dotnetfile_extractor():
-    return get_dotnetfile_extractor(get_data_path_by_name("b9f5b"))
-
-
-@pytest.fixture
-def mixed_mode_64_dotnetfile_extractor():
-    return get_dotnetfile_extractor(get_data_path_by_name("mixed-mode-64"))
-
-
-@pytest.fixture
-def hello_world_dotnetfile_extractor():
-    return get_dnfile_extractor(get_data_path_by_name("hello-world"))
-
-
-@pytest.fixture
-def _1c444_dotnetfile_extractor():
-    return get_dnfile_extractor(get_data_path_by_name("_1c444"))
-
-
-@pytest.fixture
-def _692f_dotnetfile_extractor():
-    return get_dnfile_extractor(get_data_path_by_name("_692f"))
-
-
-@pytest.fixture
-def _0953c_dotnetfile_extractor():
-    return get_dnfile_extractor(get_data_path_by_name("_0953c"))
-
-
-@pytest.fixture
-def _039a6_dotnetfile_extractor():
-    return get_dnfile_extractor(get_data_path_by_name("_039a6"))
+    assert features.get(feature, set()) != set(), f"{feature} should be found in {scope.__name__}"
+    assert len(features[feature]) == expected, f"{feature} should be found {expected} times in {scope.__name__}"
 
 
 def get_result_doc(path: Path):
@@ -1623,4 +783,233 @@ def dynamic_a0000a6_rd():
         / "data"
         / "rd"
         / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+    )
+
+
+PMA1601 = CD / "data" / "Practical Malware Analysis Lab 16-01.exe_"
+z9324 = CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_"
+
+
+# used by test_viv_features
+# as well as some fixtures below
+@functools.lru_cache(maxsize=1)
+def get_viv_extractor(path: Path):
+    import capa.features.extractors.viv.extractor
+    import capa.main
+
+    sigpaths = [
+        CD / "data" / "sigs" / "test_aulldiv.pat",
+        CD / "data" / "sigs" / "test_aullrem.pat.gz",
+        CD.parent / "sigs" / "1_flare_msvc_rtf_32_64.sig",
+        CD.parent / "sigs" / "2_flare_msvc_atlmfc_32_64.sig",
+        CD.parent / "sigs" / "3_flare_common_libs.sig",
+    ]
+
+    if "raw32" in path.name:
+        vw = capa.loader.get_workspace(path, "sc32", sigpaths=sigpaths)
+    elif "raw64" in path.name:
+        vw = capa.loader.get_workspace(path, "sc64", sigpaths=sigpaths)
+    else:
+        vw = capa.loader.get_workspace(path, FORMAT_AUTO, sigpaths=sigpaths)
+    vw.saveWorkspace()
+
+    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(
+        vw, path, OS_AUTO
+    )
+
+    #
+    # fixups to overcome differences between backends
+    # 
+    if "3b13b" in path.name:
+        # vivisect only recognizes calling thunk function at 0x10001573
+        extractor.vw.makeFunction(0x10006860)
+    if "294b8d" in path.name:
+        # see vivisect/#561
+        extractor.vw.makeFunction(0x404970)
+
+    return extractor
+
+
+@pytest.fixture
+def z9324d_extractor():
+    return get_viv_extractor(z9324)
+
+
+@pytest.fixture
+def pma16_01_extractor():
+    return get_viv_extractor(PMA1601)
+
+
+@functools.lru_cache(maxsize=1)
+def get_pefile_extractor(path: Path):
+    import capa.features.extractors.pefile
+
+    extractor = capa.features.extractors.pefile.PefileFeatureExtractor(path)
+    setattr(extractor, "path", path.as_posix())
+    return extractor
+
+
+@functools.lru_cache(maxsize=1)
+def get_dnfile_extractor(path: Path):
+    extractor = DnfileFeatureExtractor(path)
+    setattr(extractor, "path", path.as_posix())
+    return extractor
+
+
+@functools.lru_cache(maxsize=1)
+def get_dotnetfile_extractor(path: Path):
+    import capa.features.extractors.dotnetfile
+
+    extractor = capa.features.extractors.dotnetfile.DotnetFileFeatureExtractor(path)
+    setattr(extractor, "path", path.as_posix())
+    return extractor
+
+
+@functools.lru_cache(maxsize=1)
+def get_cape_extractor(path):
+    from capa.helpers import load_json_from_path
+    from capa.features.extractors.cape.extractor import CapeExtractor
+
+    report = load_json_from_path(path)
+    return CapeExtractor.from_report(report)
+
+
+@functools.lru_cache(maxsize=1)
+def get_drakvuf_extractor(path):
+    from capa.helpers import load_jsonl_from_path
+    from capa.features.extractors.drakvuf.extractor import DrakvufExtractor
+
+    report = load_jsonl_from_path(path)
+    return DrakvufExtractor.from_report(report)
+
+
+@functools.lru_cache(maxsize=1)
+def get_vmray_extractor(path):
+    from capa.features.extractors.vmray.extractor import VMRayExtractor
+
+    return VMRayExtractor.from_zipfile(path)
+
+
+@functools.lru_cache(maxsize=1)
+def get_binja_extractor(path: Path):
+    import binaryninja
+    from binaryninja import Settings
+
+    import capa.features.extractors.binja.extractor
+
+    settings = Settings()
+    if path.name.endswith("kernel32-64.dll_"):
+        old_pdb = settings.get_bool("pdb.loadGlobalSymbols")
+        settings.set_bool("pdb.loadGlobalSymbols", False)
+    else:
+        old_pdb = False
+    bv = binaryninja.load(str(path))
+    if path.name.endswith("kernel32-64.dll_"):
+        settings.set_bool("pdb.loadGlobalSymbols", old_pdb)
+
+    if "al-khaser_x64.exe_" in path.name:
+        bv.create_user_function(0x14004B4F0)
+        bv.update_analysis_and_wait()
+
+    extractor = capa.features.extractors.binja.extractor.BinjaFeatureExtractor(bv)
+    setattr(extractor, "path", path.as_posix())
+    return extractor
+
+
+GHIDRA_CACHE: dict[Path, tuple] = {}
+
+
+def get_ghidra_extractor(path: Path):
+    import pyghidra
+
+    if not pyghidra.started():
+        pyghidra.start()
+
+    import capa.features.extractors.ghidra.context
+
+    if path in GHIDRA_CACHE:
+        extractor, program, flat_api, monitor = GHIDRA_CACHE[path]
+        capa.features.extractors.ghidra.context.set_context(program, flat_api, monitor)
+        return extractor
+
+    extractor = capa.loader.get_extractor(
+        path,
+        FORMAT_AUTO,
+        OS_AUTO,
+        capa.loader.BACKEND_GHIDRA,
+        [],
+        disable_progress=True,
+    )
+
+    ctx = capa.features.extractors.ghidra.context.get_context()
+    GHIDRA_CACHE[path] = (extractor, ctx.program, ctx.flat_api, ctx.monitor)
+    return extractor
+
+
+def _fixup_idalib(path: Path, extractor):
+    import idaapi
+    import ida_funcs
+
+    def remove_library_id_flag(fva):
+        f = idaapi.get_func(fva)
+        f.flags &= ~ida_funcs.FUNC_LIB
+        ida_funcs.update_func(f)
+
+    if "kernel32-64" in path.name:
+        remove_library_id_flag(0x1800202B0)
+
+    if "al-khaser_x64" in path.name:
+        remove_library_id_flag(0x14004B4F0)
+
+
+def get_idalib_extractor(path: Path):
+    import capa.features.extractors.ida.extractor
+    import capa.features.extractors.ida.idalib as idalib
+
+    if not idalib.has_idalib():
+        raise RuntimeError("cannot find IDA idalib module.")
+
+    if not idalib.load_idalib():
+        raise RuntimeError("failed to load IDA idalib module.")
+
+    import idapro
+    import ida_auto
+
+    logger.debug("idalib: opening database...")
+    idapro.enable_console_messages(False)
+
+    ret = idapro.open_database(
+        str(path),
+        run_auto_analysis=True,
+        args="-Olumina:host=0.0.0.0 -Osecondary_lumina:host=0.0.0.0 -R",
+    )
+    if ret != 0:
+        raise RuntimeError("failed to analyze input file")
+
+    logger.debug("idalib: waiting for analysis...")
+    ida_auto.auto_wait()
+    logger.debug("idalib: opened database.")
+
+    extractor = capa.features.extractors.ida.extractor.IdaFeatureExtractor()
+    _fixup_idalib(path, extractor)
+    return extractor
+
+
+# used by both:
+# - test_binexport_features
+# - test_binexport_accessors
+@functools.lru_cache(maxsize=1)
+def get_binexport_extractor(path):
+    import capa.features.extractors.binexport2
+    import capa.features.extractors.binexport2.extractor
+
+    be2 = capa.features.extractors.binexport2.get_binexport2(path)
+    search_paths = [CD / "data", CD / "data" / "aarch64"]
+    path = capa.features.extractors.binexport2.get_sample_from_binexport2(
+        path, be2, search_paths
+    )
+    buf = path.read_bytes()
+
+    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(
+        be2, buf
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,128 +12,279 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
+import contextlib
 import json
 import logging
-import contextlib
-import collections
-from pathlib import Path
+from dataclasses import dataclass, field
 from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Optional, Union
 
 import pytest
 
-import capa.rules
 import capa.engine as ceng
-import capa.loader
+import capa.features.basicblock
+import capa.features.common
 import capa.features.file
 import capa.features.insn
 import capa.features.common
 import capa.features.basicblock
+import capa.loader
+import capa.rules
 import capa.render.result_document
+from capa.features.address import Address
 from capa.features.common import (
+    ARCH_AMD64,
+    ARCH_I386,
+    FORMAT_AUTO,
+    FORMAT_DOTNET,
+    FORMAT_ELF,
+    FORMAT_PE,
     OS,
     OS_ANY,
     OS_AUTO,
     OS_LINUX,
-    ARCH_I386,
-    FORMAT_PE,
-    ARCH_AMD64,
-    FORMAT_ELF,
     OS_WINDOWS,
-    FORMAT_AUTO,
-    FORMAT_DOTNET,
     Arch,
-    Format,
     Feature,
     FeatureAccess,
+    Format,
 )
-from capa.features.address import Address
 from capa.features.extractors.base_extractor import (
     BBHandle,
     CallHandle,
-    InsnHandle,
-    ThreadHandle,
-    ProcessHandle,
     FunctionHandle,
+    InsnHandle,
+    ProcessHandle,
+    ThreadHandle,
 )
 from capa.features.extractors.dnfile.extractor import DnfileFeatureExtractor
 
 logger = logging.getLogger(__name__)
 CD = Path(__file__).resolve().parent
+FIXTURE_MANIFEST_DIR = CD / "fixtures" / "features"
 DOTNET_DIR = CD / "data" / "dotnet"
 DNFILE_TESTFILES = DOTNET_DIR / "dnfile-testfiles"
 
 
 def parse_feature_string(s: str) -> Feature | ceng.Range | ceng.Statement:
+    """
+    parse a fixture feature string into a Feature, Range, or Statement.
+
+    count(...) fixtures have a string integer value in the JSON
+    (e.g. `count(basic blocks): 7`). translate that to an int so
+    `build_feature` returns a Range rather than raising on an
+    unrecognized range expression.
+    """
     key, _, value = s.partition(": ")
-    return capa.rules.build_feature(key, value, initial_description=None)
+    initial_value: str | int = value
+    if key.startswith("count(") and key.endswith(")"):
+        try:
+            initial_value = int(value)
+        except ValueError:
+            # leave as string so that `build_feature` can handle
+            # "N or more"/"N or fewer"/"(N, M)" range expressions.
+            initial_value = value
+    return capa.rules.build_feature(key, initial_value, initial_description=None)
 
 
-FEATURE_MARKS: dict[tuple[str, str, str], list[dict]] = {}
+# scope-kind tags are derived from the fixture location and inserted
+# into the fixture's tag set. backends that only support a subset of
+# scopes (e.g., pefile is file-only) can exclude the others via tags.
+SCOPE_KIND_TAGS: frozenset[str] = frozenset(
+    {
+        "file",
+        "function",
+        "basic-block",
+        "instruction",
+        "process",
+        "thread",
+        "call",
+    }
+)
 
+# feature-type tags are derived from the fixture feature string's key
+# and inserted into the fixture's tag set. backends that don't support
+# a feature type (e.g., pefile has no function-name features) can
+# exclude by tag rather than by Python class.
+#
+# values come from `capa.rules.parse_feature` keys so the tag names
+# align with the textual rule syntax.
+FEATURE_TYPE_TAGS: frozenset[str] = frozenset(
+    {
+        "api",
+        "string",
+        "substring",
+        "bytes",
+        "number",
+        "offset",
+        "mnemonic",
+        "basic blocks",
+        "characteristic",
+        "export",
+        "import",
+        "section",
+        "match",
+        "function-name",
+        "os",
+        "format",
+        "arch",
+        "class",
+        "namespace",
+        "property",
+        # operand[N].X is collapsed to operand.X (index-independent)
+        "operand.number",
+        "operand.offset",
+    }
+)
 
-def _load_feature_tests() -> tuple[list[tuple], list[tuple], list[tuple], list[tuple], list[tuple], list[tuple]]:
-    with (CD / "fixtures" / "feature-presence.json").open("r") as f:
-        data = json.load(f)
-
-    presence_tests = []
-    symtab_tests = []
-    count_tests = []
-    ghidra_count_tests = []
-    dotnet_presence_tests = []
-    dotnet_count_tests = []
-
-    for entry in data["features"]:
-        feature_str = entry["feature"]
-        tags = entry.get("tags", [])
-
-        if "marks" in entry:
-            FEATURE_MARKS[(entry["file"], entry["location"], feature_str)] = entry["marks"]
-
-        if feature_str.startswith("count("):
-            key, _, value_str = feature_str.partition(": ")
-            count = int(value_str)
-            range_obj = capa.rules.build_feature(key, count, initial_description=None)
-            inner_feature = range_obj.child
-            test_tuple = (entry["file"], entry["location"], inner_feature, count)
-
-            if "ghidra" in tags:
-                ghidra_count_tests.append(test_tuple)
-            elif "dotnet" in tags:
-                dotnet_count_tests.append(test_tuple)
-            else:
-                count_tests.append(test_tuple)
-        else:
-            feature = parse_feature_string(feature_str)
-            test_tuple = (entry["file"], entry["location"], feature, entry["expected"])
-
-            if "symtab" in tags:
-                symtab_tests.append(test_tuple)
-            elif "dotnet" in tags:
-                dotnet_presence_tests.append(test_tuple)
-            else:
-                presence_tests.append(test_tuple)
-
-    presence_tests.sort(key=lambda t: (t[0], t[1]))
-    symtab_tests.sort(key=lambda t: (t[0], t[1]))
-    count_tests.sort(key=lambda t: (t[0], t[1]))
-    ghidra_count_tests.sort(key=lambda t: (t[0], t[1]))
-    dotnet_presence_tests.sort(key=lambda t: (t[0], t[1]))
-    dotnet_count_tests.sort(key=lambda t: (t[0], t[1]))
-    return (
-        presence_tests,
-        symtab_tests,
-        count_tests,
-        ghidra_count_tests,
-        dotnet_presence_tests,
-        dotnet_count_tests,
+# known fixture tags used for backend selection.
+# merged tags that are not listed here will fail collection, to catch typos.
+KNOWN_FIXTURE_TAGS: frozenset[str] = (
+    frozenset(
+        {
+            "static",
+            "dynamic",
+            "dotnet",
+            "elf",
+            "flirt",
+            "symtab",
+            "ghidra",
+            "binja-db",
+            "binexport",
+            "aarch64",
+            "cape",
+            "drakvuf",
+            "vmray",
+        }
     )
+    | SCOPE_KIND_TAGS
+    | FEATURE_TYPE_TAGS
+)
+
+
+def get_scope_kind(location: str) -> str:
+    """
+    classify a fixture location string into a scope kind.
+
+    reuses the same location grammar handled by `resolve_scope()`.
+    """
+    if location == "file":
+        return "file"
+    if "insn=" in location:
+        return "instruction"
+    if "bb=" in location:
+        return "basic-block"
+    if "call=" in location:
+        return "call"
+    if "thread=" in location:
+        return "thread"
+    if "process=" in location:
+        return "process"
+    if location.startswith(("function", "token")):
+        return "function"
+    raise ValueError(f"unexpected scope location: {location}")
+
+
+def get_feature_type_tag(feature_str: str) -> str:
+    """
+    extract the feature-type tag from a fixture feature string.
+
+    examples:
+      `api: CryptSetHashParam`         -> `api`
+      `function-name: __aulldiv`       -> `function-name`
+      `count(basic blocks): 7`         -> `basic blocks`
+      `count(mnemonic(mov)): 3`        -> `mnemonic`
+      `count(characteristic(nzxor))`   -> `characteristic`
+      `operand[1].number: 0xFF`        -> `operand.number`
+      `property/read: Foo.Bar`         -> `property`
+    """
+    if feature_str.startswith("count("):
+        # find the matching close-paren for the outer `count(` so that
+        # nested parens and colons inside the argument (e.g. strings with
+        # `:` or `(`) don't confuse a naive partition.
+        depth = 0
+        for i, c in enumerate(feature_str):
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    inner = feature_str[len("count(") : i]
+                    # collapse nested arg: `mnemonic(mov)` -> `mnemonic`
+                    inner, _, _ = inner.partition("(")
+                    return _normalize_feature_key(inner.strip())
+        raise ValueError(f"unbalanced parentheses in feature string: {feature_str!r}")
+    key, _, _ = feature_str.partition(":")
+    return _normalize_feature_key(key.strip())
+
+
+def _normalize_feature_key(key: str) -> str:
+    # collapse `operand[N].X` -> `operand.X` so the tag is index-independent
+    if key.startswith("operand[") and "]." in key:
+        _, _, suffix = key.partition("].")
+        return f"operand.{suffix}"
+    # collapse `property/read` and `property/write` -> `property`
+    if key.startswith("property/"):
+        return "property"
+    return key
+
+
+@dataclass(frozen=True)
+class FixtureMark:
+    backend: str
+    mark: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class FixtureFile:
+    key: str
+    path: Path
+    tags: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class FeatureFixture:
+    sample_key: str
+    sample_path: Path
+    location: str
+    scope_kind: str
+    statement: Union[Feature, ceng.Range, ceng.Statement]
+    expected: bool = True
+    tags: frozenset[str] = frozenset()
+    marks: tuple[FixtureMark, ...] = ()
+    explanation: Optional[str] = None
+    comment: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class BackendFeaturePolicy:
+    name: str
+    get_extractor: Callable[[Path], object]
+    include_tags: frozenset[str] = field(default_factory=frozenset)
+    exclude_tags: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self):
+        object.__setattr__(self, "include_tags", frozenset(self.include_tags))
+        object.__setattr__(self, "exclude_tags", frozenset(self.exclude_tags))
+
+
+@lru_cache(maxsize=1)
+def _load_feature_fixture_manifests() -> tuple[tuple[Path, dict], ...]:
+    manifests = []
+    for path in sorted(FIXTURE_MANIFEST_DIR.glob("*.json")):
+        with path.open("r") as f:
+            manifests.append((path, json.load(f)))
+    if not manifests:
+        raise ValueError(f"no fixture manifests found in {FIXTURE_MANIFEST_DIR}")
+    return tuple(manifests)
 
 
 @lru_cache(maxsize=1)
 def _load_fixture_file_paths() -> dict[str, Path]:
-    with (CD / "fixtures" / "feature-presence.json").open("r") as f:
-        data = json.load(f)
-    return {entry["key"]: CD / entry["path"] for entry in data["files"]}
+    return {key: file.path for key, file in load_feature_fixture_files().items()}
 
 
 def get_fixture_file_path(key: str) -> Path:
@@ -143,27 +294,218 @@ def get_fixture_file_path(key: str) -> Path:
     return paths[key]
 
 
-def apply_backend_marks(backend: str, sample_key: str, feature: Feature):
-    """Apply skip/xfail marks from fixtures for a specific backend.
-
-    Args:
-        backend: backend name matching marks in fixtures (e.g. "idalib", "freeze")
-        sample_key: the file key from fixtures (e.g. "mimikatz", "pma12-04")
-        feature: the parsed Feature object to match against
+@lru_cache(maxsize=1)
+def load_feature_fixture_files() -> dict[str, FixtureFile]:
     """
-    for (mk, _ml, mf), marks in FEATURE_MARKS.items():
-        if mk != sample_key:
+    load the combined `files` tables from `tests/fixtures/features/*.json`.
+
+    file entries may include a `tags` list that will be inherited
+    by feature fixtures that reference the file.
+    """
+    files: dict[str, FixtureFile] = {}
+    file_sources: dict[str, Path] = {}
+    for manifest_path, data in _load_feature_fixture_manifests():
+        for entry in data["files"]:
+            key = entry["key"]
+            if key in files:
+                raise ValueError(
+                    f"duplicate fixture file key {key!r} in {file_sources[key]} and {manifest_path}"
+                )
+
+            tags = frozenset(entry.get("tags", []))
+            unknown = tags - KNOWN_FIXTURE_TAGS
+            if unknown:
+                raise ValueError(
+                    f"unknown fixture tag(s) on file {key!r} in {manifest_path}: {sorted(unknown)}"
+                )
+            files[key] = FixtureFile(
+                key=key,
+                path=CD / entry["path"],
+                tags=tags,
+            )
+            file_sources[key] = manifest_path
+    return files
+
+
+@lru_cache(maxsize=1)
+def load_feature_fixtures() -> tuple[FeatureFixture, ...]:
+    """
+    load the full list of feature fixtures from `tests/fixtures/features/*.json`.
+
+    merges file-level tags into feature-level tags, validates tags against
+    the known registry, parses the statement (including `count(...)`), and
+    defaults `expected` to True.
+    """
+    files = load_feature_fixture_files()
+    fixtures_: list[FeatureFixture] = []
+    for manifest_path, data in _load_feature_fixture_manifests():
+        for entry in data["features"]:
+            key = entry["file"]
+            if key not in files:
+                raise ValueError(
+                    f"unknown fixture file key referenced by feature in {manifest_path}: {key!r}"
+                )
+            file = files[key]
+
+            feature_str: str = entry["feature"]
+            feature_tags = frozenset(entry.get("tags", []))
+            merged_tags = file.tags | feature_tags
+            unknown = merged_tags - KNOWN_FIXTURE_TAGS
+            if unknown:
+                raise ValueError(
+                    f"unknown fixture tag(s) on feature {feature_str!r} for file {key!r} in {manifest_path}: {sorted(unknown)}"
+                )
+
+            location = entry["location"]
+            statement = parse_feature_string(feature_str)
+            scope_kind = get_scope_kind(location)
+            feature_type_tag = get_feature_type_tag(feature_str)
+            # scope-kind and feature-type tags are auto-derived so that
+            # backend policies can include/exclude scopes and feature types
+            # purely via `include_tags`/`exclude_tags`. they're drawn from
+            # the known-tag registry so no re-validation is needed here.
+            merged_tags = merged_tags | {scope_kind, feature_type_tag}
+            expected = entry.get("expected", True)
+            marks = tuple(
+                FixtureMark(backend=m["backend"], mark=m["mark"], reason=m["reason"])
+                for m in entry.get("marks", [])
+            )
+
+            fixtures_.append(
+                FeatureFixture(
+                    sample_key=key,
+                    sample_path=file.path,
+                    location=location,
+                    scope_kind=scope_kind,
+                    statement=statement,
+                    expected=expected,
+                    tags=merged_tags,
+                    marks=marks,
+                    explanation=entry.get("explanation"),
+                    comment=entry.get("comment"),
+                )
+            )
+
+    fixtures_.sort(key=lambda f: (f.sample_key, f.location))
+    return tuple(fixtures_)
+
+
+@dataclass(frozen=True)
+class FixtureSelectionSummary:
+    total: int
+    selected: int
+    excluded: int
+    excluded_by_tag: dict[str, int]
+
+
+def _fixture_is_included(policy: BackendFeaturePolicy, fixture: FeatureFixture) -> bool:
+    """decide whether a fixture is selected by a policy."""
+    if policy.include_tags and not (fixture.tags & policy.include_tags):
+        return False
+    if fixture.tags & policy.exclude_tags:
+        return False
+    return True
+
+
+def select_feature_fixtures(policy: BackendFeaturePolicy) -> list[FeatureFixture]:
+    """
+    select fixtures matching a backend policy.
+
+    rules (applied in order):
+      1. start from all fixtures
+      2. if `include_tags` is non-empty, keep fixtures whose tags intersect it
+      3. drop fixtures whose tags intersect `exclude_tags`
+
+    scope kinds and feature types are exposed as auto-derived tags, so
+    a policy can restrict scope or feature type via `exclude_tags` too.
+    """
+    return [f for f in load_feature_fixtures() if _fixture_is_included(policy, f)]
+
+
+def summarize_feature_selection(
+    policy: BackendFeaturePolicy,
+) -> FixtureSelectionSummary:
+    """
+    summarize the effect of a policy's fixture selection.
+
+    useful for debug output and maintenance scripts.
+    """
+    all_fixtures = load_feature_fixtures()
+    excluded_by_tag: dict[str, int] = collections.defaultdict(int)
+    selected = 0
+    for fixture in all_fixtures:
+        if _fixture_is_included(policy, fixture):
+            selected += 1
             continue
-        if parse_feature_string(mf) != feature:
-            continue
-        for m in marks:
-            if m["backend"] != backend:
+        for tag in sorted(fixture.tags):
+            excluded_by_tag[tag] += 1
+    return FixtureSelectionSummary(
+        total=len(all_fixtures),
+        selected=selected,
+        excluded=len(all_fixtures) - selected,
+        excluded_by_tag=dict(excluded_by_tag),
+    )
+
+
+def _fixture_test_id(fixture: FeatureFixture) -> str:
+    """
+    build a readable pytest parameter id for a fixture.
+
+    mirrors the legacy `make_test_id` shape: sample-location-statement-expected.
+    """
+    return "-".join(
+        [
+            fixture.sample_key,
+            fixture.location,
+            str(fixture.statement),
+            str(fixture.expected),
+        ]
+    )
+
+
+def parametrize_backend_feature_fixtures(policy: BackendFeaturePolicy):
+    """
+    build a pytest parametrize decorator for a backend's selected fixtures.
+
+    applies JSON marks matching `policy.name` to the parameter set, so
+    backend-specific skip/xfail behavior stays in the JSON data file.
+    """
+    selected = select_feature_fixtures(policy)
+    params = []
+    for fixture in selected:
+        marks = []
+        for mark in fixture.marks:
+            if mark.backend != policy.name:
                 continue
-            if m["mark"] == "skip":
-                pytest.skip(m["reason"])
-            elif m["mark"] == "xfail":
-                pytest.xfail(m["reason"])
-        return
+            if mark.mark == "skip":
+                marks.append(pytest.mark.skip(reason=mark.reason))
+            elif mark.mark == "xfail":
+                marks.append(pytest.mark.xfail(reason=mark.reason))
+            else:
+                raise ValueError(
+                    f"unknown mark {mark.mark!r} for backend {policy.name!r}"
+                )
+        params.append(pytest.param(fixture, marks=marks, id=_fixture_test_id(fixture)))
+    return pytest.mark.parametrize("feature_fixture", params)
+
+
+def run_feature_fixture(policy: BackendFeaturePolicy, fixture: FeatureFixture) -> None:
+    """
+    generic runner that evaluates a feature fixture against a backend.
+
+    handles both plain features and `count(...)` statements via one
+    `evaluate` path, comparing the boolean result to `fixture.expected`.
+    """
+    extractor = policy.get_extractor(fixture.sample_path)
+    scope = resolve_scope(fixture.location)
+    features = scope(extractor)
+    result = fixture.statement.evaluate(features)
+    actual = bool(result)
+    if fixture.expected:
+        msg = f"{fixture.statement} should match in {fixture.location}"
+    else:
+        msg = f"{fixture.statement} should not match in {fixture.location}"
+    assert actual == fixture.expected, msg
 
 
 @contextlib.contextmanager
@@ -209,6 +551,7 @@ def xfail(condition, reason: str = ""):
 def get_viv_extractor(path: Path):
     import capa.loader
     import capa.features.extractors.viv.extractor
+    import capa.main
 
     sigpaths = [
         CD / "data" / "sigs" / "test_aulldiv.pat",
@@ -225,7 +568,9 @@ def get_viv_extractor(path: Path):
     else:
         vw = capa.loader.get_workspace(path, FORMAT_AUTO, sigpaths=sigpaths)
     vw.saveWorkspace()
-    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(vw, path, OS_AUTO)
+    extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(
+        vw, path, OS_AUTO
+    )
     fixup_viv(path, extractor)
     return extractor
 
@@ -320,8 +665,8 @@ def get_idalib_extractor(path: Path):
     if not idalib.load_idalib():
         raise RuntimeError("failed to load IDA idalib module.")
 
-    import idapro
     import ida_auto
+    import idapro
 
     import capa.features.extractors.ida.extractor
 
@@ -361,8 +706,8 @@ def fixup_idalib(path: Path, extractor):
     """
     IDA fixups to overcome differences between backends
     """
-    import idaapi
     import ida_funcs
+    import idaapi
 
     def remove_library_id_flag(fva):
         f = idaapi.get_func(fva)
@@ -380,8 +725,8 @@ def fixup_idalib(path: Path, extractor):
 
 @lru_cache(maxsize=1)
 def get_cape_extractor(path):
-    from capa.helpers import load_json_from_path
     from capa.features.extractors.cape.extractor import CapeExtractor
+    from capa.helpers import load_json_from_path
 
     report = load_json_from_path(path)
 
@@ -390,8 +735,8 @@ def get_cape_extractor(path):
 
 @lru_cache(maxsize=1)
 def get_drakvuf_extractor(path):
-    from capa.helpers import load_jsonl_from_path
     from capa.features.extractors.drakvuf.extractor import DrakvufExtractor
+    from capa.helpers import load_jsonl_from_path
 
     report = load_jsonl_from_path(path)
 
@@ -447,10 +792,14 @@ def get_binexport_extractor(path):
 
     be2 = capa.features.extractors.binexport2.get_binexport2(path)
     search_paths = [CD / "data", CD / "data" / "aarch64"]
-    path = capa.features.extractors.binexport2.get_sample_from_binexport2(path, be2, search_paths)
+    path = capa.features.extractors.binexport2.get_sample_from_binexport2(
+        path, be2, search_paths
+    )
     buf = path.read_bytes()
 
-    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(be2, buf)
+    return capa.features.extractors.binexport2.extractor.BinExport2FeatureExtractor(
+        be2, buf
+    )
 
 
 def extract_global_features(extractor):
@@ -533,6 +882,13 @@ def extract_instruction_features(extractor, fh, bbh, ih) -> dict[Feature, set[Ad
 
 # note: to reduce the testing time it's recommended to reuse already existing test samples, if possible
 def get_data_path_by_name(name) -> Path:
+    # prefer the fixture manifest registry; fall back to the legacy hard-coded
+    # branches below for any keys not yet migrated.
+    lookup_key = name[:-3] if name.endswith("...") else name
+    json_paths = _load_fixture_file_paths()
+    if lookup_key in json_paths:
+        return json_paths[lookup_key]
+
     if name == "mimikatz":
         return CD / "data" / "mimikatz.exe_"
     elif name == "kernel32":
@@ -556,7 +912,11 @@ def get_data_path_by_name(name) -> Path:
     elif name == "al-khaser x64":
         return CD / "data" / "al-khaser_x64.exe_"
     elif name.startswith("39c05"):
-        return CD / "data" / "39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_"
+        return (
+            CD
+            / "data"
+            / "39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_"
+        )
     elif name.startswith("499c2"):
         return CD / "data" / "499c2a85f6e8142c3f48d4251c9c7cd6.raw32"
     elif name.startswith("9324d"):
@@ -580,7 +940,11 @@ def get_data_path_by_name(name) -> Path:
     elif name.startswith("77329"):
         return CD / "data" / "773290480d5445f11d3dc1b800728966.exe_"
     elif name.startswith("3b13b"):
-        return CD / "data" / "3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_"
+        return (
+            CD
+            / "data"
+            / "3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_"
+        )
     elif name == "7351f.elf":
         return CD / "data" / "7351f8a40c5450557b24622417fc478d.elf_"
     elif name == "055da8e6.elf":
@@ -596,25 +960,54 @@ def get_data_path_by_name(name) -> Path:
     elif name.startswith("b9f5b"):
         return CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_"
     elif name.startswith("mixed-mode-64"):
-        return DNFILE_TESTFILES / "mixed-mode" / "ModuleCode" / "bin" / "ModuleCode_amd64.exe"
+        return (
+            DNFILE_TESTFILES
+            / "mixed-mode"
+            / "ModuleCode"
+            / "bin"
+            / "ModuleCode_amd64.exe"
+        )
     elif name.startswith("hello-world"):
         return DNFILE_TESTFILES / "hello-world" / "hello-world.exe"
     elif name.startswith("_1c444"):
         return DOTNET_DIR / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_"
     elif name.startswith("_387f15"):
-        return DOTNET_DIR / "387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_"
+        return (
+            DOTNET_DIR
+            / "387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_"
+        )
     elif name.startswith("_692f"):
         return DOTNET_DIR / "692f7fd6d198e804d6af98eb9e390d61.exe_"
     elif name.startswith("_0953c"):
-        return CD / "data" / "0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_"
+        return (
+            CD
+            / "data"
+            / "0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_"
+        )
     elif name.startswith("_039a6"):
-        return CD / "data" / "039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_"
+        return (
+            CD
+            / "data"
+            / "039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_"
+        )
     elif name.startswith("b5f052"):
-        return CD / "data" / "b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_"
+        return (
+            CD
+            / "data"
+            / "b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_"
+        )
     elif name.startswith("bf7a9c"):
-        return CD / "data" / "bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_"
+        return (
+            CD
+            / "data"
+            / "bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_"
+        )
     elif name.startswith("294b8d"):
-        return CD / "data" / "294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
+        return (
+            CD
+            / "data"
+            / "294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
+        )
     elif name.startswith("2bf18d"):
         return CD / "data" / "2bf18d0403677378adad9001b1243211.elf_"
     elif name.startswith("2d3edc"):
@@ -670,11 +1063,23 @@ def get_data_path_by_name(name) -> Path:
             / "eb12873c0ce3e9ea109c2a447956cbd10ca2c3e86936e526b2c6e28764999f21_min_archive.zip"
         )
     elif name.startswith("ea2876"):
-        return CD / "data" / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
+        return (
+            CD
+            / "data"
+            / "ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
+        )
     elif name.startswith("1038a2"):
-        return CD / "data" / "1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_"
+        return (
+            CD
+            / "data"
+            / "1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_"
+        )
     elif name.startswith("3da7c"):
-        return CD / "data" / "3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_"
+        return (
+            CD
+            / "data"
+            / "3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_"
+        )
     elif name.startswith("nested_typedef"):
         return CD / "data" / "dotnet" / "dd9098ff91717f4906afe9dafdfa2f52.exe_"
     elif name.startswith("nested_typeref"):
@@ -820,7 +1225,9 @@ def get_basic_block(extractor, fh: FunctionHandle, va: int) -> BBHandle:
     raise ValueError("basic block not found")
 
 
-def get_instruction(extractor, fh: FunctionHandle, bbh: BBHandle, va: int) -> InsnHandle:
+def get_instruction(
+    extractor, fh: FunctionHandle, bbh: BBHandle, va: int
+) -> InsnHandle:
     for ih in extractor.get_instructions(fh, bbh):
         if isinstance(extractor, DnfileFeatureExtractor):
             addr = ih.inner.offset
@@ -980,65 +1387,28 @@ def parametrize(params, values, **kwargs):
     return pytest.mark.parametrize(params, values, ids=ids, **kwargs)
 
 
-(
-    FEATURE_PRESENCE_TESTS,
-    FEATURE_SYMTAB_FUNC_TESTS,
-    FEATURE_COUNT_TESTS,
-    FEATURE_COUNT_TESTS_GHIDRA,
-    FEATURE_PRESENCE_TESTS_DOTNET,
-    FEATURE_COUNT_TESTS_DOTNET,
-) = _load_feature_tests()
+# legacy tuple-of-tuples lists still needed by `test_binexport_features.py`,
+# which rewrites a mimikatz sample path to its `.ghidra.BinExport` counterpart
+# at test time.
+#
+# built from the new `load_feature_fixtures()` so the JSON manifests remain the
+# single source of truth for fixture data.
+FEATURE_PRESENCE_TESTS: list[tuple] = sorted(
+    (
+        (f.sample_key, f.location, f.statement, f.expected)
+        for f in load_feature_fixtures()
+        if not isinstance(f.statement, ceng.Range)
+        and not (f.tags & frozenset({"dotnet", "symtab"}))
+    ),
+    key=lambda t: (t[0], t[1]),
+)
 
-
-FEATURE_PRESENCE_TESTS_IDA = [
-    # file/imports
-    # IDA can recover more names of APIs imported by ordinal
-    ("mimikatz", "file", capa.features.file.Import("cabinet.FCIAddFile"), True),
-]
-
-FEATURE_BINJA_DATABASE_TESTS = sorted(
-    [
-        # insn/regex
-        (
-            "pma16-01_binja_db",
-            "function=0x4021B0",
-            capa.features.common.Regex("HTTP/1.0"),
-            True,
-        ),
-        (
-            "pma16-01_binja_db",
-            "function=0x402F40",
-            capa.features.common.Regex("www.practicalmalwareanalysis.com"),
-            True,
-        ),
-        (
-            "pma16-01_binja_db",
-            "function=0x402F40",
-            capa.features.common.Substring("practicalmalwareanalysis.com"),
-            True,
-        ),
-        (
-            "pma16-01_binja_db",
-            "file",
-            capa.features.file.FunctionName("__aulldiv"),
-            True,
-        ),
-        # os & format & arch
-        ("pma16-01_binja_db", "file", OS(OS_WINDOWS), True),
-        ("pma16-01_binja_db", "file", OS(OS_LINUX), False),
-        ("pma16-01_binja_db", "function=0x404356", OS(OS_WINDOWS), True),
-        ("pma16-01_binja_db", "function=0x404356,bb=0x4043B9", OS(OS_WINDOWS), True),
-        ("pma16-01_binja_db", "file", Arch(ARCH_I386), True),
-        ("pma16-01_binja_db", "file", Arch(ARCH_AMD64), False),
-        ("pma16-01_binja_db", "function=0x404356", Arch(ARCH_I386), True),
-        ("pma16-01_binja_db", "function=0x404356,bb=0x4043B9", Arch(ARCH_I386), True),
-        ("pma16-01_binja_db", "file", Format(FORMAT_PE), True),
-        ("pma16-01_binja_db", "file", Format(FORMAT_ELF), False),
-        # format is also a global feature
-        ("pma16-01_binja_db", "function=0x404356", Format(FORMAT_PE), True),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
+FEATURE_COUNT_TESTS_GHIDRA: list[tuple] = sorted(
+    (
+        (f.sample_key, f.location, f.statement.child, f.statement.min)
+        for f in load_feature_fixtures()
+        if isinstance(f.statement, ceng.Range) and "ghidra" in f.tags
+    ),
     key=lambda t: (t[0], t[1]),
 )
 
@@ -1202,20 +1572,26 @@ def get_result_doc(path: Path):
 @pytest.fixture
 def pma0101_rd():
     # python -m capa.main tests/data/Practical\ Malware\ Analysis\ Lab\ 01-01.dll_ --json > tests/data/rd/Practical\ Malware\ Analysis\ Lab\ 01-01.dll_.json
-    return get_result_doc(CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json")
+    return get_result_doc(
+        CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
+    )
 
 
 @pytest.fixture
 def dotnet_1c444e_rd():
     # .NET sample
     # python -m capa.main tests/data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_ --json > tests/data/rd/1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json
-    return get_result_doc(CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json")
+    return get_result_doc(
+        CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json"
+    )
 
 
 @pytest.fixture
 def a3f3bbc_rd():
     # python -m capa.main tests/data/3f3bbcf8fd90bdcdcdc5494314ed4225.exe_ --json > tests/data/rd/3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json
-    return get_result_doc(CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json")
+    return get_result_doc(
+        CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json"
+    )
 
 
 @pytest.fixture
@@ -1233,7 +1609,9 @@ def al_khaserx64_rd():
 @pytest.fixture
 def a076114_rd():
     # python -m capa.main tests/data/0761142efbda6c4b1e801223de723578.dll_ --json > tests/data/rd/0761142efbda6c4b1e801223de723578.dll_.json
-    return get_result_doc(CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json")
+    return get_result_doc(
+        CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json"
+    )
 
 
 @pytest.fixture
@@ -1241,5 +1619,8 @@ def dynamic_a0000a6_rd():
     # python -m capa.main tests/data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json --json > tests/data/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json
     # gzip tests/data/rd/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json
     return get_result_doc(
-        CD / "data" / "rd" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+        CD
+        / "data"
+        / "rd"
+        / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
     )

--- a/tests/fixtures/feature-presence.json
+++ b/tests/fixtures/feature-presence.json
@@ -1,0 +1,1882 @@
+{
+  "files": [
+    {
+      "key": "mimikatz",
+      "path": "data/mimikatz.exe_"
+    },
+    {
+      "key": "kernel32",
+      "path": "data/kernel32.dll_"
+    },
+    {
+      "key": "kernel32-64",
+      "path": "data/kernel32-64.dll_"
+    },
+    {
+      "key": "pma12-04",
+      "path": "data/Practical Malware Analysis Lab 12-04.exe_"
+    },
+    {
+      "key": "pma16-01",
+      "path": "data/Practical Malware Analysis Lab 16-01.exe_"
+    },
+    {
+      "key": "7351f.elf",
+      "path": "data/7351f8a40c5450557b24622417fc478d.elf_"
+    },
+    {
+      "key": "055da8e6.elf",
+      "path": "data/055da8e6ccfe5a9380231ea04b850e18.elf_"
+    },
+    {
+      "key": "bb38149.elf",
+      "path": "data/bb38149ff4b5c95722b83f24ca27a42b.elf_"
+    },
+    {
+      "key": "al-khaser x64",
+      "path": "data/al-khaser_x64.exe_"
+    },
+    {
+      "key": "64d9f",
+      "path": "data/64d9f7d96b99467f36e22fada623c3bb.dll_"
+    },
+    {
+      "key": "79abd",
+      "path": "data/79abd17391adc6251ecdc58d13d76baf.dll_"
+    },
+    {
+      "key": "946a9",
+      "path": "data/946a99f36a46d335dec080d9a4371940.dll_"
+    },
+    {
+      "key": "773290",
+      "path": "data/773290480d5445f11d3dc1b800728966.exe_"
+    },
+    {
+      "key": "294b8d",
+      "path": "data/294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
+    },
+    {
+      "key": "a1982",
+      "path": "data/a198216798ca38f280dc413f8c57f2c2.exe_"
+    },
+    {
+      "key": "c91887",
+      "path": "data/c91887d861d9bd4a5872249b641bc9f9.exe_"
+    },
+    {
+      "key": "2bf18d",
+      "path": "data/2bf18d0403677378adad9001b1243211.elf_"
+    },
+    {
+      "key": "2d3edc",
+      "path": "data/2d3edc218a90f03089cc01715a9f047f.exe_"
+    },
+    {
+      "key": "ea2876",
+      "path": "data/ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
+    },
+    {
+      "key": "pma01-01.frz",
+      "path": "fixtures/freeze/Practical Malware Analysis Lab 01-01.dll_.frz"
+    },
+    {
+      "key": "009c2377.frz",
+      "path": "fixtures/freeze/009c2377b67997b0da1579f4bbc822c1.exe_.frz"
+    },
+    {
+      "key": "055da8e6.frz",
+      "path": "fixtures/freeze/055da8e6ccfe5a9380231ea04b850e18.elf_.frz"
+    },
+    {
+      "key": "034b7231.frz",
+      "path": "fixtures/freeze/034b7231a49387604e81a5a5d2fe7e08f6982c418a28b719d2faace3c312ebb5.exe_.frz"
+    },
+
+    {
+      "key": "b9f5b",
+      "path": "data/b9f5bd514485fb06da39beff051b9fdc.exe_"
+    },
+    {
+      "key": "mixed-mode-64",
+      "path": "data/dotnet/dnfile-testfiles/mixed-mode/ModuleCode/bin/ModuleCode_amd64.exe"
+    },
+    {
+      "key": "hello-world",
+      "path": "data/dotnet/dnfile-testfiles/hello-world/hello-world.exe"
+    },
+    {
+      "key": "_1c444",
+      "path": "data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_"
+    },
+    {
+      "key": "_692f",
+      "path": "data/dotnet/692f7fd6d198e804d6af98eb9e390d61.exe_"
+    },
+    {
+      "key": "_0953c",
+      "path": "data/0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_"
+    },
+    {
+      "key": "_039a6",
+      "path": "data/039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_"
+    },
+    {
+      "key": "_387f15",
+      "path": "data/dotnet/387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_"
+    },
+    {
+      "key": "nested_typedef",
+      "path": "data/dotnet/dd9098ff91717f4906afe9dafdfa2f52.exe_"
+    },
+    {
+      "key": "nested_typeref",
+      "path": "data/dotnet/2c7d60f77812607dec5085973ff76cea.dll_"
+    }
+  ],
+  "features": [
+    {
+      "file": "pma12-04",
+      "location": "file",
+      "feature": "characteristic: embedded pe",
+      "expected": true,
+      "explanation": "embedded PE file in resource section",
+      "marks": [
+        {
+          "backend": "idalib",
+          "mark": "skip",
+          "reason": "Embedded PE is in .rsrc section at file offset 0x4060, which IDA doesn't load by default"
+        },
+        {
+          "backend": "freeze",
+          "mark": "skip",
+          "reason": "Embedded PE is in .rsrc section at file offset 0x4060, which freeze doesn't handle correctly"
+        }
+      ]
+    },
+    {
+      "file": "2d3edc",
+      "location": "file",
+      "feature": "characteristic: embedded pe",
+      "expected": true,
+      "explanation": "embedded PE file at file scope using file offset addresses",
+      "marks": [
+        {
+          "backend": "freeze",
+          "mark": "skip",
+          "reason": "Python capa has bug extracting embedded PE files at absolute offsets"
+        }
+      ],
+      "comment": "Embedded PE at file offset 0x7FB0. Note: vivisect freeze has 0x4091b0 but that's a virtual address mislabeled as file offset."
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "string: SCardControl",
+      "expected": true,
+      "explanation": "basic UTF-16LE string"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "string: ACR  > ",
+      "expected": true,
+      "explanation": "UTF-16LE encoded strings with unusual characters and trailing spaces"
+    },
+    {
+      "file": "pma12-04",
+      "location": "file",
+      "feature": "string: winlogon.exe",
+      "expected": true,
+      "explanation": "basic ASCII string"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "string: nope",
+      "expected": false,
+      "explanation": "non-existant string"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "section: .text",
+      "expected": true,
+      "explanation": "basic section name"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "section: .nope",
+      "expected": false,
+      "explanation": "non-existant section"
+    },
+    {
+      "file": "kernel32",
+      "location": "file",
+      "feature": "export: BaseThreadInitThunk",
+      "expected": true,
+      "explanation": "basic export name"
+    },
+    {
+      "file": "kernel32",
+      "location": "file",
+      "feature": "export: nope",
+      "expected": false,
+      "explanation": "non-existant export"
+    },
+    {
+      "file": "ea2876",
+      "location": "file",
+      "feature": "export: vresion.GetFileVersionInfoA",
+      "expected": true,
+      "explanation": "forwarded export"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: advapi32.CryptSetHashParam",
+      "expected": true,
+      "explanation": "import with DLL prefix"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: CryptSetHashParam",
+      "expected": true,
+      "explanation": "import with no DLL prefix"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: cabinet.#11",
+      "expected": true,
+      "explanation": "import by ordinal"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: #11",
+      "expected": false,
+      "explanation": "non-existant ordinal import"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: #nope",
+      "expected": false,
+      "explanation": "non-existant ordinal import"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "import: nope",
+      "expected": false,
+      "explanation": "non-existant import"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401517",
+      "feature": "characteristic: loop",
+      "expected": true,
+      "explanation": "loop"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "characteristic: loop",
+      "expected": false,
+      "explanation": "non-existant loop"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x402EC4",
+      "feature": "characteristic: tight loop",
+      "expected": true,
+      "explanation": "tight-loop"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "characteristic: tight loop",
+      "expected": false,
+      "explanation": "non-existant tight-loop"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x402EC4,bb=0x402F8E",
+      "feature": "characteristic: tight loop",
+      "expected": true,
+      "explanation": "tight-loop at basic block scope"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000,bb=0x401000",
+      "feature": "characteristic: tight loop",
+      "expected": false,
+      "explanation": "non-existant tight-loop at basic block scope"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: stack string",
+      "expected": true,
+      "explanation": "stack string (but capa doesn't extract it as a string yet)"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "characteristic: stack string",
+      "expected": false,
+      "explanation": "non-existant stack string"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "mnemonic: push",
+      "explanation": "basic mnemonic",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "mnemonic: in",
+      "expected": false,
+      "explanation": "non-existant mnemonic"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "number: 0xFF",
+      "expected": true,
+      "explanation": "number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "operand[1].number: 0xFF",
+      "expected": true,
+      "explanation": "mov eax, 0FFh; instruction operand number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "operand[0].number: 0xFF",
+      "expected": false,
+      "explanation": "mov eax, 0FFh; non-existant instruction operand number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x4010B0,insn=0x4010B4",
+      "feature": "operand[0].offset: 4",
+      "expected": true,
+      "explanation": "cmp [esi+4], ebx; instruction operand offset"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x4010B0,insn=0x4010B4",
+      "feature": "operand[1].offset: 4",
+      "expected": false,
+      "explanation": "cmp [esi+4], ebx; non-existant instruction operand offset"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "number: 0xFF",
+      "expected": true,
+      "explanation": "small number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "number: 0x3136B0",
+      "expected": true,
+      "explanation": "large number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "number: 0x0",
+      "expected": true,
+      "explanation": "zero number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "number: 0xC",
+      "expected": false,
+      "explanation": "non-existant number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401553",
+      "feature": "number: 0xFFFFFFFF",
+      "expected": true,
+      "explanation": "max u32 number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x43e543",
+      "feature": "number: 0xFFFFFFF0",
+      "expected": true,
+      "explanation": "large u32 number"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x0",
+      "explanation": "cmp [esi], ebx; zero offset",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x4",
+      "explanation": "cmp [esi+4], ebx; simple offset",
+      "expected": true
+    },
+    {
+      "file": "64d9f",
+      "location": "function=0x10001510,bb=0x100015B0",
+      "feature": "offset: 0x4000",
+      "expected": true,
+      "explanation": "regression test for issue #276"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x8",
+      "expected": false,
+      "explanation": "no instruction in the function references [reg+8]"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4011FB",
+      "feature": "offset: -0x1",
+      "expected": true,
+      "explanation": "movzx ecx, [eax-1]; negative offset"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4011FB",
+      "feature": "offset: -0x2",
+      "expected": true,
+      "explanation": "cmp [eax-2], cx; negative offset -2"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4011FB",
+      "feature": "number: -0x2",
+      "expected": false,
+      "explanation": "cmp [eax-2], cx; negative offset shouldn't emit a number too"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401D64,bb=0x401D73,insn=0x401D85",
+      "feature": "offset: 0x80000000",
+      "expected": false,
+      "explanation": "add ecx, 80000000h; too-large immediate should not be considered an offset"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401CC7,bb=0x401CDE,insn=0x401CF6",
+      "feature": "offset: 0x10",
+      "expected": false,
+      "explanation": "add esp, 10h; stack-relative ADD should not be considered an offset"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x402203,bb=0x402221,insn=0x40223C",
+      "feature": "offset: 0x4",
+      "expected": true,
+      "explanation": "add eax, 4; non-stack register ADD should emit an offset feature, treating eax as a pointer"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x471EAB,bb=0x471ED8,insn=0x471EE6",
+      "feature": "number: 0x4",
+      "expected": false,
+      "explanation": "lea ebx, [ecx+eax*4]; should not emit Number feature for the scale"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x47153B,bb=0x4717AB,insn=0x4717B1",
+      "feature": "number: -0x30",
+      "expected": false,
+      "explanation": "lea ecx, [ecx+esi-30h]; should not emit Number feature for the displacement"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401873,bb=0x4018B2,insn=0x4018C0",
+      "feature": "number: 0x2",
+      "expected": true,
+      "explanation": "lea ecx, [ebx+2]; should emit Number feature, treating ebx as zero"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x403BAC",
+      "feature": "api: CryptAcquireContextW",
+      "expected": true,
+      "explanation": "basic API feature with trailing W"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x403BAC",
+      "feature": "api: CryptAcquireContext",
+      "expected": true,
+      "explanation": "basic API feature with stripped W"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x403BAC",
+      "feature": "api: Nope",
+      "expected": false,
+      "explanation": "non-existent API"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "api: LsaQueryInformationPolicy",
+      "expected": true
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x180001010",
+      "feature": "api: RtlVirtualUnwind",
+      "expected": true,
+      "marks": [
+        {
+          "backend": "idalib",
+          "mark": "skip",
+          "reason": "IDA identifies 0x180001010 as lib function and skips it"
+        }
+      ]
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x1800202B0",
+      "feature": "api: RtlCaptureContext",
+      "expected": true,
+      "explanation": "API called via thunk",
+      "marks": [
+        {
+          "backend": "idalib",
+          "mark": "skip",
+          "reason": "IDA identifies 0x1800202B0 as lib function _report_gsfailure"
+        },
+        {
+          "backend": "freeze",
+          "mark": "skip",
+          "reason": "IDA skipping lib functions prevents freeze from detecting this API"
+        }
+      ]
+    },
+    {
+      "file": "al-khaser x64",
+      "location": "function=0x14004B4F0",
+      "feature": "api: __vcrt_GetModuleHandle",
+      "expected": true,
+      "explanation": "API called via nested thunks",
+      "marks": [
+        {
+          "backend": "idalib",
+          "mark": "skip",
+          "reason": "IDA identifies this as lib function GetPdbDll"
+        },
+        {
+          "backend": "freeze",
+          "mark": "skip",
+          "reason": "IDA skipping lib functions prevents freeze from detecting this API"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40B3C6",
+      "feature": "api: LocalFree",
+      "expected": true,
+      "explanation": "tail call to API via jmp"
+    },
+    {
+      "file": "c91887",
+      "location": "function=0x40156F",
+      "feature": "api: CloseClipboard",
+      "expected": true,
+      "explanation": "tail call to API via jmp"
+    },
+    {
+      "file": "c91887",
+      "location": "function=0x401A77",
+      "feature": "api: CreatePipe",
+      "expected": true,
+      "explanation": "API is present"
+    },
+    {
+      "file": "c91887",
+      "location": "function=0x401A77",
+      "feature": "api: kernel32.CreatePipe",
+      "expected": true,
+      "explanation": "API is present, and DLL name is ignored"
+    },
+    {
+      "file": "c91887",
+      "location": "function=0x401A77",
+      "feature": "api: CreatePipe",
+      "expected": true,
+      "explanation": "API resolved from call to GetProcAddress"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "string: SCardControl",
+      "expected": true,
+      "explanation": "basic string"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "string: ACR  > ",
+      "expected": true,
+      "explanation": "basic string with trailing whitespace"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "string: nope",
+      "expected": false,
+      "explanation": "basic string not present"
+    },
+    {
+      "file": "773290",
+      "location": "function=0x140001140",
+      "feature": "string: %s:\\\\OfficePackagesForWDAG",
+      "expected": true,
+      "explanation": "string with escaping characters"
+    },
+    {
+      "file": "294b8d",
+      "location": "function=0x404970,bb=0x404970,insn=0x40499F",
+      "feature": "string: \r\n\u0000:ht",
+      "expected": false,
+      "explanation": "regression test for issue #1271: should not extract overlapping string spanning a NUL byte"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x4021B0",
+      "feature": "substring: HTTP/1.0",
+      "expected": true,
+      "explanation": "basic substring"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x402F40",
+      "feature": "string: /PRACTICALmalwareANALYSIS/i",
+      "expected": true,
+      "explanation": "case-insensitive regex"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x402F40",
+      "feature": "string: /www.*/",
+      "expected": true,
+      "explanation": "simple regex prefix match"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x402F40",
+      "feature": "substring: practicalmalwareanalysis.com",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x44EDEF",
+      "feature": "string: INPUTEVENT",
+      "expected": true,
+      "explanation": "string referenced via a pointer"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x46D6CE",
+      "feature": "string: (null)",
+      "expected": true,
+      "explanation": "string referenced via direct memory reference"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401517",
+      "feature": "bytes: CA 3B 0E 00 00 00 F8 AF 47",
+      "expected": true,
+      "explanation": "basic bytes"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x404414",
+      "feature": "bytes: 01 80 00 00 40 EA 47 00",
+      "expected": true,
+      "explanation": "basic bytes, which are a pointer"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "bytes: 53 00 43 00 61 00 72 00 64 00 43 00 6F 00 6E 00 74 00 72 00 6F 00 6C 00",
+      "expected": false,
+      "explanation": "should not extract bytes feature for an obvious string (here: UTF-16LE 'SCardControl')"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "bytes: FD FF 59 F6 47",
+      "expected": false,
+      "explanation": "push offset aAcsAcr1220 ('ACS...') where ACS == 41 00 43 00 happens to be a valid pointer to the middle of an instruction; should not be misinterpreted as bytes feature"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x44570F",
+      "feature": "bytes: FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF",
+      "expected": false,
+      "explanation": "regression test for issue #409: should not extract bytes feature from byte sequences read from invalid memory"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x44EDEF",
+      "feature": "bytes: 49 00 4E 00 50 00 55 00 54 00 45 00 56 00 45 00 4E 00 54 00",
+      "expected": false,
+      "explanation": "should not extract bytes feature when instruction references it as a pointer to string bytes (here: UTF-16LE 'INPUTEVENT')"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x410DFC",
+      "feature": "characteristic: nzxor",
+      "expected": true,
+      "explanation": "should extract nzxor characteristic, including from xorps SSE instructions"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "characteristic: nzxor",
+      "expected": false,
+      "explanation": "non-existant nzxor"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x46D534",
+      "feature": "characteristic: nzxor",
+      "expected": false,
+      "explanation": "should not extract nzxor characteristic for security cookie xors"
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x1800017D0",
+      "feature": "characteristic: peb access",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: peb access",
+      "expected": false
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x180001068",
+      "feature": "characteristic: gs access",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: gs access",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x410DFC,bb=0x410F05,insn=0x410F0B",
+      "feature": "characteristic: nzxor",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x410DFC,bb=0x410F05,insn=0x410F12",
+      "feature": "characteristic: nzxor",
+      "expected": true
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x1800017D0,bb=0x1800018AD,insn=0x1800018AD",
+      "feature": "characteristic: peb access",
+      "expected": true
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x180001068,bb=0x18000118D,insn=0x180001197",
+      "feature": "characteristic: gs access",
+      "expected": true
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x180001068,bb=0x180001269,insn=0x18000127F",
+      "feature": "characteristic: gs access",
+      "expected": true
+    },
+    {
+      "file": "kernel32",
+      "location": "function=0x7DD70E00,bb=0x7DD70E00,insn=0x7DD70E05",
+      "feature": "characteristic: fs access",
+      "expected": true
+    },
+    {
+      "file": "kernel32",
+      "location": "function=0x7DD70E00,bb=0x7DD70E25,insn=0x7DD70E2D",
+      "feature": "characteristic: fs access",
+      "expected": true
+    },
+    {
+      "file": "kernel32",
+      "location": "function=0x7DD70E00,bb=0x7DD70FCB,insn=0x7DD70FCB",
+      "feature": "characteristic: fs access",
+      "expected": true
+    },
+    {
+      "file": "a1982",
+      "location": "function=0x4014D0",
+      "feature": "characteristic: cross section flow",
+      "expected": true
+    },
+    {
+      "file": "kernel32-64",
+      "location": "function=0x180001068",
+      "feature": "characteristic: cross section flow",
+      "expected": false,
+      "explanation": "should not extract cross section flow characteristic for control transfers to imports"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: cross section flow",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40640e",
+      "feature": "characteristic: recursive call",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4175FF",
+      "feature": "characteristic: recursive call",
+      "expected": false,
+      "explanation": "issue #386: 0x4175FF makes indirect calls (via dword_4B821C) but never calls itself, directly or via callback"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4175FF",
+      "feature": "characteristic: indirect call",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: indirect call",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: calls from",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4702FD",
+      "feature": "characteristic: calls from",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D",
+      "feature": "characteristic: calls to",
+      "expected": true
+    },
+    {
+      "file": "ea2876",
+      "location": "file",
+      "feature": "characteristic: forwarded export",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x456BB9",
+      "feature": "characteristic: calls to",
+      "expected": false,
+      "explanation": "issue #386: 0x456BB9 is only referenced from a function-pointer table at 0x475834, never via a direct call instruction"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40105D,bb=0x401089,insn=0x40108E",
+      "feature": "characteristic: calls from",
+      "expected": true
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4175FF,bb=0x41761B,insn=0x417620",
+      "feature": "characteristic: indirect call",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "function-name: __aulldiv",
+      "expected": true,
+      "explanation": "recognize function name via FLIRT signatures"
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "os: windows",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "os: linux",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "os: windows",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x401100",
+      "feature": "os: windows",
+      "expected": true,
+      "explanation": "OS available at function scope"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x401100,bb=0x401130",
+      "feature": "os: windows",
+      "expected": true,
+      "explanation": "OS available at basic block scope"
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x401100",
+      "feature": "arch: i386",
+      "expected": true,
+      "explanation": "arch available at function scope"
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x401100,bb=0x401130",
+      "feature": "arch: i386",
+      "expected": true,
+      "explanation": "arch available at basic blockscope"
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "format: pe",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "file",
+      "feature": "format: elf",
+      "expected": false
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "format: pe",
+      "expected": true
+    },
+    {
+      "file": "pma16-01",
+      "location": "function=0x401100",
+      "feature": "format: pe",
+      "expected": true,
+      "explanation": "format available at function scope"
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "os: linux",
+      "expected": true
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "os: windows",
+      "expected": false
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "format: elf",
+      "expected": true
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "format: pe",
+      "expected": false
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": false
+    },
+    {
+      "file": "7351f.elf",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": true
+    },
+    {
+      "file": "7351f.elf",
+      "location": "function=0x408753",
+      "feature": "string: /dev/null",
+      "expected": true
+    },
+    {
+      "file": "7351f.elf",
+      "location": "function=0x408753,bb=0x408781",
+      "feature": "api: open",
+      "expected": true,
+      "explanation": "API from ELF import"
+    },
+    {
+      "file": "055da8e6.elf",
+      "location": "file",
+      "feature": "import: puts",
+      "expected": true,
+      "explanation": "ELF import promoted from elffile feature tests"
+    },
+    {
+      "file": "055da8e6.elf",
+      "location": "file",
+      "feature": "section: .text",
+      "expected": true,
+      "explanation": "ELF section promoted from primary presence fixture"
+    },
+    {
+      "file": "bb38149.elf",
+      "location": "file",
+      "feature": "import: __android_log_print",
+      "expected": true,
+      "explanation": "stripped ELF import promoted from elffile feature tests"
+    },
+    {
+      "file": "bb38149.elf",
+      "location": "file",
+      "feature": "export: Java_o_ac_a",
+      "expected": true,
+      "explanation": "stripped ELF export promoted from elffile feature tests"
+    },
+    {
+      "file": "bb38149.elf",
+      "location": "file",
+      "feature": "section: .dynamic",
+      "expected": true,
+      "explanation": "stripped ELF section promoted into the shared presence fixture"
+    },
+    {
+      "file": "79abd",
+      "location": "function=0x10002385,bb=0x10002385",
+      "feature": "characteristic: call $+5",
+      "expected": true
+    },
+    {
+      "file": "946a9",
+      "location": "function=0x10001510,bb=0x100015c0",
+      "feature": "characteristic: call $+5",
+      "expected": true
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
+      "feature": "api: __GI_connect",
+      "expected": true,
+      "explanation": "API from symbol table alternative name"
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
+      "feature": "api: connect",
+      "expected": true,
+      "explanation": "API from symbol table alternative name"
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
+      "feature": "api: __libc_connect",
+      "expected": true,
+      "explanation": "API from symbol table alternative name"
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4088a4",
+      "feature": "function-name: __GI_connect",
+      "expected": true,
+      "explanation": "function name from symbol table alternative name"
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4088a4",
+      "feature": "function-name: connect",
+      "expected": true,
+      "explanation": "function name from symbol table alternative name"
+    },
+    {
+      "file": "2bf18d",
+      "location": "function=0x4088a4",
+      "feature": "function-name: __libc_connect",
+      "expected": true,
+      "explanation": "function name from symbol table alternative name"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000,bb=0x401000",
+      "feature": "basic blocks: x",
+      "expected": true,
+      "explanation": "basic block feature emitted"
+    },
+    {
+      "file": "mimikatz",
+      "location": "file",
+      "feature": "basic blocks: 1",
+      "expected": false,
+      "explanation": "non-existant basic block feature"
+    },
+
+    {
+      "file": "mimikatz",
+      "location": "function=0x40E5C2",
+      "feature": "count(basic blocks): 7",
+      "expected": true,
+      "explanation": "7 basic blocks in function"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4702FD",
+      "feature": "count(characteristic(calls from)): 0",
+      "expected": true,
+      "explanation": "function has no calls"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40E5C2",
+      "feature": "count(characteristic(calls from)): 3",
+      "expected": true,
+      "explanation": "function has 3 calls"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x4556E5",
+      "feature": "count(characteristic(calls to)): 0",
+      "expected": true,
+      "explanation": "function has no callers"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x40B1F1",
+      "feature": "count(characteristic(calls to)): 3",
+      "expected": true,
+      "explanation": "function has 3 callers"
+    },
+
+    {
+      "file": "mimikatz",
+      "location": "function=0x4702FD",
+      "feature": "count(characteristic(calls from)): 0",
+      "expected": true,
+      "tags": ["ghidra"],
+      "explanation": "Ghidra: function has no calls"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401bf1",
+      "feature": "count(characteristic(calls to)): 2",
+      "expected": true,
+      "tags": ["ghidra"],
+      "explanation": "Ghidra: function has 2 callers"
+    },
+    {
+      "file": "mimikatz",
+      "location": "function=0x401000",
+      "feature": "count(basic blocks): 3",
+      "expected": true,
+      "tags": ["ghidra"],
+      "explanation": "Ghidra: 3 basic blocks in function"
+    },
+
+    {
+      "file": "b9f5b",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "b9f5b",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "mixed-mode-64",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "mixed-mode-64",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "mixed-mode-64",
+      "location": "file",
+      "feature": "characteristic: mixed mode",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "characteristic: mixed mode",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "b9f5b",
+      "location": "file",
+      "feature": "os: any",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "b9f5b",
+      "location": "file",
+      "feature": "format: pe",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "b9f5b",
+      "location": "file",
+      "feature": "format: dotnet",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "function-name: HelloWorld::Main",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "function-name: HelloWorld::ctor",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "function-name: HelloWorld::cctor",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "string: Hello World!",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "class: HelloWorld",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "class: System.Console",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "namespace: System.Diagnostics",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "function=0x250",
+      "feature": "string: Hello World!",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "function=0x250,bb=0x250,insn=0x252",
+      "feature": "string: Hello World!",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "function=0x250,bb=0x250,insn=0x257",
+      "feature": "class: System.Console",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "function=0x250,bb=0x250,insn=0x257",
+      "feature": "namespace: System",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "function=0x250",
+      "feature": "api: System.Console::WriteLine",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "hello-world",
+      "location": "file",
+      "feature": "import: System.Console::WriteLine",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "file",
+      "feature": "string: SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "file",
+      "feature": "string: get_IsAlive",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "file",
+      "feature": "import: gdi32.CreateCompatibleBitmap",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "file",
+      "feature": "import: CreateCompatibleBitmap",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "file",
+      "feature": "import: gdi32::CreateCompatibleBitmap",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68",
+      "feature": "api: GetWindowDC",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68",
+      "feature": "number: 0xCC0020",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600001D",
+      "feature": "characteristic: calls to",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000018",
+      "feature": "characteristic: calls to",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600001D",
+      "feature": "characteristic: calls from",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600000F",
+      "feature": "characteristic: calls from",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68",
+      "feature": "number: 0x0",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68",
+      "feature": "number: 0x1",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_692f",
+      "location": "token=0x6000004",
+      "feature": "api: System.Linq.Enumerable::First",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "generic method"
+    },
+    {
+      "file": "_692f",
+      "location": "token=0x6000004",
+      "feature": "property: System.Linq.Enumerable::First",
+      "expected": false,
+      "tags": ["dotnet"],
+      "explanation": "generic method"
+    },
+    {
+      "file": "_692f",
+      "location": "token=0x6000004",
+      "feature": "namespace: System.Linq",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "generic method"
+    },
+    {
+      "file": "_692f",
+      "location": "token=0x6000004",
+      "feature": "class: System.Linq.Enumerable",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "generic method"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000020",
+      "feature": "namespace: Reqss",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "ldftn"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000020",
+      "feature": "class: Reqss.Reqss",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "ldftn"
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F59,bb=0x1F59,insn=0x1F5B",
+      "feature": "characteristic: unmanaged call",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x2544",
+      "feature": "characteristic: unmanaged call",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000088",
+      "feature": "characteristic: unmanaged call",
+      "expected": false,
+      "tags": ["dotnet"],
+      "explanation": "same as above but using token instead of function"
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
+      "feature": "api: System.Drawing.Image::FromHbitmap",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
+      "feature": "api: FromHbitmap",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600002B",
+      "feature": "property/read: System.IO.FileInfo::Length",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600002B",
+      "feature": "property: System.IO.FileInfo::Length",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000081",
+      "feature": "api: System.Diagnostics.Process::Start",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000081",
+      "feature": "property/write: System.Diagnostics.ProcessStartInfo::UseShellExecute",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000081",
+      "feature": "property/write: System.Diagnostics.ProcessStartInfo::WorkingDirectory",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000081",
+      "feature": "property/write: System.Diagnostics.ProcessStartInfo::FileName",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x6000087",
+      "feature": "property/write: Sockets.MySocket::reConnectionDelay",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "Field property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600008A",
+      "feature": "property/write: Sockets.MySocket::isConnected",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "Field property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600008A",
+      "feature": "class: Sockets.MySocket",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "Field property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600008A",
+      "feature": "namespace: Sockets",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "Field property access"
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600008A",
+      "feature": "property/read: Sockets.MySocket::onConnected",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "Field property access"
+    },
+    {
+      "file": "_0953c",
+      "location": "token=0x6000004",
+      "feature": "property/read: System.Diagnostics.Debugger::IsAttached",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_0953c",
+      "location": "token=0x6000004",
+      "feature": "class: System.Diagnostics.Debugger",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_0953c",
+      "location": "token=0x6000004",
+      "feature": "namespace: System.Diagnostics",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_692f",
+      "location": "token=0x6000006",
+      "feature": "property/read: System.Management.Automation.PowerShell::Streams",
+      "expected": false,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef property access"
+    },
+    {
+      "file": "_387f15",
+      "location": "token=0x600009E",
+      "feature": "property/read: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE::geoplugin_countryCode",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MethodDef property access"
+    },
+    {
+      "file": "_387f15",
+      "location": "token=0x600009E",
+      "feature": "class: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MethodDef property access"
+    },
+    {
+      "file": "_387f15",
+      "location": "token=0x600009E",
+      "feature": "namespace: Modulo",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MethodDef property access"
+    },
+    {
+      "file": "_039a6",
+      "location": "token=0x6000007",
+      "feature": "api: System.Reflection.Assembly::Load",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_039a6",
+      "location": "token=0x600001D",
+      "feature": "property/read: StagelessHollow.Arac::Marka",
+      "expected": true,
+      "tags": ["dotnet"],
+      "explanation": "MethodDef method"
+    },
+    {
+      "file": "_039a6",
+      "location": "token=0x600001C",
+      "feature": "property/read: StagelessHollow.Arac::Marka",
+      "expected": false,
+      "tags": ["dotnet"],
+      "explanation": "MethodDef method"
+    },
+    {
+      "file": "_039a6",
+      "location": "token=0x6000023",
+      "feature": "property/read: System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Task",
+      "expected": false,
+      "tags": ["dotnet"],
+      "explanation": "MemberRef method"
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer0",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer1",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer0/myclass_inner0_0",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer0/myclass_inner0_1",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer1/myclass_inner1_1",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0/myclass_inner_inner",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: myclass_inner_inner",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: myclass_inner1_0",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: myclass_inner1_1",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: myclass_inner0_0",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typedef",
+      "location": "file",
+      "feature": "class: myclass_inner0_1",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Android.OS.Build/VERSION::SdkInt",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Android.Media.Image/Plane::Buffer",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Android.Provider.Telephony/Sent/Sent::ContentUri",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Android.OS.Build::SdkInt",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Plane::Buffer",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "nested_typeref",
+      "location": "file",
+      "feature": "import: Sent::ContentUri",
+      "expected": false,
+      "tags": ["dotnet"]
+    },
+
+    {
+      "file": "_1c444",
+      "location": "token=0x600001D",
+      "feature": "count(characteristic(calls to)): 1",
+      "expected": true,
+      "tags": ["dotnet"]
+    },
+    {
+      "file": "_1c444",
+      "location": "token=0x600001D",
+      "feature": "count(characteristic(calls from)): 9",
+      "expected": true,
+      "tags": ["dotnet"]
+    }
+  ]
+}

--- a/tests/fixtures/features/README.md
+++ b/tests/fixtures/features/README.md
@@ -126,16 +126,17 @@ For example:
 ```python
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="viv",
-    get_extractor=fixtures.get_viv_extractor,
-    exclude_tags={"dotnet"},
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="viv",
+        include_tags={"static"},
+        exclude_tags={"dotnet", "ghidra"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_viv_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_viv_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 ```
 
 Module-level availability checks are still allowed. runtime-specific hooks are allowed only when they depend on the installed backend or tool version and cannot be represented declaratively in the fixture manifests.

--- a/tests/fixtures/features/README.md
+++ b/tests/fixtures/features/README.md
@@ -1,0 +1,169 @@
+# backend feature fixtures
+
+This spec describes how contributors should add and consume backend feature fixtures.
+
+## Scope
+
+This spec covers feature-fixture tests only. It does not cover extractor helper tests, CLI smoke tests, or other bespoke tests.
+
+## Source of truth
+
+Feature fixtures live in these JSON manifests under `tests/fixtures/features/`:
+
+- `static.json`
+- `binja-db.json`
+- `binexport.json`
+- `cape.json`
+- `drakvuf.json`
+- `vmray.json`
+
+Each manifest contains:
+
+- a `files` list that maps fixture keys to sample paths
+- a `features` list that describes feature assertions
+
+The loader reads all of these manifests and combines them into one fixture set.
+
+A backend feature test should not maintain its own private list of feature fixtures if the same information can be expressed in these JSON manifests.
+
+## Fixture shape
+
+Each feature fixture specifies:
+
+- the sample key
+- the location within the sample
+- the feature or statement to evaluate
+- optional tags
+- optional backend marks
+- optional `expected: false`
+
+If `expected` is omitted, it means `true`.
+
+This applies to ordinary feature assertions and `count(...)` assertions.
+
+Examples:
+
+```json
+{
+  "file": "pma16-01",
+  "location": "file",
+  "feature": "format: pe"
+}
+```
+
+```json
+{
+  "file": "mimikatz",
+  "location": "function=0x40E5C2",
+  "feature": "count(basic blocks): 7"
+}
+```
+
+```json
+{
+  "file": "mimikatz",
+  "location": "function=0x401000",
+  "feature": "characteristic: loop",
+  "expected": false
+}
+```
+
+## Tags
+
+Tags are used to describe fixture requirements or sample properties that backends may need for selection.
+
+Examples include:
+
+- `dotnet`
+- `elf`
+- `dynamic`
+- `flirt`
+- `symtab`
+- `binja-db`
+- `binexport`
+- `aarch64`
+
+Tags may appear on file entries or feature entries. file tags are inherited by their features.
+
+Tags should not duplicate information that can already be derived from:
+
+- the location string
+- the parsed feature type
+
+Unknown tags should fail collection.
+
+## Backend selection
+
+Backends consume one shared fixture list and select the fixtures they support.
+
+Large backends should prefer exclusion-based selection. this means new fixtures run by default unless they are explicitly out of scope.
+
+Examples:
+
+- `viv` excludes `.NET`
+- `ghidra` excludes `.NET`
+- `binja` excludes `.NET`
+- `idalib` excludes `.NET`
+
+Small-surface backends may use inclusion-based selection where that is clearer.
+
+Examples:
+
+- `dnfile` includes `.NET`
+- `dotnetfile` includes `.NET`
+
+Backends may also restrict supported scopes or feature types.
+
+## Backend test file shape
+
+A backend feature test file should normally have:
+
+- one backend policy object
+- one feature-test entry point that consumes shared fixtures
+
+For example:
+
+```python
+import fixtures
+
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="viv",
+    get_extractor=fixtures.get_viv_extractor,
+    exclude_tags={"dotnet"},
+)
+
+
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_viv_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+```
+
+Module-level availability checks are still allowed. runtime-specific hooks are allowed only when they depend on the installed backend or tool version and cannot be represented declaratively in the fixture manifests.
+
+## Known bugs and marks
+
+Known backend bugs should be represented in the fixture manifests through backend-specific marks.
+
+Backends should not usually edit the shared JSON manifests just to avoid a fixture. they should prefer selecting or excluding fixtures through backend policy.
+
+The main reason to keep marks in JSON is to record known exceptions such as:
+
+- a backend-specific `xfail`
+- a backend-specific `skip`
+
+## Expected contributor workflow
+
+When adding a new feature test:
+
+1. add the sample path to the appropriate JSON manifest `files` list if it is not already present
+2. add the feature fixture to that manifest `features` list
+3. add tags only when they express a real requirement or sample property
+4. omit `expected` unless the expected result is `false`
+5. use JSON marks only for known backend bugs
+
+When adding a new backend:
+
+1. create one backend feature test file
+2. define one backend policy describing extractor and exclusions
+3. use the shared feature runner
+4. add runtime hooks only if the environment or installed tool version requires them

--- a/tests/fixtures/features/README.md
+++ b/tests/fixtures/features/README.md
@@ -78,7 +78,6 @@ Examples include:
 - `elf`
 - `dynamic`
 - `flirt`
-- `symtab`
 - `binja-db`
 - `binexport`
 - `aarch64`
@@ -145,12 +144,16 @@ Module-level availability checks are still allowed. runtime-specific hooks are a
 
 Known backend bugs should be represented in the fixture manifests through backend-specific marks.
 
-Backends should not usually edit the shared JSON manifests just to avoid a fixture. they should prefer selecting or excluding fixtures through backend policy.
+Backends should not usually edit the shared JSON manifests just to avoid a fixture. They should prefer selecting or excluding fixtures through backend policy.
 
 The main reason to keep marks in JSON is to record known exceptions such as:
 
 - a backend-specific `xfail`
 - a backend-specific `skip`
+
+Ideally, this information is better to put in the backend-specific test code (like test_viv_features.py);
+however, in order to triage one of these failures, you have to go look at the json file anyways, and its
+easier to see the mark next to the thing that fails.
 
 ## Expected contributor workflow
 

--- a/tests/fixtures/features/binexport.json
+++ b/tests/fixtures/features/binexport.json
@@ -1,0 +1,517 @@
+{
+  "files": [
+    {
+      "key": "687e79.ghidra.be2",
+      "path": "data/binexport2/687e79cde5b0ced75ac229465835054931f9ec438816f2827a8be5f3bd474929.elf_.ghidra.BinExport",
+      "tags": [
+        "binexport",
+        "elf",
+        "aarch64"
+      ]
+    },
+    {
+      "key": "d1e650.ghidra.be2",
+      "path": "data/binexport2/d1e6506964edbfffb08c0dd32e1486b11fbced7a4bd870ffe79f110298f0efb8.elf_.ghidra.BinExport",
+      "tags": [
+        "binexport",
+        "elf",
+        "aarch64"
+      ]
+    }
+  ],
+  "features": [
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "string: AppDataService start",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "string: nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "section: .text",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "section: .nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "export: android::clearDir",
+      "expected": true,
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "name demangling is not implemented"
+        }
+      ]
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "export: nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "import: fopen",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "import: exit",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "import: _ZN7android10IInterfaceD0Ev",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "import: nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1056c0",
+      "feature": "characteristic: loop",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1075c0",
+      "feature": "characteristic: loop",
+      "expected": false
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x114af4",
+      "feature": "characteristic: tight loop",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x118F1C",
+      "feature": "characteristic: tight loop",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x11464c",
+      "feature": "characteristic: tight loop",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x0",
+      "feature": "characteristic: stack string",
+      "expected": true,
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "stack string detection not implemented yet for binexport"
+        }
+      ]
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "mnemonic: stp",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "mnemonic: adrp",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "mnemonic: bl",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "mnemonic: in",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "mnemonic: adrl",
+      "expected": false
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x11451c",
+      "feature": "number: 0x10",
+      "expected": false,
+      "comment": "00114524 add x29,sp,#0x10"
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105128",
+      "feature": "number: 0xE0",
+      "expected": false,
+      "comment": "00105128 sub sp,sp,#0xE0"
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105128,bb=0x1051e4",
+      "feature": "operand[1].number: 0xFFFFFFFF",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588,bb=0x107588",
+      "feature": "operand[1].number: 0x8",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588,bb=0x107588,insn=0x1075a4",
+      "feature": "operand[1].number: 0x8",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105128,bb=0x105450",
+      "feature": "operand[2].offset: 0x10",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x124854,bb=0x1248AC,insn=0x1248B4",
+      "feature": "operand[2].offset: -0x48",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x13347c,bb=0x133548,insn=0x133554",
+      "feature": "operand[2].offset: 0x20",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105C88",
+      "feature": "number: 0xF000",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1057f8,bb=0x1057f8",
+      "feature": "number: 0xFFFFFFFFFFFFFFFF",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1066e0,bb=0x1068c4",
+      "feature": "number: 0xFFFFFFFF",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105128,bb=0x105450",
+      "feature": "offset: 0x10",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x13347c,bb=0x133548,insn=0x133554",
+      "feature": "offset: 0x20",
+      "expected": false,
+      "comment": "ldp x29,x30,[sp, #0x20]"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x1183e0,bb=0x11849c,insn=0x1184b0",
+      "feature": "offset: 0x8",
+      "expected": true,
+      "comment": "stp x20,x0,[x19, #0x8]"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x138688,bb=0x138994,insn=0x1389a8",
+      "feature": "offset: 0x8",
+      "expected": true,
+      "comment": "str xzr,[x8, #0x8]!"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x138688,bb=0x138978,insn=0x138984",
+      "feature": "offset: 0x8",
+      "expected": true,
+      "comment": "ldr x9,[x8, #0x8]!"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x11451c",
+      "feature": "offset: 0x20",
+      "expected": false,
+      "comment": "ldr x19,[sp], #0x20"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x138a9c,bb=0x138b00,insn=0x138b00",
+      "feature": "offset: 0x1",
+      "expected": true,
+      "comment": "ldrb w9,[x8, #0x1]"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x124854,bb=0x1248AC,insn=0x1248B4",
+      "feature": "offset: -0x48",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105128,bb=0x105128,insn=0x10514c",
+      "feature": "offset: 0x8",
+      "expected": true,
+      "comment": "0010514c add x23,param_1,#0x8"
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105c88",
+      "feature": "api: memset",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105c88",
+      "feature": "api: Nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "string: AppDataService start",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1075c0",
+      "feature": "string: AppDataService",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "string: nope",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x106d58",
+      "feature": "string: /data/misc/wifi/wpa_supplicant.conf",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105c88",
+      "feature": "string: /innerRename/",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x106d58",
+      "feature": "string: /\\/data\\/misc/",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x106d58",
+      "feature": "substring: /data/misc",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x1165a4",
+      "feature": "bytes: E4 05 B8 93 70 BA 6B 41 9C D7 92 52 75 BF 6F CC 1E 83 60 CC",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1057f8",
+      "feature": "bytes: 2F 00 73 00 79 00 73 00 74 00 65 00 6D 00 2F 00 78 00 62 00 69 00 6E 00 2F 00 62 00 75 00 73 00 79 00 62 00 6F 00 78 00",
+      "expected": false,
+      "comment": "don't extract byte features for obvious strings"
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x114af4",
+      "feature": "characteristic: nzxor",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x117988",
+      "feature": "characteristic: nzxor",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105b38",
+      "feature": "characteristic: recursive call",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x106530",
+      "feature": "characteristic: recursive call",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x118620",
+      "feature": "characteristic: indirect call",
+      "expected": true
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x118500",
+      "feature": "characteristic: indirect call",
+      "expected": false
+    },
+    {
+      "file": "d1e650.ghidra.be2",
+      "location": "function=0x11451c",
+      "feature": "characteristic: indirect call",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x105080",
+      "feature": "characteristic: calls from",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1070e8",
+      "feature": "characteristic: calls from",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1075c0",
+      "feature": "characteristic: calls to",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "function-name: __libc_init",
+      "expected": true,
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "TODO should this be a function-name?"
+        }
+      ]
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "os: android",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "os: linux",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "os: windows",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "os: android",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1075c0,bb=0x1076c0",
+      "feature": "os: android",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "arch: i386",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "arch: aarch64",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "arch: aarch64",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x1075c0,bb=0x1076c0",
+      "feature": "arch: aarch64",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "format: elf",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "file",
+      "feature": "format: pe",
+      "expected": false
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "format: elf",
+      "expected": true
+    },
+    {
+      "file": "687e79.ghidra.be2",
+      "location": "function=0x107588",
+      "feature": "format: pe",
+      "expected": false
+    }
+  ]
+}

--- a/tests/fixtures/features/binexport.json
+++ b/tests/fixtures/features/binexport.json
@@ -3,28 +3,24 @@
     {
       "key": "687e79.ghidra.be2",
       "path": "data/binexport2/687e79cde5b0ced75ac229465835054931f9ec438816f2827a8be5f3bd474929.elf_.ghidra.BinExport",
-      "tags": [
-        "binexport",
-        "elf",
-        "aarch64"
-      ]
+      "tags": ["binexport", "elf", "aarch64"]
     },
     {
       "key": "d1e650.ghidra.be2",
       "path": "data/binexport2/d1e6506964edbfffb08c0dd32e1486b11fbced7a4bd870ffe79f110298f0efb8.elf_.ghidra.BinExport",
-      "tags": [
-        "binexport",
-        "elf",
-        "aarch64"
-      ]
+      "tags": ["binexport", "elf", "aarch64"]
+    },
+    {
+      "key": "mimikatz.ghidra.be2",
+      "path": "data/binexport2/mimikatz.exe_.ghidra.BinExport",
+      "tags": ["binexport"]
     }
   ],
   "features": [
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "string: AppDataService start",
-      "expected": true
+      "feature": "string: AppDataService start"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -35,8 +31,7 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "section: .text",
-      "expected": true
+      "feature": "section: .text"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -48,7 +43,6 @@
       "file": "687e79.ghidra.be2",
       "location": "file",
       "feature": "export: android::clearDir",
-      "expected": true,
       "marks": [
         {
           "backend": "binexport",
@@ -66,20 +60,17 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "import: fopen",
-      "expected": true
+      "feature": "import: fopen"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "import: exit",
-      "expected": true
+      "feature": "import: exit"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "import: _ZN7android10IInterfaceD0Ev",
-      "expected": true
+      "feature": "import: _ZN7android10IInterfaceD0Ev"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -90,8 +81,7 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1056c0",
-      "feature": "characteristic: loop",
-      "expected": true
+      "feature": "characteristic: loop"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -102,14 +92,12 @@
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x114af4",
-      "feature": "characteristic: tight loop",
-      "expected": true
+      "feature": "characteristic: tight loop"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x118F1C",
-      "feature": "characteristic: tight loop",
-      "expected": true
+      "feature": "characteristic: tight loop"
     },
     {
       "file": "d1e650.ghidra.be2",
@@ -121,7 +109,6 @@
       "file": "687e79.ghidra.be2",
       "location": "function=0x0",
       "feature": "characteristic: stack string",
-      "expected": true,
       "marks": [
         {
           "backend": "binexport",
@@ -133,20 +120,17 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "mnemonic: stp",
-      "expected": true
+      "feature": "mnemonic: stp"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "mnemonic: adrp",
-      "expected": true
+      "feature": "mnemonic: adrp"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "mnemonic: bl",
-      "expected": true
+      "feature": "mnemonic: bl"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -177,32 +161,27 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105128,bb=0x1051e4",
-      "feature": "operand[1].number: 0xFFFFFFFF",
-      "expected": true
+      "feature": "operand[1].number: 0xFFFFFFFF"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588,bb=0x107588",
-      "feature": "operand[1].number: 0x8",
-      "expected": true
+      "feature": "operand[1].number: 0x8"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588,bb=0x107588,insn=0x1075a4",
-      "feature": "operand[1].number: 0x8",
-      "expected": true
+      "feature": "operand[1].number: 0x8"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105128,bb=0x105450",
-      "feature": "operand[2].offset: 0x10",
-      "expected": true
+      "feature": "operand[2].offset: 0x10"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x124854,bb=0x1248AC,insn=0x1248B4",
-      "feature": "operand[2].offset: -0x48",
-      "expected": true
+      "feature": "operand[2].offset: -0x48"
     },
     {
       "file": "d1e650.ghidra.be2",
@@ -213,26 +192,22 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105C88",
-      "feature": "number: 0xF000",
-      "expected": true
+      "feature": "number: 0xF000"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1057f8,bb=0x1057f8",
-      "feature": "number: 0xFFFFFFFFFFFFFFFF",
-      "expected": true
+      "feature": "number: 0xFFFFFFFFFFFFFFFF"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1066e0,bb=0x1068c4",
-      "feature": "number: 0xFFFFFFFF",
-      "expected": true
+      "feature": "number: 0xFFFFFFFF"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105128,bb=0x105450",
-      "feature": "offset: 0x10",
-      "expected": true
+      "feature": "offset: 0x10"
     },
     {
       "file": "d1e650.ghidra.be2",
@@ -245,21 +220,18 @@
       "file": "d1e650.ghidra.be2",
       "location": "function=0x1183e0,bb=0x11849c,insn=0x1184b0",
       "feature": "offset: 0x8",
-      "expected": true,
       "comment": "stp x20,x0,[x19, #0x8]"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x138688,bb=0x138994,insn=0x1389a8",
       "feature": "offset: 0x8",
-      "expected": true,
       "comment": "str xzr,[x8, #0x8]!"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x138688,bb=0x138978,insn=0x138984",
       "feature": "offset: 0x8",
-      "expected": true,
       "comment": "ldr x9,[x8, #0x8]!"
     },
     {
@@ -273,27 +245,23 @@
       "file": "d1e650.ghidra.be2",
       "location": "function=0x138a9c,bb=0x138b00,insn=0x138b00",
       "feature": "offset: 0x1",
-      "expected": true,
       "comment": "ldrb w9,[x8, #0x1]"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x124854,bb=0x1248AC,insn=0x1248B4",
-      "feature": "offset: -0x48",
-      "expected": true
+      "feature": "offset: -0x48"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105128,bb=0x105128,insn=0x10514c",
       "feature": "offset: 0x8",
-      "expected": true,
       "comment": "0010514c add x23,param_1,#0x8"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105c88",
-      "feature": "api: memset",
-      "expected": true
+      "feature": "api: memset"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -304,14 +272,12 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "string: AppDataService start",
-      "expected": true
+      "feature": "string: AppDataService start"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1075c0",
-      "feature": "string: AppDataService",
-      "expected": true
+      "feature": "string: AppDataService"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -322,32 +288,27 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x106d58",
-      "feature": "string: /data/misc/wifi/wpa_supplicant.conf",
-      "expected": true
+      "feature": "string: /data/misc/wifi/wpa_supplicant.conf"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105c88",
-      "feature": "string: /innerRename/",
-      "expected": true
+      "feature": "string: /innerRename/"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x106d58",
-      "feature": "string: /\\/data\\/misc/",
-      "expected": true
+      "feature": "string: /\\/data\\/misc/"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x106d58",
-      "feature": "substring: /data/misc",
-      "expected": true
+      "feature": "substring: /data/misc"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x1165a4",
-      "feature": "bytes: E4 05 B8 93 70 BA 6B 41 9C D7 92 52 75 BF 6F CC 1E 83 60 CC",
-      "expected": true
+      "feature": "bytes: E4 05 B8 93 70 BA 6B 41 9C D7 92 52 75 BF 6F CC 1E 83 60 CC"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -359,32 +320,27 @@
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x114af4",
-      "feature": "characteristic: nzxor",
-      "expected": true
+      "feature": "characteristic: nzxor"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x117988",
-      "feature": "characteristic: nzxor",
-      "expected": true
+      "feature": "characteristic: nzxor"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105b38",
-      "feature": "characteristic: recursive call",
-      "expected": true
+      "feature": "characteristic: recursive call"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x106530",
-      "feature": "characteristic: recursive call",
-      "expected": true
+      "feature": "characteristic: recursive call"
     },
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x118620",
-      "feature": "characteristic: indirect call",
-      "expected": true
+      "feature": "characteristic: indirect call"
     },
     {
       "file": "d1e650.ghidra.be2",
@@ -395,14 +351,12 @@
     {
       "file": "d1e650.ghidra.be2",
       "location": "function=0x11451c",
-      "feature": "characteristic: indirect call",
-      "expected": true
+      "feature": "characteristic: indirect call"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x105080",
-      "feature": "characteristic: calls from",
-      "expected": true
+      "feature": "characteristic: calls from"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -413,14 +367,12 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1075c0",
-      "feature": "characteristic: calls to",
-      "expected": true
+      "feature": "characteristic: calls to"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
       "feature": "function-name: __libc_init",
-      "expected": true,
       "marks": [
         {
           "backend": "binexport",
@@ -432,8 +384,7 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "os: android",
-      "expected": true
+      "feature": "os: android"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -450,14 +401,12 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "os: android",
-      "expected": true
+      "feature": "os: android"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1075c0,bb=0x1076c0",
-      "feature": "os: android",
-      "expected": true
+      "feature": "os: android"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -474,26 +423,22 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "arch: aarch64",
-      "expected": true
+      "feature": "arch: aarch64"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "arch: aarch64",
-      "expected": true
+      "feature": "arch: aarch64"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x1075c0,bb=0x1076c0",
-      "feature": "arch: aarch64",
-      "expected": true
+      "feature": "arch: aarch64"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "file",
-      "feature": "format: elf",
-      "expected": true
+      "feature": "format: elf"
     },
     {
       "file": "687e79.ghidra.be2",
@@ -504,14 +449,612 @@
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
-      "feature": "format: elf",
-      "expected": true
+      "feature": "format: elf"
     },
     {
       "file": "687e79.ghidra.be2",
       "location": "function=0x107588",
       "feature": "format: pe",
       "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "string: SCardControl",
+      "explanation": "basic UTF-16LE string"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "string: ACR  > ",
+      "explanation": "UTF-16LE encoded strings with unusual characters and trailing spaces"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "string: nope",
+      "expected": false,
+      "explanation": "non-existant string"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "section: .text",
+      "explanation": "basic section name"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "section: .nope",
+      "expected": false,
+      "explanation": "non-existant section"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: advapi32.CryptSetHashParam",
+      "explanation": "import with DLL prefix"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: CryptSetHashParam",
+      "explanation": "import with no DLL prefix"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: cabinet.#11",
+      "explanation": "import by ordinal"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: #11",
+      "expected": false,
+      "explanation": "non-existant ordinal import"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: #nope",
+      "expected": false,
+      "explanation": "non-existant ordinal import"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "import: nope",
+      "expected": false,
+      "explanation": "non-existant import"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401517",
+      "feature": "characteristic: loop",
+      "explanation": "loop"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "characteristic: loop",
+      "expected": false,
+      "explanation": "non-existant loop"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x402EC4",
+      "feature": "characteristic: tight loop",
+      "explanation": "tight-loop"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "characteristic: tight loop",
+      "expected": false,
+      "explanation": "non-existant tight-loop"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x402EC4,bb=0x402F8E",
+      "feature": "characteristic: tight loop",
+      "explanation": "tight-loop at basic block scope"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000,bb=0x401000",
+      "feature": "characteristic: tight loop",
+      "expected": false,
+      "explanation": "non-existant tight-loop at basic block scope"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: stack string",
+      "explanation": "stack string (but capa doesn't extract it as a string yet)",
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "stack string detection not implemented for binexport"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "characteristic: stack string",
+      "expected": false,
+      "explanation": "non-existant stack string"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "mnemonic: push",
+      "explanation": "basic mnemonic"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "mnemonic: in",
+      "expected": false,
+      "explanation": "non-existant mnemonic"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "number: 0xFF",
+      "explanation": "number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "operand[1].number: 0xFF",
+      "explanation": "mov eax, 0FFh; instruction operand number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x401073,insn=0x401073",
+      "feature": "operand[0].number: 0xFF",
+      "expected": false,
+      "explanation": "mov eax, 0FFh; non-existant instruction operand number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x4010B0,insn=0x4010B4",
+      "feature": "operand[0].offset: 4",
+      "explanation": "cmp [esi+4], ebx; instruction operand offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x4010B0,insn=0x4010B4",
+      "feature": "operand[1].offset: 4",
+      "expected": false,
+      "explanation": "cmp [esi+4], ebx; non-existant instruction operand offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "number: 0xFF",
+      "explanation": "small number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "number: 0x3136B0",
+      "explanation": "large number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "number: 0x0",
+      "explanation": "zero number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "number: 0xC",
+      "expected": false,
+      "explanation": "non-existant number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401553",
+      "feature": "number: 0xFFFFFFFF",
+      "explanation": "max u32 number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x43e543",
+      "feature": "number: 0xFFFFFFF0",
+      "explanation": "large u32 number"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x0",
+      "explanation": "cmp [esi], ebx; zero offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x4",
+      "explanation": "cmp [esi+4], ebx; simple offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "offset: 0x8",
+      "expected": false,
+      "explanation": "no instruction in the function references [reg+8]"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4011FB",
+      "feature": "offset: -0x1",
+      "explanation": "movzx ecx, [eax-1]; negative offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4011FB",
+      "feature": "offset: -0x2",
+      "explanation": "cmp [eax-2], cx; negative offset -2"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4011FB",
+      "feature": "number: -0x2",
+      "expected": false,
+      "explanation": "cmp [eax-2], cx; negative offset shouldn't emit a number too"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401D64,bb=0x401D73,insn=0x401D85",
+      "feature": "offset: 0x80000000",
+      "expected": false,
+      "explanation": "add ecx, 80000000h; too-large immediate should not be considered an offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401CC7,bb=0x401CDE,insn=0x401CF6",
+      "feature": "offset: 0x10",
+      "expected": false,
+      "explanation": "add esp, 10h; stack-relative ADD should not be considered an offset"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x402203,bb=0x402221,insn=0x40223C",
+      "feature": "offset: 0x4",
+      "explanation": "add eax, 4; non-stack register ADD should emit an offset feature, treating eax as a pointer"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x471EAB,bb=0x471ED8,insn=0x471EE6",
+      "feature": "number: 0x4",
+      "expected": false,
+      "explanation": "lea ebx, [ecx+eax*4]; should not emit Number feature for the scale"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x47153B,bb=0x4717AB,insn=0x4717B1",
+      "feature": "number: -0x30",
+      "expected": false,
+      "explanation": "lea ecx, [ecx+esi-30h]; should not emit Number feature for the displacement"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401873,bb=0x4018B2,insn=0x4018C0",
+      "feature": "number: 0x2",
+      "explanation": "lea ecx, [ebx+2]; should emit Number feature, treating ebx as zero"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x403BAC",
+      "feature": "api: CryptAcquireContextW",
+      "explanation": "basic API feature with trailing W"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x403BAC",
+      "feature": "api: CryptAcquireContext",
+      "explanation": "basic API feature with stripped W"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x403BAC",
+      "feature": "api: Nope",
+      "expected": false,
+      "explanation": "non-existent API"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "api: LsaQueryInformationPolicy"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40B3C6",
+      "feature": "api: LocalFree",
+      "explanation": "tail call to API via jmp"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "string: SCardControl",
+      "explanation": "basic string"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "string: ACR  > ",
+      "explanation": "basic string with trailing whitespace"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "string: nope",
+      "expected": false,
+      "explanation": "basic string not present"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x44EDEF",
+      "feature": "string: INPUTEVENT",
+      "explanation": "string referenced via a pointer"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x46D6CE",
+      "feature": "string: (null)",
+      "explanation": "string referenced via direct memory reference"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401517",
+      "feature": "bytes: CA 3B 0E 00 00 00 F8 AF 47",
+      "explanation": "basic bytes"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x404414",
+      "feature": "bytes: 01 80 00 00 40 EA 47 00",
+      "explanation": "basic bytes, which are a pointer"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "bytes: 53 00 43 00 61 00 72 00 64 00 43 00 6F 00 6E 00 74 00 72 00 6F 00 6C 00",
+      "expected": false,
+      "explanation": "should not extract bytes feature for an obvious string (here: UTF-16LE 'SCardControl')"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "bytes: FD FF 59 F6 47",
+      "expected": false,
+      "explanation": "push offset aAcsAcr1220 ('ACS...') where ACS == 41 00 43 00 happens to be a valid pointer to the middle of an instruction; should not be misinterpreted as bytes feature"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x44570F",
+      "feature": "bytes: FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF",
+      "expected": false,
+      "explanation": "regression test for issue #409: should not extract bytes feature from byte sequences read from invalid memory"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x44EDEF",
+      "feature": "bytes: 49 00 4E 00 50 00 55 00 54 00 45 00 56 00 45 00 4E 00 54 00",
+      "expected": false,
+      "explanation": "should not extract bytes feature when instruction references it as a pointer to string bytes"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x410DFC",
+      "feature": "characteristic: nzxor",
+      "explanation": "should extract nzxor characteristic, including from xorps SSE instructions"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "characteristic: nzxor",
+      "expected": false,
+      "explanation": "non-existant nzxor"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x46D534",
+      "feature": "characteristic: nzxor",
+      "expected": false,
+      "explanation": "should not extract nzxor characteristic for security cookie xors"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: peb access",
+      "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: gs access",
+      "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x410DFC,bb=0x410F05,insn=0x410F0B",
+      "feature": "characteristic: nzxor"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x410DFC,bb=0x410F05,insn=0x410F12",
+      "feature": "characteristic: nzxor"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: cross section flow",
+      "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40640e",
+      "feature": "characteristic: recursive call"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4175FF",
+      "feature": "characteristic: recursive call",
+      "expected": false,
+      "explanation": "issue #386: 0x4175FF makes indirect calls (via dword_4B821C) but never calls itself, directly or via a function-pointer table"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4175FF",
+      "feature": "characteristic: indirect call"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: indirect call",
+      "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "characteristic: calls from"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4702FD",
+      "feature": "characteristic: calls from",
+      "expected": false
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D",
+      "feature": "characteristic: calls to"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x456BB9",
+      "feature": "characteristic: calls to",
+      "expected": false,
+      "explanation": "issue #386: 0x456BB9 is only referenced from a function-pointer table at 0x475834, never via a direct call"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105D,bb=0x401089,insn=0x40108E",
+      "feature": "characteristic: calls from"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4175FF,bb=0x41761B,insn=0x417620",
+      "feature": "characteristic: indirect call"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "os: windows"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "arch: i386"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "format: pe"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000,bb=0x401000",
+      "feature": "basic blocks: x",
+      "explanation": "basic block feature emitted"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "file",
+      "feature": "basic blocks: 1",
+      "expected": false,
+      "explanation": "non-existant basic block feature"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40E5C2",
+      "feature": "count(basic blocks): 7",
+      "explanation": "7 basic blocks in function",
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4702FD",
+      "feature": "count(characteristic(calls from)): 0",
+      "explanation": "function has no calls"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40E5C2",
+      "feature": "count(characteristic(calls from)): 3",
+      "explanation": "function has 3 calls",
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4556E5",
+      "feature": "count(characteristic(calls to)): 0",
+      "explanation": "function has no callers",
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40B1F1",
+      "feature": "count(characteristic(calls to)): 3",
+      "explanation": "function has 3 callers",
+      "marks": [
+        {
+          "backend": "binexport",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x4702FD",
+      "feature": "count(characteristic(calls from)): 0",
+      "explanation": "Ghidra: function has no calls"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401bf1",
+      "feature": "count(characteristic(calls to)): 2",
+      "explanation": "Ghidra: function has 2 callers"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x401000",
+      "feature": "count(basic blocks): 3",
+      "explanation": "Ghidra: 3 basic blocks in function"
     }
   ]
 }

--- a/tests/fixtures/features/binexport.json
+++ b/tests/fixtures/features/binexport.json
@@ -1055,6 +1055,18 @@
       "location": "function=0x401000",
       "feature": "count(basic blocks): 3",
       "explanation": "Ghidra: 3 basic blocks in function"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105d,bb=0x401125,insn=0x401125",
+      "feature": "count(offset(0x0)): 1",
+      "explanation": "MOV [EDI], CX matches OFFSET_ZERO_PATTERNS, must yield Offset(0) exactly once"
+    },
+    {
+      "file": "mimikatz.ghidra.be2",
+      "location": "function=0x40105d,bb=0x401125,insn=0x401125",
+      "feature": "count(operand[1].offset(0x0)): 1",
+      "explanation": "MOV [EDI], CX matches OFFSET_ZERO_PATTERNS, must yield OperandOffset(1, 0) exactly once"
     }
   ]
 }

--- a/tests/fixtures/features/binja-db.json
+++ b/tests/fixtures/features/binja-db.json
@@ -1,0 +1,91 @@
+{
+  "files": [
+    {
+      "key": "pma16-01_binja_db",
+      "path": "data/Practical Malware Analysis Lab 16-01.exe_.bndb",
+      "tags": [
+        "binja-db"
+      ]
+    }
+  ],
+  "features": [
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x4021B0",
+      "feature": "string: /HTTP/1.0/"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x402F40",
+      "feature": "string: /www.practicalmalwareanalysis.com/"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x402F40",
+      "feature": "substring: practicalmalwareanalysis.com"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "function-name: __aulldiv"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "os: windows"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "os: linux",
+      "expected": false
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x404356",
+      "feature": "os: windows"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x404356,bb=0x4043B9",
+      "feature": "os: windows"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "arch: i386"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "arch: amd64",
+      "expected": false
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x404356",
+      "feature": "arch: i386"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x404356,bb=0x4043B9",
+      "feature": "arch: i386"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "format: pe"
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "file",
+      "feature": "format: elf",
+      "expected": false
+    },
+    {
+      "file": "pma16-01_binja_db",
+      "location": "function=0x404356",
+      "feature": "format: pe"
+    }
+  ]
+}

--- a/tests/fixtures/features/cape.json
+++ b/tests/fixtures/features/cape.json
@@ -3,18 +3,7 @@
     {
       "key": "0000a657",
       "path": "data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz",
-      "tags": [
-        "dynamic",
-        "cape"
-      ]
-    },
-    {
-      "key": "d46900",
-      "path": "data/dynamic/cape/v2.2/d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz",
-      "tags": [
-        "dynamic",
-        "cape"
-      ]
+      "tags": ["dynamic", "cape"]
     }
   ],
   "features": [

--- a/tests/fixtures/features/cape.json
+++ b/tests/fixtures/features/cape.json
@@ -1,0 +1,221 @@
+{
+  "files": [
+    {
+      "key": "0000a657",
+      "path": "data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz",
+      "tags": [
+        "dynamic",
+        "cape"
+      ]
+    },
+    {
+      "key": "d46900",
+      "path": "data/dynamic/cape/v2.2/d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz",
+      "tags": [
+        "dynamic",
+        "cape"
+      ]
+    }
+  ],
+  "features": [
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "string: T_Ba?.BcRJa"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "string: GetNamedPipeClientSessionId"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "string: nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "section: .rdata"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "section: .nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "import: NdrSimpleTypeUnmarshall"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "import: Nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "export: Nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(1180:3052)",
+      "feature": "string: C:\\Users\\comp\\AppData\\Roaming\\Microsoft\\Jxoqwnx\\jxoqwn.exe"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(1180:3052)",
+      "feature": "string: nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2900:2852),thread=2904",
+      "feature": "api: RegQueryValueExA"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2900:2852),thread=2904",
+      "feature": "api: RegQueryValueEx"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "api: NtQueryValueKey"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "api: GetActiveWindow",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "number: 0xEC"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "number: 110173",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "string: SetThreadUILanguage"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "string: nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804,call=56",
+      "feature": "api: NtQueryValueKey"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804,call=1958",
+      "feature": "api: nope",
+      "expected": false
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(string(T_Ba?.BcRJa)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(string(GetNamedPipeClientSessionId)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(string(nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(section(.rdata)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(section(.nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(import(NdrSimpleTypeUnmarshall)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(import(Nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "file",
+      "feature": "count(export(Nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(1180:3052)",
+      "feature": "count(string(C:\\Users\\comp\\AppData\\Roaming\\Microsoft\\Jxoqwnx\\jxoqwn.exe)): 2"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(1180:3052)",
+      "feature": "count(string(nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(api(NtQueryValueKey)): 7"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(api(GetActiveWindow)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(number(0xEC)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(number(110173)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(string(SetThreadUILanguage)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804",
+      "feature": "count(string(nope)): 0"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804,call=56",
+      "feature": "count(api(NtQueryValueKey)): 1"
+    },
+    {
+      "file": "0000a657",
+      "location": "process=(2852:3052),thread=2804,call=1958",
+      "feature": "count(api(nope)): 0"
+    }
+  ]
+}

--- a/tests/fixtures/features/drakvuf.json
+++ b/tests/fixtures/features/drakvuf.json
@@ -1,0 +1,129 @@
+{
+  "files": [
+    {
+      "key": "93b2d1-drakvuf",
+      "path": "data/dynamic/drakvuf/93b2d1840566f45fab674ebc79a9d19c88993bcb645e0357f3cb584d16e7c795.log.gz",
+      "tags": [
+        "dynamic",
+        "drakvuf"
+      ]
+    }
+  ],
+  "features": [
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "file",
+      "feature": "string: \\Program Files\\WindowsApps\\does_not_exist",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "file",
+      "feature": "import: SetUnhandledExceptionFilter"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592",
+      "feature": "api: LdrLoadDll"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592",
+      "feature": "api: DoesNotExist",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=4716,call=17",
+      "feature": "api: CreateWindowExW"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=4716,call=17",
+      "feature": "api: CreateWindowEx"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "api: LdrLoadDll"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "api: DoesNotExist",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "string: 0x667e2beb40:\"api-ms-win-core-fibers-l1-1-1\""
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "string: non_existant",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "number: 0x801"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "number: 0x10101010101",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "file",
+      "feature": "count(string(\\Program Files\\WindowsApps\\does_not_exist)): 0"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "file",
+      "feature": "count(import(SetUnhandledExceptionFilter)): 1"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592",
+      "feature": "count(api(LdrLoadDll)): 9"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592",
+      "feature": "count(api(DoesNotExist)): 0"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(api(LdrLoadDll)): 1"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(api(DoesNotExist)): 0"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(string(0x667e2beb40:\"api-ms-win-core-fibers-l1-1-1\")): 1"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(string(non_existant)): 0"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(number(0x801)): 1"
+    },
+    {
+      "file": "93b2d1-drakvuf",
+      "location": "process=(3564:4852),thread=6592,call=1",
+      "feature": "count(number(0x10101010101)): 0"
+    }
+  ]
+}

--- a/tests/fixtures/features/static.json
+++ b/tests/fixtures/features/static.json
@@ -2,79 +2,142 @@
   "files": [
     {
       "key": "mimikatz",
-      "path": "data/mimikatz.exe_"
+      "path": "data/mimikatz.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "kernel32",
-      "path": "data/kernel32.dll_"
+      "path": "data/kernel32.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "kernel32-64",
-      "path": "data/kernel32-64.dll_"
+      "path": "data/kernel32-64.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "pma12-04",
-      "path": "data/Practical Malware Analysis Lab 12-04.exe_"
+      "path": "data/Practical Malware Analysis Lab 12-04.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "pma16-01",
-      "path": "data/Practical Malware Analysis Lab 16-01.exe_"
+      "path": "data/Practical Malware Analysis Lab 16-01.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "7351f.elf",
-      "path": "data/7351f8a40c5450557b24622417fc478d.elf_"
+      "path": "data/7351f8a40c5450557b24622417fc478d.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
     },
     {
       "key": "055da8e6.elf",
-      "path": "data/055da8e6ccfe5a9380231ea04b850e18.elf_"
+      "path": "data/055da8e6ccfe5a9380231ea04b850e18.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
     },
     {
       "key": "bb38149.elf",
-      "path": "data/bb38149ff4b5c95722b83f24ca27a42b.elf_"
+      "path": "data/bb38149ff4b5c95722b83f24ca27a42b.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
     },
     {
       "key": "al-khaser x64",
-      "path": "data/al-khaser_x64.exe_"
+      "path": "data/al-khaser_x64.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "64d9f",
-      "path": "data/64d9f7d96b99467f36e22fada623c3bb.dll_"
+      "path": "data/64d9f7d96b99467f36e22fada623c3bb.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "79abd",
-      "path": "data/79abd17391adc6251ecdc58d13d76baf.dll_"
+      "path": "data/79abd17391adc6251ecdc58d13d76baf.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "946a9",
-      "path": "data/946a99f36a46d335dec080d9a4371940.dll_"
+      "path": "data/946a99f36a46d335dec080d9a4371940.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "773290",
-      "path": "data/773290480d5445f11d3dc1b800728966.exe_"
+      "path": "data/773290480d5445f11d3dc1b800728966.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "294b8d",
-      "path": "data/294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_"
+      "path": "data/294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
     },
     {
       "key": "a1982",
-      "path": "data/a198216798ca38f280dc413f8c57f2c2.exe_"
+      "path": "data/a198216798ca38f280dc413f8c57f2c2.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "c91887",
-      "path": "data/c91887d861d9bd4a5872249b641bc9f9.exe_"
+      "path": "data/c91887d861d9bd4a5872249b641bc9f9.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "2bf18d",
-      "path": "data/2bf18d0403677378adad9001b1243211.elf_"
+      "path": "data/2bf18d0403677378adad9001b1243211.elf_",
+      "tags": [
+        "elf",
+        "static",
+        "symtab"
+      ]
     },
     {
       "key": "2d3edc",
-      "path": "data/2d3edc218a90f03089cc01715a9f047f.exe_"
+      "path": "data/2d3edc218a90f03089cc01715a9f047f.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "ea2876",
-      "path": "data/ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_"
+      "path": "data/ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "pma01-01.frz",
@@ -92,46 +155,203 @@
       "key": "034b7231.frz",
       "path": "fixtures/freeze/034b7231a49387604e81a5a5d2fe7e08f6982c418a28b719d2faace3c312ebb5.exe_.frz"
     },
-
     {
       "key": "b9f5b",
-      "path": "data/b9f5bd514485fb06da39beff051b9fdc.exe_"
+      "path": "data/b9f5bd514485fb06da39beff051b9fdc.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "mixed-mode-64",
-      "path": "data/dotnet/dnfile-testfiles/mixed-mode/ModuleCode/bin/ModuleCode_amd64.exe"
+      "path": "data/dotnet/dnfile-testfiles/mixed-mode/ModuleCode/bin/ModuleCode_amd64.exe",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "hello-world",
-      "path": "data/dotnet/dnfile-testfiles/hello-world/hello-world.exe"
+      "path": "data/dotnet/dnfile-testfiles/hello-world/hello-world.exe",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "_1c444",
-      "path": "data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_"
+      "path": "data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "_692f",
-      "path": "data/dotnet/692f7fd6d198e804d6af98eb9e390d61.exe_"
+      "path": "data/dotnet/692f7fd6d198e804d6af98eb9e390d61.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "_0953c",
-      "path": "data/0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_"
+      "path": "data/0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "_039a6",
-      "path": "data/039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_"
+      "path": "data/039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "_387f15",
-      "path": "data/dotnet/387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_"
+      "path": "data/dotnet/387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "nested_typedef",
-      "path": "data/dotnet/dd9098ff91717f4906afe9dafdfa2f52.exe_"
+      "path": "data/dotnet/dd9098ff91717f4906afe9dafdfa2f52.exe_",
+      "tags": [
+        "static"
+      ]
     },
     {
       "key": "nested_typeref",
-      "path": "data/dotnet/2c7d60f77812607dec5085973ff76cea.dll_"
+      "path": "data/dotnet/2c7d60f77812607dec5085973ff76cea.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "pma01-01",
+      "path": "data/Practical Malware Analysis Lab 01-01.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "pma01-01-rd",
+      "path": "data/rd/Practical Malware Analysis Lab 01-01.dll_.json"
+    },
+    {
+      "key": "pma21-01",
+      "path": "data/Practical Malware Analysis Lab 21-01.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "al-khaser x86",
+      "path": "data/al-khaser_x86.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "39c05",
+      "path": "data/39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "499c2",
+      "path": "data/499c2a85f6e8142c3f48d4251c9c7cd6.raw32",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "9324d",
+      "path": "data/9324d1a8ae37a36ae560c37448c9705a.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "395eb",
+      "path": "data/395eb0ddd99d2c9e37b6d0b73485ee9c.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "a933a",
+      "path": "data/a933a1a402775cfa94b6bee0963f4b46.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "bfb9b",
+      "path": "data/bfb9b5391a13d0afd787e87ab90f14f5.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "82bf6",
+      "path": "data/82BF6347ACF15E5D883715DC289D8A2B.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "pingtaest",
+      "path": "data/ping_t\u00e4st.exe_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "3b13b",
+      "path": "data/3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_",
+      "tags": [
+        "static"
+      ]
+    },
+    {
+      "key": "2f7f5f",
+      "path": "data/2f7f5fb5de175e770d7eae87666f9831.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
+    },
+    {
+      "key": "b5f052",
+      "path": "data/b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
+    },
+    {
+      "key": "bf7a9c",
+      "path": "data/bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
+    },
+    {
+      "key": "1038a2",
+      "path": "data/1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
+    },
+    {
+      "key": "3da7c",
+      "path": "data/3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_",
+      "tags": [
+        "elf",
+        "static"
+      ]
     }
   ],
   "features": [
@@ -1171,13 +1391,19 @@
       "expected": false,
       "explanation": "non-existant basic block feature"
     },
-
     {
       "file": "mimikatz",
       "location": "function=0x40E5C2",
       "feature": "count(basic blocks): 7",
       "expected": true,
-      "explanation": "7 basic blocks in function"
+      "explanation": "7 basic blocks in function",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
     },
     {
       "file": "mimikatz",
@@ -1191,29 +1417,51 @@
       "location": "function=0x40E5C2",
       "feature": "count(characteristic(calls from)): 3",
       "expected": true,
-      "explanation": "function has 3 calls"
+      "explanation": "function has 3 calls",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
     },
     {
       "file": "mimikatz",
       "location": "function=0x4556E5",
       "feature": "count(characteristic(calls to)): 0",
       "expected": true,
-      "explanation": "function has no callers"
+      "explanation": "function has no callers",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
     },
     {
       "file": "mimikatz",
       "location": "function=0x40B1F1",
       "feature": "count(characteristic(calls to)): 3",
       "expected": true,
-      "explanation": "function has 3 callers"
+      "explanation": "function has 3 callers",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra identifies different function boundaries; see ghidra-tagged count variant"
+        }
+      ]
     },
-
     {
       "file": "mimikatz",
       "location": "function=0x4702FD",
       "feature": "count(characteristic(calls from)): 0",
       "expected": true,
-      "tags": ["ghidra"],
+      "tags": [
+        "ghidra"
+      ],
       "explanation": "Ghidra: function has no calls"
     },
     {
@@ -1221,7 +1469,9 @@
       "location": "function=0x401bf1",
       "feature": "count(characteristic(calls to)): 2",
       "expected": true,
-      "tags": ["ghidra"],
+      "tags": [
+        "ghidra"
+      ],
       "explanation": "Ghidra: function has 2 callers"
     },
     {
@@ -1229,261 +1479,334 @@
       "location": "function=0x401000",
       "feature": "count(basic blocks): 3",
       "expected": true,
-      "tags": ["ghidra"],
+      "tags": [
+        "ghidra"
+      ],
       "explanation": "Ghidra: 3 basic blocks in function"
     },
-
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "arch: i386",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "arch: amd64",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "arch: amd64",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "arch: i386",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "characteristic: mixed mode",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "characteristic: mixed mode",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "os: any",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "format: pe",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "format: dotnet",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::Main",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::ctor",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::cctor",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "string: Hello World!",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "class: HelloWorld",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "class: System.Console",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "namespace: System.Diagnostics",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "function=0x250",
       "feature": "string: Hello World!",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x252",
       "feature": "string: Hello World!",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x257",
       "feature": "class: System.Console",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x257",
       "feature": "namespace: System",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "function=0x250",
       "feature": "api: System.Console::WriteLine",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "import: System.Console::WriteLine",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "string: SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "string: get_IsAlive",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: gdi32.CreateCompatibleBitmap",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: CreateCompatibleBitmap",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: gdi32::CreateCompatibleBitmap",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "api: GetWindowDC",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0xCC0020",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "characteristic: calls to",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x6000018",
       "feature": "characteristic: calls to",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "characteristic: calls from",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x600000F",
       "feature": "characteristic: calls from",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0x0",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0x1",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_692f",
       "location": "token=0x6000004",
       "feature": "api: System.Linq.Enumerable::First",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "generic method"
     },
     {
@@ -1491,7 +1814,9 @@
       "location": "token=0x6000004",
       "feature": "property: System.Linq.Enumerable::First",
       "expected": false,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "generic method"
     },
     {
@@ -1499,7 +1824,9 @@
       "location": "token=0x6000004",
       "feature": "namespace: System.Linq",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "generic method"
     },
     {
@@ -1507,7 +1834,9 @@
       "location": "token=0x6000004",
       "feature": "class: System.Linq.Enumerable",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "generic method"
     },
     {
@@ -1515,7 +1844,9 @@
       "location": "token=0x6000020",
       "feature": "namespace: Reqss",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "ldftn"
     },
     {
@@ -1523,7 +1854,9 @@
       "location": "token=0x6000020",
       "feature": "class: Reqss.Reqss",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "ldftn"
     },
     {
@@ -1531,21 +1864,27 @@
       "location": "function=0x1F59,bb=0x1F59,insn=0x1F5B",
       "feature": "characteristic: unmanaged call",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x2544",
       "feature": "characteristic: unmanaged call",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x6000088",
       "feature": "characteristic: unmanaged call",
       "expected": false,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "same as above but using token instead of function"
     },
     {
@@ -1553,21 +1892,27 @@
       "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
       "feature": "api: System.Drawing.Image::FromHbitmap",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
       "feature": "api: FromHbitmap",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x600002B",
       "feature": "property/read: System.IO.FileInfo::Length",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1575,7 +1920,9 @@
       "location": "token=0x600002B",
       "feature": "property: System.IO.FileInfo::Length",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1583,7 +1930,9 @@
       "location": "token=0x6000081",
       "feature": "api: System.Diagnostics.Process::Start",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1591,7 +1940,9 @@
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::UseShellExecute",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1599,7 +1950,9 @@
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::WorkingDirectory",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1607,7 +1960,9 @@
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::FileName",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1615,7 +1970,9 @@
       "location": "token=0x6000087",
       "feature": "property/write: Sockets.MySocket::reConnectionDelay",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "Field property access"
     },
     {
@@ -1623,7 +1980,9 @@
       "location": "token=0x600008A",
       "feature": "property/write: Sockets.MySocket::isConnected",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "Field property access"
     },
     {
@@ -1631,7 +1990,9 @@
       "location": "token=0x600008A",
       "feature": "class: Sockets.MySocket",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "Field property access"
     },
     {
@@ -1639,7 +2000,9 @@
       "location": "token=0x600008A",
       "feature": "namespace: Sockets",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "Field property access"
     },
     {
@@ -1647,7 +2010,9 @@
       "location": "token=0x600008A",
       "feature": "property/read: Sockets.MySocket::onConnected",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "Field property access"
     },
     {
@@ -1655,7 +2020,9 @@
       "location": "token=0x6000004",
       "feature": "property/read: System.Diagnostics.Debugger::IsAttached",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1663,7 +2030,9 @@
       "location": "token=0x6000004",
       "feature": "class: System.Diagnostics.Debugger",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1671,7 +2040,9 @@
       "location": "token=0x6000004",
       "feature": "namespace: System.Diagnostics",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1679,7 +2050,9 @@
       "location": "token=0x6000006",
       "feature": "property/read: System.Management.Automation.PowerShell::Streams",
       "expected": false,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef property access"
     },
     {
@@ -1687,7 +2060,9 @@
       "location": "token=0x600009E",
       "feature": "property/read: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE::geoplugin_countryCode",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MethodDef property access"
     },
     {
@@ -1695,7 +2070,9 @@
       "location": "token=0x600009E",
       "feature": "class: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MethodDef property access"
     },
     {
@@ -1703,7 +2080,9 @@
       "location": "token=0x600009E",
       "feature": "namespace: Modulo",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MethodDef property access"
     },
     {
@@ -1711,14 +2090,18 @@
       "location": "token=0x6000007",
       "feature": "api: System.Reflection.Assembly::Load",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_039a6",
       "location": "token=0x600001D",
       "feature": "property/read: StagelessHollow.Arac::Marka",
       "expected": true,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MethodDef method"
     },
     {
@@ -1726,7 +2109,9 @@
       "location": "token=0x600001C",
       "feature": "property/read: StagelessHollow.Arac::Marka",
       "expected": false,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MethodDef method"
     },
     {
@@ -1734,7 +2119,9 @@
       "location": "token=0x6000023",
       "feature": "property/read: System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Task",
       "expected": false,
-      "tags": ["dotnet"],
+      "tags": [
+        "dotnet"
+      ],
       "explanation": "MemberRef method"
     },
     {
@@ -1742,141 +2129,180 @@
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0/myclass_inner0_0",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0/myclass_inner0_1",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_1",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0/myclass_inner_inner",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner_inner",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner1_0",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner1_1",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner0_0",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner0_1",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.OS.Build/VERSION::SdkInt",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.Media.Image/Plane::Buffer",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.Provider.Telephony/Sent/Sent::ContentUri",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.OS.Build::SdkInt",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Plane::Buffer",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Sent::ContentUri",
       "expected": false,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
-
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "count(characteristic(calls to)): 1",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "count(characteristic(calls from)): 9",
       "expected": true,
-      "tags": ["dotnet"]
+      "tags": [
+        "dotnet"
+      ]
     }
   ]
 }

--- a/tests/fixtures/features/static.json
+++ b/tests/fixtures/features/static.json
@@ -634,6 +634,13 @@
     },
     {
       "file": "pma16-01",
+      "location": "function=0x4021B0",
+      "feature": "substring: nope",
+      "expected": false,
+      "explanation": "substring not present"
+    },
+    {
+      "file": "pma16-01",
       "location": "function=0x402F40",
       "feature": "string: /PRACTICALmalwareANALYSIS/i",
       "explanation": "case-insensitive regex"

--- a/tests/fixtures/features/static.json
+++ b/tests/fixtures/features/static.json
@@ -3,141 +3,97 @@
     {
       "key": "mimikatz",
       "path": "data/mimikatz.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "kernel32",
       "path": "data/kernel32.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "kernel32-64",
       "path": "data/kernel32-64.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pma12-04",
       "path": "data/Practical Malware Analysis Lab 12-04.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pma16-01",
       "path": "data/Practical Malware Analysis Lab 16-01.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "7351f.elf",
       "path": "data/7351f8a40c5450557b24622417fc478d.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "055da8e6.elf",
       "path": "data/055da8e6ccfe5a9380231ea04b850e18.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "bb38149.elf",
       "path": "data/bb38149ff4b5c95722b83f24ca27a42b.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "al-khaser x64",
       "path": "data/al-khaser_x64.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "64d9f",
       "path": "data/64d9f7d96b99467f36e22fada623c3bb.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "79abd",
       "path": "data/79abd17391adc6251ecdc58d13d76baf.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "946a9",
       "path": "data/946a99f36a46d335dec080d9a4371940.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "773290",
       "path": "data/773290480d5445f11d3dc1b800728966.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "294b8d",
       "path": "data/294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "a1982",
       "path": "data/a198216798ca38f280dc413f8c57f2c2.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "c91887",
       "path": "data/c91887d861d9bd4a5872249b641bc9f9.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "2bf18d",
       "path": "data/2bf18d0403677378adad9001b1243211.elf_",
-      "tags": [
-        "elf",
-        "static",
-        "symtab"
-      ]
+      "tags": ["elf", "static", "symtab"]
     },
     {
       "key": "2d3edc",
       "path": "data/2d3edc218a90f03089cc01715a9f047f.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "ea2876",
       "path": "data/ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pma01-01.frz",
@@ -158,79 +114,57 @@
     {
       "key": "b9f5b",
       "path": "data/b9f5bd514485fb06da39beff051b9fdc.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "mixed-mode-64",
       "path": "data/dotnet/dnfile-testfiles/mixed-mode/ModuleCode/bin/ModuleCode_amd64.exe",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "hello-world",
       "path": "data/dotnet/dnfile-testfiles/hello-world/hello-world.exe",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "_1c444",
       "path": "data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "_692f",
       "path": "data/dotnet/692f7fd6d198e804d6af98eb9e390d61.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "_0953c",
       "path": "data/0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "_039a6",
       "path": "data/039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "_387f15",
       "path": "data/dotnet/387f15043f0198fd3a637b0758c2b6dde9ead795c3ed70803426fc355731b173.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "nested_typedef",
       "path": "data/dotnet/dd9098ff91717f4906afe9dafdfa2f52.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "nested_typeref",
       "path": "data/dotnet/2c7d60f77812607dec5085973ff76cea.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pma01-01",
       "path": "data/Practical Malware Analysis Lab 01-01.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pma01-01-rd",
@@ -239,119 +173,82 @@
     {
       "key": "pma21-01",
       "path": "data/Practical Malware Analysis Lab 21-01.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "al-khaser x86",
       "path": "data/al-khaser_x86.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "39c05",
       "path": "data/39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "499c2",
       "path": "data/499c2a85f6e8142c3f48d4251c9c7cd6.raw32",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "9324d",
       "path": "data/9324d1a8ae37a36ae560c37448c9705a.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "395eb",
       "path": "data/395eb0ddd99d2c9e37b6d0b73485ee9c.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "a933a",
       "path": "data/a933a1a402775cfa94b6bee0963f4b46.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "bfb9b",
       "path": "data/bfb9b5391a13d0afd787e87ab90f14f5.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "82bf6",
       "path": "data/82BF6347ACF15E5D883715DC289D8A2B.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "pingtaest",
       "path": "data/ping_t\u00e4st.exe_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "3b13b",
       "path": "data/3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_",
-      "tags": [
-        "static"
-      ]
+      "tags": ["static"]
     },
     {
       "key": "2f7f5f",
       "path": "data/2f7f5fb5de175e770d7eae87666f9831.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "b5f052",
       "path": "data/b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "bf7a9c",
       "path": "data/bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "1038a2",
       "path": "data/1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     },
     {
       "key": "3da7c",
       "path": "data/3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_",
-      "tags": [
-        "elf",
-        "static"
-      ]
+      "tags": ["elf", "static"]
     }
   ],
   "features": [
@@ -359,7 +256,6 @@
       "file": "pma12-04",
       "location": "file",
       "feature": "characteristic: embedded pe",
-      "expected": true,
       "explanation": "embedded PE file in resource section",
       "marks": [
         {
@@ -378,7 +274,6 @@
       "file": "2d3edc",
       "location": "file",
       "feature": "characteristic: embedded pe",
-      "expected": true,
       "explanation": "embedded PE file at file scope using file offset addresses",
       "marks": [
         {
@@ -386,28 +281,24 @@
           "mark": "skip",
           "reason": "Python capa has bug extracting embedded PE files at absolute offsets"
         }
-      ],
-      "comment": "Embedded PE at file offset 0x7FB0. Note: vivisect freeze has 0x4091b0 but that's a virtual address mislabeled as file offset."
+      ]
     },
     {
       "file": "mimikatz",
       "location": "file",
       "feature": "string: SCardControl",
-      "expected": true,
       "explanation": "basic UTF-16LE string"
     },
     {
       "file": "mimikatz",
       "location": "file",
       "feature": "string: ACR  > ",
-      "expected": true,
       "explanation": "UTF-16LE encoded strings with unusual characters and trailing spaces"
     },
     {
       "file": "pma12-04",
       "location": "file",
       "feature": "string: winlogon.exe",
-      "expected": true,
       "explanation": "basic ASCII string"
     },
     {
@@ -421,7 +312,6 @@
       "file": "mimikatz",
       "location": "file",
       "feature": "section: .text",
-      "expected": true,
       "explanation": "basic section name"
     },
     {
@@ -435,7 +325,6 @@
       "file": "kernel32",
       "location": "file",
       "feature": "export: BaseThreadInitThunk",
-      "expected": true,
       "explanation": "basic export name"
     },
     {
@@ -449,28 +338,24 @@
       "file": "ea2876",
       "location": "file",
       "feature": "export: vresion.GetFileVersionInfoA",
-      "expected": true,
       "explanation": "forwarded export"
     },
     {
       "file": "mimikatz",
       "location": "file",
       "feature": "import: advapi32.CryptSetHashParam",
-      "expected": true,
       "explanation": "import with DLL prefix"
     },
     {
       "file": "mimikatz",
       "location": "file",
       "feature": "import: CryptSetHashParam",
-      "expected": true,
       "explanation": "import with no DLL prefix"
     },
     {
       "file": "mimikatz",
       "location": "file",
       "feature": "import: cabinet.#11",
-      "expected": true,
       "explanation": "import by ordinal"
     },
     {
@@ -498,7 +383,6 @@
       "file": "mimikatz",
       "location": "function=0x401517",
       "feature": "characteristic: loop",
-      "expected": true,
       "explanation": "loop"
     },
     {
@@ -512,7 +396,6 @@
       "file": "mimikatz",
       "location": "function=0x402EC4",
       "feature": "characteristic: tight loop",
-      "expected": true,
       "explanation": "tight-loop"
     },
     {
@@ -526,7 +409,6 @@
       "file": "mimikatz",
       "location": "function=0x402EC4,bb=0x402F8E",
       "feature": "characteristic: tight loop",
-      "expected": true,
       "explanation": "tight-loop at basic block scope"
     },
     {
@@ -540,7 +422,6 @@
       "file": "mimikatz",
       "location": "function=0x4556E5",
       "feature": "characteristic: stack string",
-      "expected": true,
       "explanation": "stack string (but capa doesn't extract it as a string yet)"
     },
     {
@@ -554,8 +435,7 @@
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "mnemonic: push",
-      "explanation": "basic mnemonic",
-      "expected": true
+      "explanation": "basic mnemonic"
     },
     {
       "file": "mimikatz",
@@ -568,14 +448,12 @@
       "file": "mimikatz",
       "location": "function=0x40105D,bb=0x401073,insn=0x401073",
       "feature": "number: 0xFF",
-      "expected": true,
       "explanation": "number"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D,bb=0x401073,insn=0x401073",
       "feature": "operand[1].number: 0xFF",
-      "expected": true,
       "explanation": "mov eax, 0FFh; instruction operand number"
     },
     {
@@ -589,7 +467,6 @@
       "file": "mimikatz",
       "location": "function=0x40105D,bb=0x4010B0,insn=0x4010B4",
       "feature": "operand[0].offset: 4",
-      "expected": true,
       "explanation": "cmp [esi+4], ebx; instruction operand offset"
     },
     {
@@ -603,21 +480,18 @@
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "number: 0xFF",
-      "expected": true,
       "explanation": "small number"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "number: 0x3136B0",
-      "expected": true,
       "explanation": "large number"
     },
     {
       "file": "mimikatz",
       "location": "function=0x401000",
       "feature": "number: 0x0",
-      "expected": true,
       "explanation": "zero number"
     },
     {
@@ -631,35 +505,30 @@
       "file": "mimikatz",
       "location": "function=0x401553",
       "feature": "number: 0xFFFFFFFF",
-      "expected": true,
       "explanation": "max u32 number"
     },
     {
       "file": "mimikatz",
       "location": "function=0x43e543",
       "feature": "number: 0xFFFFFFF0",
-      "expected": true,
       "explanation": "large u32 number"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "offset: 0x0",
-      "explanation": "cmp [esi], ebx; zero offset",
-      "expected": true
+      "explanation": "cmp [esi], ebx; zero offset"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "offset: 0x4",
-      "explanation": "cmp [esi+4], ebx; simple offset",
-      "expected": true
+      "explanation": "cmp [esi+4], ebx; simple offset"
     },
     {
       "file": "64d9f",
       "location": "function=0x10001510,bb=0x100015B0",
       "feature": "offset: 0x4000",
-      "expected": true,
       "explanation": "regression test for issue #276"
     },
     {
@@ -673,14 +542,12 @@
       "file": "mimikatz",
       "location": "function=0x4011FB",
       "feature": "offset: -0x1",
-      "expected": true,
       "explanation": "movzx ecx, [eax-1]; negative offset"
     },
     {
       "file": "mimikatz",
       "location": "function=0x4011FB",
       "feature": "offset: -0x2",
-      "expected": true,
       "explanation": "cmp [eax-2], cx; negative offset -2"
     },
     {
@@ -708,7 +575,6 @@
       "file": "mimikatz",
       "location": "function=0x402203,bb=0x402221,insn=0x40223C",
       "feature": "offset: 0x4",
-      "expected": true,
       "explanation": "add eax, 4; non-stack register ADD should emit an offset feature, treating eax as a pointer"
     },
     {
@@ -729,21 +595,18 @@
       "file": "mimikatz",
       "location": "function=0x401873,bb=0x4018B2,insn=0x4018C0",
       "feature": "number: 0x2",
-      "expected": true,
       "explanation": "lea ecx, [ebx+2]; should emit Number feature, treating ebx as zero"
     },
     {
       "file": "mimikatz",
       "location": "function=0x403BAC",
       "feature": "api: CryptAcquireContextW",
-      "expected": true,
       "explanation": "basic API feature with trailing W"
     },
     {
       "file": "mimikatz",
       "location": "function=0x403BAC",
       "feature": "api: CryptAcquireContext",
-      "expected": true,
       "explanation": "basic API feature with stripped W"
     },
     {
@@ -756,14 +619,12 @@
     {
       "file": "mimikatz",
       "location": "function=0x4556E5",
-      "feature": "api: LsaQueryInformationPolicy",
-      "expected": true
+      "feature": "api: LsaQueryInformationPolicy"
     },
     {
       "file": "kernel32-64",
       "location": "function=0x180001010",
       "feature": "api: RtlVirtualUnwind",
-      "expected": true,
       "marks": [
         {
           "backend": "idalib",
@@ -776,7 +637,6 @@
       "file": "kernel32-64",
       "location": "function=0x1800202B0",
       "feature": "api: RtlCaptureContext",
-      "expected": true,
       "explanation": "API called via thunk",
       "marks": [
         {
@@ -795,7 +655,6 @@
       "file": "al-khaser x64",
       "location": "function=0x14004B4F0",
       "feature": "api: __vcrt_GetModuleHandle",
-      "expected": true,
       "explanation": "API called via nested thunks",
       "marks": [
         {
@@ -814,49 +673,42 @@
       "file": "mimikatz",
       "location": "function=0x40B3C6",
       "feature": "api: LocalFree",
-      "expected": true,
       "explanation": "tail call to API via jmp"
     },
     {
       "file": "c91887",
       "location": "function=0x40156F",
       "feature": "api: CloseClipboard",
-      "expected": true,
       "explanation": "tail call to API via jmp"
     },
     {
       "file": "c91887",
       "location": "function=0x401A77",
       "feature": "api: CreatePipe",
-      "expected": true,
       "explanation": "API is present"
     },
     {
       "file": "c91887",
       "location": "function=0x401A77",
       "feature": "api: kernel32.CreatePipe",
-      "expected": true,
       "explanation": "API is present, and DLL name is ignored"
     },
     {
       "file": "c91887",
       "location": "function=0x401A77",
       "feature": "api: CreatePipe",
-      "expected": true,
       "explanation": "API resolved from call to GetProcAddress"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "string: SCardControl",
-      "expected": true,
       "explanation": "basic string"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
       "feature": "string: ACR  > ",
-      "expected": true,
       "explanation": "basic string with trailing whitespace"
     },
     {
@@ -870,7 +722,6 @@
       "file": "773290",
       "location": "function=0x140001140",
       "feature": "string: %s:\\\\OfficePackagesForWDAG",
-      "expected": true,
       "explanation": "string with escaping characters"
     },
     {
@@ -884,55 +735,47 @@
       "file": "pma16-01",
       "location": "function=0x4021B0",
       "feature": "substring: HTTP/1.0",
-      "expected": true,
       "explanation": "basic substring"
     },
     {
       "file": "pma16-01",
       "location": "function=0x402F40",
       "feature": "string: /PRACTICALmalwareANALYSIS/i",
-      "expected": true,
       "explanation": "case-insensitive regex"
     },
     {
       "file": "pma16-01",
       "location": "function=0x402F40",
       "feature": "string: /www.*/",
-      "expected": true,
       "explanation": "simple regex prefix match"
     },
     {
       "file": "pma16-01",
       "location": "function=0x402F40",
-      "feature": "substring: practicalmalwareanalysis.com",
-      "expected": true
+      "feature": "substring: practicalmalwareanalysis.com"
     },
     {
       "file": "mimikatz",
       "location": "function=0x44EDEF",
       "feature": "string: INPUTEVENT",
-      "expected": true,
       "explanation": "string referenced via a pointer"
     },
     {
       "file": "mimikatz",
       "location": "function=0x46D6CE",
       "feature": "string: (null)",
-      "expected": true,
       "explanation": "string referenced via direct memory reference"
     },
     {
       "file": "mimikatz",
       "location": "function=0x401517",
       "feature": "bytes: CA 3B 0E 00 00 00 F8 AF 47",
-      "expected": true,
       "explanation": "basic bytes"
     },
     {
       "file": "mimikatz",
       "location": "function=0x404414",
       "feature": "bytes: 01 80 00 00 40 EA 47 00",
-      "expected": true,
       "explanation": "basic bytes, which are a pointer"
     },
     {
@@ -967,7 +810,6 @@
       "file": "mimikatz",
       "location": "function=0x410DFC",
       "feature": "characteristic: nzxor",
-      "expected": true,
       "explanation": "should extract nzxor characteristic, including from xorps SSE instructions"
     },
     {
@@ -987,8 +829,7 @@
     {
       "file": "kernel32-64",
       "location": "function=0x1800017D0",
-      "feature": "characteristic: peb access",
-      "expected": true
+      "feature": "characteristic: peb access"
     },
     {
       "file": "mimikatz",
@@ -999,8 +840,7 @@
     {
       "file": "kernel32-64",
       "location": "function=0x180001068",
-      "feature": "characteristic: gs access",
-      "expected": true
+      "feature": "characteristic: gs access"
     },
     {
       "file": "mimikatz",
@@ -1011,56 +851,47 @@
     {
       "file": "mimikatz",
       "location": "function=0x410DFC,bb=0x410F05,insn=0x410F0B",
-      "feature": "characteristic: nzxor",
-      "expected": true
+      "feature": "characteristic: nzxor"
     },
     {
       "file": "mimikatz",
       "location": "function=0x410DFC,bb=0x410F05,insn=0x410F12",
-      "feature": "characteristic: nzxor",
-      "expected": true
+      "feature": "characteristic: nzxor"
     },
     {
       "file": "kernel32-64",
       "location": "function=0x1800017D0,bb=0x1800018AD,insn=0x1800018AD",
-      "feature": "characteristic: peb access",
-      "expected": true
+      "feature": "characteristic: peb access"
     },
     {
       "file": "kernel32-64",
       "location": "function=0x180001068,bb=0x18000118D,insn=0x180001197",
-      "feature": "characteristic: gs access",
-      "expected": true
+      "feature": "characteristic: gs access"
     },
     {
       "file": "kernel32-64",
       "location": "function=0x180001068,bb=0x180001269,insn=0x18000127F",
-      "feature": "characteristic: gs access",
-      "expected": true
+      "feature": "characteristic: gs access"
     },
     {
       "file": "kernel32",
       "location": "function=0x7DD70E00,bb=0x7DD70E00,insn=0x7DD70E05",
-      "feature": "characteristic: fs access",
-      "expected": true
+      "feature": "characteristic: fs access"
     },
     {
       "file": "kernel32",
       "location": "function=0x7DD70E00,bb=0x7DD70E25,insn=0x7DD70E2D",
-      "feature": "characteristic: fs access",
-      "expected": true
+      "feature": "characteristic: fs access"
     },
     {
       "file": "kernel32",
       "location": "function=0x7DD70E00,bb=0x7DD70FCB,insn=0x7DD70FCB",
-      "feature": "characteristic: fs access",
-      "expected": true
+      "feature": "characteristic: fs access"
     },
     {
       "file": "a1982",
       "location": "function=0x4014D0",
-      "feature": "characteristic: cross section flow",
-      "expected": true
+      "feature": "characteristic: cross section flow"
     },
     {
       "file": "kernel32-64",
@@ -1078,8 +909,7 @@
     {
       "file": "mimikatz",
       "location": "function=0x40640e",
-      "feature": "characteristic: recursive call",
-      "expected": true
+      "feature": "characteristic: recursive call"
     },
     {
       "file": "mimikatz",
@@ -1091,8 +921,7 @@
     {
       "file": "mimikatz",
       "location": "function=0x4175FF",
-      "feature": "characteristic: indirect call",
-      "expected": true
+      "feature": "characteristic: indirect call"
     },
     {
       "file": "mimikatz",
@@ -1103,8 +932,7 @@
     {
       "file": "mimikatz",
       "location": "function=0x4556E5",
-      "feature": "characteristic: calls from",
-      "expected": true
+      "feature": "characteristic: calls from"
     },
     {
       "file": "mimikatz",
@@ -1115,14 +943,12 @@
     {
       "file": "mimikatz",
       "location": "function=0x40105D",
-      "feature": "characteristic: calls to",
-      "expected": true
+      "feature": "characteristic: calls to"
     },
     {
       "file": "ea2876",
       "location": "file",
-      "feature": "characteristic: forwarded export",
-      "expected": true
+      "feature": "characteristic: forwarded export"
     },
     {
       "file": "mimikatz",
@@ -1134,27 +960,23 @@
     {
       "file": "mimikatz",
       "location": "function=0x40105D,bb=0x401089,insn=0x40108E",
-      "feature": "characteristic: calls from",
-      "expected": true
+      "feature": "characteristic: calls from"
     },
     {
       "file": "mimikatz",
       "location": "function=0x4175FF,bb=0x41761B,insn=0x417620",
-      "feature": "characteristic: indirect call",
-      "expected": true
+      "feature": "characteristic: indirect call"
     },
     {
       "file": "pma16-01",
       "location": "file",
       "feature": "function-name: __aulldiv",
-      "expected": true,
       "explanation": "recognize function name via FLIRT signatures"
     },
     {
       "file": "pma16-01",
       "location": "file",
-      "feature": "os: windows",
-      "expected": true
+      "feature": "os: windows"
     },
     {
       "file": "pma16-01",
@@ -1165,28 +987,24 @@
     {
       "file": "mimikatz",
       "location": "file",
-      "feature": "os: windows",
-      "expected": true
+      "feature": "os: windows"
     },
     {
       "file": "pma16-01",
       "location": "function=0x401100",
       "feature": "os: windows",
-      "expected": true,
       "explanation": "OS available at function scope"
     },
     {
       "file": "pma16-01",
       "location": "function=0x401100,bb=0x401130",
       "feature": "os: windows",
-      "expected": true,
       "explanation": "OS available at basic block scope"
     },
     {
       "file": "pma16-01",
       "location": "file",
-      "feature": "arch: i386",
-      "expected": true
+      "feature": "arch: i386"
     },
     {
       "file": "pma16-01",
@@ -1197,28 +1015,24 @@
     {
       "file": "mimikatz",
       "location": "file",
-      "feature": "arch: i386",
-      "expected": true
+      "feature": "arch: i386"
     },
     {
       "file": "pma16-01",
       "location": "function=0x401100",
       "feature": "arch: i386",
-      "expected": true,
       "explanation": "arch available at function scope"
     },
     {
       "file": "pma16-01",
       "location": "function=0x401100,bb=0x401130",
       "feature": "arch: i386",
-      "expected": true,
       "explanation": "arch available at basic blockscope"
     },
     {
       "file": "pma16-01",
       "location": "file",
-      "feature": "format: pe",
-      "expected": true
+      "feature": "format: pe"
     },
     {
       "file": "pma16-01",
@@ -1229,21 +1043,18 @@
     {
       "file": "mimikatz",
       "location": "file",
-      "feature": "format: pe",
-      "expected": true
+      "feature": "format: pe"
     },
     {
       "file": "pma16-01",
       "location": "function=0x401100",
       "feature": "format: pe",
-      "expected": true,
       "explanation": "format available at function scope"
     },
     {
       "file": "7351f.elf",
       "location": "file",
-      "feature": "os: linux",
-      "expected": true
+      "feature": "os: linux"
     },
     {
       "file": "7351f.elf",
@@ -1254,8 +1065,7 @@
     {
       "file": "7351f.elf",
       "location": "file",
-      "feature": "format: elf",
-      "expected": true
+      "feature": "format: elf"
     },
     {
       "file": "7351f.elf",
@@ -1272,116 +1082,106 @@
     {
       "file": "7351f.elf",
       "location": "file",
-      "feature": "arch: amd64",
-      "expected": true
+      "feature": "arch: amd64"
     },
     {
       "file": "7351f.elf",
       "location": "function=0x408753",
-      "feature": "string: /dev/null",
-      "expected": true
+      "feature": "string: /dev/null"
     },
     {
       "file": "7351f.elf",
       "location": "function=0x408753,bb=0x408781",
       "feature": "api: open",
-      "expected": true,
       "explanation": "API from ELF import"
     },
     {
       "file": "055da8e6.elf",
       "location": "file",
       "feature": "import: puts",
-      "expected": true,
       "explanation": "ELF import promoted from elffile feature tests"
     },
     {
       "file": "055da8e6.elf",
       "location": "file",
       "feature": "section: .text",
-      "expected": true,
       "explanation": "ELF section promoted from primary presence fixture"
     },
     {
       "file": "bb38149.elf",
       "location": "file",
       "feature": "import: __android_log_print",
-      "expected": true,
       "explanation": "stripped ELF import promoted from elffile feature tests"
     },
     {
       "file": "bb38149.elf",
       "location": "file",
       "feature": "export: Java_o_ac_a",
-      "expected": true,
       "explanation": "stripped ELF export promoted from elffile feature tests"
     },
     {
       "file": "bb38149.elf",
       "location": "file",
       "feature": "section: .dynamic",
-      "expected": true,
-      "explanation": "stripped ELF section promoted into the shared presence fixture"
+      "explanation": "stripped ELF section promoted into the shared presence fixture",
+      "marks": [
+        {
+          "backend": "idalib",
+          "mark": "xfail",
+          "reason": "IDA maps this stripped ELF from program headers, not section headers, so .dynamic is subsumed into a LOAD segment"
+        }
+      ]
     },
     {
       "file": "79abd",
       "location": "function=0x10002385,bb=0x10002385",
-      "feature": "characteristic: call $+5",
-      "expected": true
+      "feature": "characteristic: call $+5"
     },
     {
       "file": "946a9",
       "location": "function=0x10001510,bb=0x100015c0",
-      "feature": "characteristic: call $+5",
-      "expected": true
+      "feature": "characteristic: call $+5"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __GI_connect",
-      "expected": true,
       "explanation": "API from symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: connect",
-      "expected": true,
       "explanation": "API from symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __libc_connect",
-      "expected": true,
       "explanation": "API from symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __GI_connect",
-      "expected": true,
       "explanation": "function name from symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: connect",
-      "expected": true,
       "explanation": "function name from symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __libc_connect",
-      "expected": true,
       "explanation": "function name from symbol table alternative name"
     },
     {
       "file": "mimikatz",
       "location": "function=0x401000,bb=0x401000",
       "feature": "basic blocks: x",
-      "expected": true,
       "explanation": "basic block feature emitted"
     },
     {
@@ -1395,7 +1195,6 @@
       "file": "mimikatz",
       "location": "function=0x40E5C2",
       "feature": "count(basic blocks): 7",
-      "expected": true,
       "explanation": "7 basic blocks in function",
       "marks": [
         {
@@ -1409,14 +1208,12 @@
       "file": "mimikatz",
       "location": "function=0x4702FD",
       "feature": "count(characteristic(calls from)): 0",
-      "expected": true,
       "explanation": "function has no calls"
     },
     {
       "file": "mimikatz",
       "location": "function=0x40E5C2",
       "feature": "count(characteristic(calls from)): 3",
-      "expected": true,
       "explanation": "function has 3 calls",
       "marks": [
         {
@@ -1430,7 +1227,6 @@
       "file": "mimikatz",
       "location": "function=0x4556E5",
       "feature": "count(characteristic(calls to)): 0",
-      "expected": true,
       "explanation": "function has no callers",
       "marks": [
         {
@@ -1444,7 +1240,6 @@
       "file": "mimikatz",
       "location": "function=0x40B1F1",
       "feature": "count(characteristic(calls to)): 3",
-      "expected": true,
       "explanation": "function has 3 callers",
       "marks": [
         {
@@ -1458,355 +1253,243 @@
       "file": "mimikatz",
       "location": "function=0x4702FD",
       "feature": "count(characteristic(calls from)): 0",
-      "expected": true,
-      "tags": [
-        "ghidra"
-      ],
       "explanation": "Ghidra: function has no calls"
     },
     {
       "file": "mimikatz",
       "location": "function=0x401bf1",
       "feature": "count(characteristic(calls to)): 2",
-      "expected": true,
-      "tags": [
-        "ghidra"
-      ],
       "explanation": "Ghidra: function has 2 callers"
     },
     {
       "file": "mimikatz",
       "location": "function=0x401000",
       "feature": "count(basic blocks): 3",
-      "expected": true,
-      "tags": [
-        "ghidra"
-      ],
       "explanation": "Ghidra: 3 basic blocks in function"
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "arch: i386",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "arch: amd64",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "arch: amd64",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "arch: i386",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "mixed-mode-64",
       "location": "file",
       "feature": "characteristic: mixed mode",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "characteristic: mixed mode",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "os: any",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "format: pe",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "b9f5b",
       "location": "file",
       "feature": "format: dotnet",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::Main",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::ctor",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "function-name: HelloWorld::cctor",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "string: Hello World!",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "class: HelloWorld",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "class: System.Console",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "namespace: System.Diagnostics",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "function=0x250",
       "feature": "string: Hello World!",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x252",
       "feature": "string: Hello World!",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x257",
       "feature": "class: System.Console",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "function=0x250,bb=0x250,insn=0x257",
       "feature": "namespace: System",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "function=0x250",
       "feature": "api: System.Console::WriteLine",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "hello-world",
       "location": "file",
       "feature": "import: System.Console::WriteLine",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "string: SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "string: get_IsAlive",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: gdi32.CreateCompatibleBitmap",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: CreateCompatibleBitmap",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "file",
       "feature": "import: gdi32::CreateCompatibleBitmap",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "api: GetWindowDC",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0xCC0020",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "characteristic: calls to",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x6000018",
       "feature": "characteristic: calls to",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "characteristic: calls from",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600000F",
       "feature": "characteristic: calls from",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0x0",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68",
       "feature": "number: 0x1",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_692f",
       "location": "token=0x6000004",
       "feature": "api: System.Linq.Enumerable::First",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "generic method"
     },
     {
@@ -1814,235 +1497,167 @@
       "location": "token=0x6000004",
       "feature": "property: System.Linq.Enumerable::First",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "generic method"
     },
     {
       "file": "_692f",
       "location": "token=0x6000004",
       "feature": "namespace: System.Linq",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "generic method"
     },
     {
       "file": "_692f",
       "location": "token=0x6000004",
       "feature": "class: System.Linq.Enumerable",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "generic method"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000020",
       "feature": "namespace: Reqss",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "ldftn"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000020",
       "feature": "class: Reqss.Reqss",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "ldftn"
     },
     {
       "file": "_1c444",
       "location": "function=0x1F59,bb=0x1F59,insn=0x1F5B",
       "feature": "characteristic: unmanaged call",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x2544",
       "feature": "characteristic: unmanaged call",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x6000088",
       "feature": "characteristic: unmanaged call",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "same as above but using token instead of function"
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
       "feature": "api: System.Drawing.Image::FromHbitmap",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "function=0x1F68,bb=0x1F68,insn=0x1FF9",
       "feature": "api: FromHbitmap",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600002B",
       "feature": "property/read: System.IO.FileInfo::Length",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x600002B",
       "feature": "property: System.IO.FileInfo::Length",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000081",
       "feature": "api: System.Diagnostics.Process::Start",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::UseShellExecute",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::WorkingDirectory",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000081",
       "feature": "property/write: System.Diagnostics.ProcessStartInfo::FileName",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x6000087",
       "feature": "property/write: Sockets.MySocket::reConnectionDelay",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "Field property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x600008A",
       "feature": "property/write: Sockets.MySocket::isConnected",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "Field property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x600008A",
       "feature": "class: Sockets.MySocket",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "Field property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x600008A",
       "feature": "namespace: Sockets",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "Field property access"
     },
     {
       "file": "_1c444",
       "location": "token=0x600008A",
       "feature": "property/read: Sockets.MySocket::onConnected",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "Field property access"
     },
     {
       "file": "_0953c",
       "location": "token=0x6000004",
       "feature": "property/read: System.Diagnostics.Debugger::IsAttached",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_0953c",
       "location": "token=0x6000004",
       "feature": "class: System.Diagnostics.Debugger",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_0953c",
       "location": "token=0x6000004",
       "feature": "namespace: System.Diagnostics",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
@@ -2050,58 +1665,41 @@
       "location": "token=0x6000006",
       "feature": "property/read: System.Management.Automation.PowerShell::Streams",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef property access"
     },
     {
       "file": "_387f15",
       "location": "token=0x600009E",
       "feature": "property/read: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE::geoplugin_countryCode",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MethodDef property access"
     },
     {
       "file": "_387f15",
       "location": "token=0x600009E",
       "feature": "class: Modulo.IqQzcRDvSTulAhyLtZHqyeYGgaXGbuLwhxUKXYmhtnOmgpnPJDTSIPhYPpnE",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MethodDef property access"
     },
     {
       "file": "_387f15",
       "location": "token=0x600009E",
       "feature": "namespace: Modulo",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MethodDef property access"
     },
     {
       "file": "_039a6",
       "location": "token=0x6000007",
       "feature": "api: System.Reflection.Assembly::Load",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_039a6",
       "location": "token=0x600001D",
       "feature": "property/read: StagelessHollow.Arac::Marka",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MethodDef method"
     },
     {
@@ -2109,9 +1707,7 @@
       "location": "token=0x600001C",
       "feature": "property/read: StagelessHollow.Arac::Marka",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MethodDef method"
     },
     {
@@ -2119,190 +1715,136 @@
       "location": "token=0x6000023",
       "feature": "property/read: System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Task",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ],
+      "tags": ["dotnet"],
       "explanation": "MemberRef method"
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0/myclass_inner0_0",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer0/myclass_inner0_1",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_1",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: mynamespace.myclass_outer1/myclass_inner1_0/myclass_inner_inner",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner_inner",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner1_0",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner1_1",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner0_0",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typedef",
       "location": "file",
       "feature": "class: myclass_inner0_1",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.OS.Build/VERSION::SdkInt",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.Media.Image/Plane::Buffer",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.Provider.Telephony/Sent/Sent::ContentUri",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Android.OS.Build::SdkInt",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Plane::Buffer",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "nested_typeref",
       "location": "file",
       "feature": "import: Sent::ContentUri",
       "expected": false,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "count(characteristic(calls to)): 1",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     },
     {
       "file": "_1c444",
       "location": "token=0x600001D",
       "feature": "count(characteristic(calls from)): 9",
-      "expected": true,
-      "tags": [
-        "dotnet"
-      ]
+      "tags": ["dotnet"]
     }
   ]
 }

--- a/tests/fixtures/features/static.json
+++ b/tests/fixtures/features/static.json
@@ -624,7 +624,14 @@
       "location": "function=0x404970,bb=0x404970,insn=0x40499F",
       "feature": "string: \r\n\u0000:ht",
       "expected": false,
-      "explanation": "regression test for issue #1271: should not extract overlapping string spanning a NUL byte"
+      "explanation": "regression test for issue #1271: should not extract overlapping string spanning a NUL byte",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "basic blocks do not align with Ghidra analysis"
+        }
+      ]
     },
     {
       "file": "pma16-01",
@@ -1048,37 +1055,79 @@
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __GI_connect",
-      "explanation": "API from ELF symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: connect",
-      "explanation": "API from ELF symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __libc_connect",
-      "explanation": "API from ELF symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __GI_connect",
-      "explanation": "function name from ELF symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: connect",
-      "explanation": "function name from ELF symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __libc_connect",
-      "explanation": "function name from ELF symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name",
+      "marks": [
+        {
+          "backend": "ghidra",
+          "mark": "xfail",
+          "reason": "Ghidra does not extract ELF symbol table alternative names"
+        }
+      ]
     },
     {
       "file": "mimikatz",

--- a/tests/fixtures/features/static.json
+++ b/tests/fixtures/features/static.json
@@ -83,7 +83,7 @@
     {
       "key": "2bf18d",
       "path": "data/2bf18d0403677378adad9001b1243211.elf_",
-      "tags": ["elf", "static", "symtab"]
+      "tags": ["elf", "static"]
     },
     {
       "key": "2d3edc",
@@ -94,22 +94,6 @@
       "key": "ea2876",
       "path": "data/ea2876e9175410b6f6719f80ee44b9553960758c7d0f7bed73c0fe9a78d8e669.dll_",
       "tags": ["static"]
-    },
-    {
-      "key": "pma01-01.frz",
-      "path": "fixtures/freeze/Practical Malware Analysis Lab 01-01.dll_.frz"
-    },
-    {
-      "key": "009c2377.frz",
-      "path": "fixtures/freeze/009c2377b67997b0da1579f4bbc822c1.exe_.frz"
-    },
-    {
-      "key": "055da8e6.frz",
-      "path": "fixtures/freeze/055da8e6ccfe5a9380231ea04b850e18.elf_.frz"
-    },
-    {
-      "key": "034b7231.frz",
-      "path": "fixtures/freeze/034b7231a49387604e81a5a5d2fe7e08f6982c418a28b719d2faace3c312ebb5.exe_.frz"
     },
     {
       "key": "b9f5b",
@@ -160,95 +144,6 @@
       "key": "nested_typeref",
       "path": "data/dotnet/2c7d60f77812607dec5085973ff76cea.dll_",
       "tags": ["static"]
-    },
-    {
-      "key": "pma01-01",
-      "path": "data/Practical Malware Analysis Lab 01-01.dll_",
-      "tags": ["static"]
-    },
-    {
-      "key": "pma01-01-rd",
-      "path": "data/rd/Practical Malware Analysis Lab 01-01.dll_.json"
-    },
-    {
-      "key": "pma21-01",
-      "path": "data/Practical Malware Analysis Lab 21-01.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "al-khaser x86",
-      "path": "data/al-khaser_x86.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "39c05",
-      "path": "data/39c05b15e9834ac93f206bc114d0a00c357c888db567ba8f5345da0529cbed41.dll_",
-      "tags": ["static"]
-    },
-    {
-      "key": "499c2",
-      "path": "data/499c2a85f6e8142c3f48d4251c9c7cd6.raw32",
-      "tags": ["static"]
-    },
-    {
-      "key": "9324d",
-      "path": "data/9324d1a8ae37a36ae560c37448c9705a.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "395eb",
-      "path": "data/395eb0ddd99d2c9e37b6d0b73485ee9c.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "a933a",
-      "path": "data/a933a1a402775cfa94b6bee0963f4b46.dll_",
-      "tags": ["static"]
-    },
-    {
-      "key": "bfb9b",
-      "path": "data/bfb9b5391a13d0afd787e87ab90f14f5.dll_",
-      "tags": ["static"]
-    },
-    {
-      "key": "82bf6",
-      "path": "data/82BF6347ACF15E5D883715DC289D8A2B.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "pingtaest",
-      "path": "data/ping_t\u00e4st.exe_",
-      "tags": ["static"]
-    },
-    {
-      "key": "3b13b",
-      "path": "data/3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_",
-      "tags": ["static"]
-    },
-    {
-      "key": "2f7f5f",
-      "path": "data/2f7f5fb5de175e770d7eae87666f9831.elf_",
-      "tags": ["elf", "static"]
-    },
-    {
-      "key": "b5f052",
-      "path": "data/b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_",
-      "tags": ["elf", "static"]
-    },
-    {
-      "key": "bf7a9c",
-      "path": "data/bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_",
-      "tags": ["elf", "static"]
-    },
-    {
-      "key": "1038a2",
-      "path": "data/1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_",
-      "tags": ["elf", "static"]
-    },
-    {
-      "key": "3da7c",
-      "path": "data/3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_",
-      "tags": ["elf", "static"]
     }
   ],
   "features": [
@@ -1146,37 +1041,37 @@
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __GI_connect",
-      "explanation": "API from symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: connect",
-      "explanation": "API from symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4027b3,bb=0x402861,insn=0x40286d",
       "feature": "api: __libc_connect",
-      "explanation": "API from symbol table alternative name"
+      "explanation": "API from ELF symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __GI_connect",
-      "explanation": "function name from symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: connect",
-      "explanation": "function name from symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name"
     },
     {
       "file": "2bf18d",
       "location": "function=0x4088a4",
       "feature": "function-name: __libc_connect",
-      "explanation": "function name from symbol table alternative name"
+      "explanation": "function name from ELF symbol table alternative name"
     },
     {
       "file": "mimikatz",

--- a/tests/fixtures/features/vmray.json
+++ b/tests/fixtures/features/vmray.json
@@ -1,0 +1,233 @@
+{
+  "files": [
+    {
+      "key": "93b2d1-vmray",
+      "path": "data/dynamic/vmray/93b2d1840566f45fab674ebc79a9d19c88993bcb645e0357f3cb584d16e7c795_min_archive.zip",
+      "tags": [
+        "dynamic",
+        "vmray"
+      ]
+    },
+    {
+      "key": "2f8a79-vmray",
+      "path": "data/dynamic/vmray/2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip",
+      "tags": [
+        "dynamic",
+        "vmray"
+      ]
+    },
+    {
+      "key": "eb1287-vmray",
+      "path": "data/dynamic/vmray/eb12873c0ce3e9ea109c2a447956cbd10ca2c3e86936e526b2c6e28764999f21_min_archive.zip",
+      "tags": [
+        "dynamic",
+        "vmray"
+      ]
+    }
+  ],
+  "features": [
+    {
+      "file": "93b2d1-vmray",
+      "location": "file",
+      "feature": "string: api.%x%x.%s"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "file",
+      "feature": "string: \\Program Files\\WindowsApps\\does_not_exist",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "file",
+      "feature": "import: GetAddrInfoW"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "file",
+      "feature": "import: GetAddrInfo"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2180",
+      "feature": "api: LoadLibraryExA"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2180",
+      "feature": "api: LoadLibraryEx"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420",
+      "feature": "api: GetAddrInfoW"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420",
+      "feature": "api: GetAddrInfo"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420",
+      "feature": "api: DoesNotExist",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2361",
+      "feature": "api: GetAddrInfoW"
+    },
+    {
+      "file": "eb1287-vmray",
+      "location": "process=(4968:0),thread=5992,call=10981",
+      "feature": "api: CreateMutexW"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10323",
+      "feature": "string: raw.githubusercontent.com"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2180,call=267",
+      "feature": "string: C:\\Users\\WhuOXYsD\\Desktop\\filename.exe",
+      "comment": "backslashes in paths; see #2428"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2180,call=267",
+      "feature": "string: C:\\\\Users\\\\WhuOXYsD\\\\Desktop\\\\filename.exe",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "string: Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "string: Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Policies\\\\System",
+      "expected": false
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2358",
+      "feature": "number: 0x1000",
+      "comment": "VirtualAlloc(4096, 4)"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2358",
+      "feature": "number: 0x4"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "number: 0x80000001",
+      "comment": "RegOpenKeyExW(Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System, 0, 131078); see #2"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "number: 0x0"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "number: 0x20006"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2397",
+      "feature": "number: 0x80000001",
+      "comment": "RegOpenKeyExW call 2397 (same parameters)"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2397",
+      "feature": "number: 0x0"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2397",
+      "feature": "number: 0x20006"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "file",
+      "feature": "count(import(GetAddrInfoW)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420",
+      "feature": "count(api(free)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420",
+      "feature": "count(api(GetAddrInfoW)): 5"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2345",
+      "feature": "count(api(free)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2345",
+      "feature": "count(api(GetAddrInfoW)): 0"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=2361",
+      "feature": "count(api(GetAddrInfoW)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10323",
+      "feature": "count(string(raw.githubusercontent.com)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10323",
+      "feature": "count(string(non_existant)): 0"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10315",
+      "feature": "count(number(0x1000)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10315",
+      "feature": "count(number(0x4)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2420,call=10315",
+      "feature": "count(number(0x194)): 0"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "count(number(0x80000001)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "count(number(0x0)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "count(number(0x20006)): 1"
+    },
+    {
+      "file": "93b2d1-vmray",
+      "location": "process=(2176:0),thread=2204,call=2395",
+      "feature": "count(number(0xf423f)): 0"
+    }
+  ]
+}

--- a/tests/fixtures/features/vmray.json
+++ b/tests/fixtures/features/vmray.json
@@ -3,26 +3,12 @@
     {
       "key": "93b2d1-vmray",
       "path": "data/dynamic/vmray/93b2d1840566f45fab674ebc79a9d19c88993bcb645e0357f3cb584d16e7c795_min_archive.zip",
-      "tags": [
-        "dynamic",
-        "vmray"
-      ]
-    },
-    {
-      "key": "2f8a79-vmray",
-      "path": "data/dynamic/vmray/2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip",
-      "tags": [
-        "dynamic",
-        "vmray"
-      ]
+      "tags": ["dynamic", "vmray"]
     },
     {
       "key": "eb1287-vmray",
       "path": "data/dynamic/vmray/eb12873c0ce3e9ea109c2a447956cbd10ca2c3e86936e526b2c6e28764999f21_min_archive.zip",
-      "tags": [
-        "dynamic",
-        "vmray"
-      ]
+      "tags": ["dynamic", "vmray"]
     }
   ],
   "features": [

--- a/tests/test_binexport_accessors.py
+++ b/tests/test_binexport_accessors.py
@@ -15,8 +15,8 @@
 
 import re
 import logging
-from pathlib import Path
 from typing import Any
+from pathlib import Path
 
 import pytest
 import fixtures
@@ -58,7 +58,6 @@ from capa.features.extractors.binexport2.arch.arm.helpers import is_stack_regist
 from capa.features.extractors.binexport2.arch.intel.helpers import get_operand_phrase_info
 
 logger = logging.getLogger(__name__)
-
 
 
 # found via https://www.virustotal.com/gui/search/type%253Aelf%2520and%2520size%253A1.2kb%252B%2520and%2520size%253A1.4kb-%2520and%2520tag%253Aarm%2520and%2520not%2520tag%253Arelocatable%2520and%2520tag%253A64bits/files
@@ -622,7 +621,9 @@ def test_pattern_matching_not_stack():
     assert match_address_with_be2(BE2_EXTRACTOR_687, queries, 0x107918) is None
 
 
-BE2_EXTRACTOR_MIMI = fixtures.get_binexport_extractor(fixtures.CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
+BE2_EXTRACTOR_MIMI = fixtures.get_binexport_extractor(
+    fixtures.CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport"
+)
 
 
 def test_pattern_matching_x86():

--- a/tests/test_binexport_accessors.py
+++ b/tests/test_binexport_accessors.py
@@ -15,11 +15,13 @@
 
 import re
 import logging
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 import pytest
 import fixtures
+
+CD = Path(__file__).resolve().parent
 from google.protobuf.json_format import ParseDict
 
 import capa.features.extractors.binexport2.helpers
@@ -57,7 +59,6 @@ from capa.features.extractors.binexport2.arch.intel.helpers import get_operand_p
 
 logger = logging.getLogger(__name__)
 
-CD = Path(__file__).resolve().parent
 
 
 # found via https://www.virustotal.com/gui/search/type%253Aelf%2520and%2520size%253A1.2kb%252B%2520and%2520size%253A1.4kb-%2520and%2520tag%253Aarm%2520and%2520not%2520tag%253Arelocatable%2520and%2520tag%253A64bits/files
@@ -621,7 +622,7 @@ def test_pattern_matching_not_stack():
     assert match_address_with_be2(BE2_EXTRACTOR_687, queries, 0x107918) is None
 
 
-BE2_EXTRACTOR_MIMI = fixtures.get_binexport_extractor(CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
+BE2_EXTRACTOR_MIMI = fixtures.get_binexport_extractor(fixtures.CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
 
 
 def test_pattern_matching_x86():

--- a/tests/test_binexport_features.py
+++ b/tests/test_binexport_features.py
@@ -14,407 +14,21 @@
 
 from typing import cast
 
-import pytest
 import fixtures
+import pytest
 
-import capa.features.file
-import capa.features.insn
 import capa.features.common
-from capa.features.common import (
-    OS,
-    OS_LINUX,
-    ARCH_I386,
-    FORMAT_PE,
-    ARCH_AMD64,
-    FORMAT_ELF,
-    OS_ANDROID,
-    OS_WINDOWS,
-    ARCH_AARCH64,
-    Arch,
-    Format,
-)
 
-FEATURE_PRESENCE_TESTS_BE2_ELF_AARCH64 = sorted(
-    [
-        # file/string
-        (
-            "687e79.ghidra.be2",
-            "file",
-            capa.features.common.String("AppDataService start"),
-            True,
-        ),
-        ("687e79.ghidra.be2", "file", capa.features.common.String("nope"), False),
-        # file/sections
-        ("687e79.ghidra.be2", "file", capa.features.file.Section(".text"), True),
-        ("687e79.ghidra.be2", "file", capa.features.file.Section(".nope"), False),
-        # file/exports
-        (
-            "687e79.ghidra.be2",
-            "file",
-            capa.features.file.Export("android::clearDir"),
-            "xfail: name demangling is not implemented",
-        ),
-        ("687e79.ghidra.be2", "file", capa.features.file.Export("nope"), False),
-        # file/imports
-        ("687e79.ghidra.be2", "file", capa.features.file.Import("fopen"), True),
-        ("687e79.ghidra.be2", "file", capa.features.file.Import("exit"), True),
-        (
-            "687e79.ghidra.be2",
-            "file",
-            capa.features.file.Import("_ZN7android10IInterfaceD0Ev"),
-            True,
-        ),
-        ("687e79.ghidra.be2", "file", capa.features.file.Import("nope"), False),
-        # function/characteristic(loop)
-        (
-            "687e79.ghidra.be2",
-            "function=0x1056c0",
-            capa.features.common.Characteristic("loop"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x1075c0",
-            capa.features.common.Characteristic("loop"),
-            False,
-        ),
-        # bb/characteristic(tight loop)
-        (
-            "d1e650.ghidra.be2",
-            "function=0x114af4",
-            capa.features.common.Characteristic("tight loop"),
-            True,
-        ),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x118F1C",
-            capa.features.common.Characteristic("tight loop"),
-            True,
-        ),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x11464c",
-            capa.features.common.Characteristic("tight loop"),
-            False,
-        ),
-        # bb/characteristic(stack string)
-        (
-            "687e79.ghidra.be2",
-            "function=0x0",
-            capa.features.common.Characteristic("stack string"),
-            "xfail: not implemented yet",
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x0",
-            capa.features.common.Characteristic("stack string"),
-            "xfail: not implemented yet",
-        ),
-        # insn/mnemonic
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.insn.Mnemonic("stp"), True),
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.insn.Mnemonic("adrp"), True),
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.insn.Mnemonic("bl"), True),
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.insn.Mnemonic("in"), False),
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.insn.Mnemonic("adrl"), False),
-        # insn/number
-        # 00114524 add x29,sp,#0x10
-        (
-            "d1e650.ghidra.be2",
-            "function=0x11451c",
-            capa.features.insn.Number(0x10),
-            False,
-        ),
-        # 00105128 sub sp,sp,#0xE0
-        (
-            "687e79.ghidra.be2",
-            "function=0x105128",
-            capa.features.insn.Number(0xE0),
-            False,
-        ),
-        # insn/operand.number
-        (
-            "687e79.ghidra.be2",
-            "function=0x105128,bb=0x1051e4",
-            capa.features.insn.OperandNumber(1, 0xFFFFFFFF),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x107588,bb=0x107588",
-            capa.features.insn.OperandNumber(1, 0x8),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x107588,bb=0x107588,insn=0x1075a4",
-            capa.features.insn.OperandNumber(1, 0x8),
-            True,
-        ),
-        # insn/operand.offset
-        (
-            "687e79.ghidra.be2",
-            "function=0x105128,bb=0x105450",
-            capa.features.insn.OperandOffset(2, 0x10),
-            True,
-        ),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x124854,bb=0x1248AC,insn=0x1248B4",
-            capa.features.insn.OperandOffset(2, -0x48),
-            True,
-        ),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x13347c,bb=0x133548,insn=0x133554",
-            capa.features.insn.OperandOffset(2, 0x20),
-            False,
-        ),
-        ("687e79.ghidra.be2", "function=0x105C88", capa.features.insn.Number(0xF000), True),
-        # insn/number: negative
-        (
-            "687e79.ghidra.be2",
-            "function=0x1057f8,bb=0x1057f8",
-            capa.features.insn.Number(0xFFFFFFFFFFFFFFFF),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x1057f8,bb=0x1057f8",
-            capa.features.insn.Number(0xFFFFFFFFFFFFFFFF),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x1066e0,bb=0x1068c4",
-            capa.features.insn.Number(0xFFFFFFFF),
-            True,
-        ),
-        # insn/offset
-        (
-            "687e79.ghidra.be2",
-            "function=0x105128,bb=0x105450",
-            capa.features.insn.Offset(0x10),
-            True,
-        ),
-        # ldp x29,x30,[sp, #0x20]
-        (
-            "d1e650.ghidra.be2",
-            "function=0x13347c,bb=0x133548,insn=0x133554",
-            capa.features.insn.Offset(0x20),
-            False,
-        ),
-        # stp x20,x0,[x19, #0x8]
-        (
-            "d1e650.ghidra.be2",
-            "function=0x1183e0,bb=0x11849c,insn=0x1184b0",
-            capa.features.insn.Offset(0x8),
-            True,
-        ),
-        # str xzr,[x8, #0x8]!
-        (
-            "d1e650.ghidra.be2",
-            "function=0x138688,bb=0x138994,insn=0x1389a8",
-            capa.features.insn.Offset(0x8),
-            True,
-        ),
-        # ldr x9,[x8, #0x8]!
-        (
-            "d1e650.ghidra.be2",
-            "function=0x138688,bb=0x138978,insn=0x138984",
-            capa.features.insn.Offset(0x8),
-            True,
-        ),
-        # ldr x19,[sp], #0x20
-        (
-            "d1e650.ghidra.be2",
-            "function=0x11451c",
-            capa.features.insn.Offset(0x20),
-            False,
-        ),
-        # ldrb w9,[x8, #0x1]
-        (
-            "d1e650.ghidra.be2",
-            "function=0x138a9c,bb=0x138b00,insn=0x138b00",
-            capa.features.insn.Offset(0x1),
-            True,
-        ),
-        # insn/offset: negative
-        (
-            "d1e650.ghidra.be2",
-            "function=0x124854,bb=0x1248AC,insn=0x1248B4",
-            capa.features.insn.Offset(-0x48),
-            True,
-        ),
-        # insn/offset from mnemonic: add
-        # 0010514c add x23,param_1,#0x8
-        (
-            "687e79.ghidra.be2",
-            "function=0x105128,bb=0x105128,insn=0x10514c",
-            capa.features.insn.Offset(0x8),
-            True,
-        ),
-        # insn/api
-        # not extracting dll name
-        ("687e79.ghidra.be2", "function=0x105c88", capa.features.insn.API("memset"), True),
-        ("687e79.ghidra.be2", "function=0x105c88", capa.features.insn.API("Nope"), False),
-        # insn/string
-        (
-            "687e79.ghidra.be2",
-            "function=0x107588",
-            capa.features.common.String("AppDataService start"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x1075c0",
-            capa.features.common.String("AppDataService"),
-            True,
-        ),
-        ("687e79.ghidra.be2", "function=0x107588", capa.features.common.String("nope"), False),
-        (
-            "687e79.ghidra.be2",
-            "function=0x106d58",
-            capa.features.common.String("/data/misc/wifi/wpa_supplicant.conf"),
-            True,
-        ),
-        # insn/regex
-        (
-            "687e79.ghidra.be2",
-            "function=0x105c88",
-            capa.features.common.Regex("innerRename"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x106d58",
-            capa.features.common.Regex("/data/misc"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x106d58",
-            capa.features.common.Substring("/data/misc"),
-            True,
-        ),
-        # insn/bytes
-        (
-            "d1e650.ghidra.be2",
-            "function=0x1165a4",
-            capa.features.common.Bytes(bytes.fromhex("E405B89370BA6B419CD7925275BF6FCC1E8360CC")),
-            True,
-        ),
-        # # don't extract byte features for obvious strings
-        (
-            "687e79.ghidra.be2",
-            "function=0x1057f8",
-            capa.features.common.Bytes("/system/xbin/busybox".encode("utf-16le")),
-            False,
-        ),
-        # insn/characteristic(nzxor)
-        (
-            "d1e650.ghidra.be2",
-            "function=0x114af4",
-            capa.features.common.Characteristic("nzxor"),
-            True,
-        ),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x117988",
-            capa.features.common.Characteristic("nzxor"),
-            True,
-        ),
-        # # insn/characteristic(cross section flow)
-        # ("a1982...", "function=0x4014D0", capa.features.common.Characteristic("cross section flow"), True),
-        # # insn/characteristic(cross section flow): imports don't count
-        # ("mimikatz", "function=0x4556E5", capa.features.common.Characteristic("cross section flow"), False),
-        # insn/characteristic(recursive call)
-        (
-            "687e79.ghidra.be2",
-            "function=0x105b38",
-            capa.features.common.Characteristic("recursive call"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x106530",
-            capa.features.common.Characteristic("recursive call"),
-            True,
-        ),
-        # insn/characteristic(indirect call)
-        ("d1e650.ghidra.be2", "function=0x118620", capa.features.common.Characteristic("indirect call"), True),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x118500",
-            capa.features.common.Characteristic("indirect call"),
-            False,
-        ),
-        ("d1e650.ghidra.be2", "function=0x118620", capa.features.common.Characteristic("indirect call"), True),
-        (
-            "d1e650.ghidra.be2",
-            "function=0x11451c",
-            capa.features.common.Characteristic("indirect call"),
-            True,
-        ),
-        # insn/characteristic(calls from)
-        (
-            "687e79.ghidra.be2",
-            "function=0x105080",
-            capa.features.common.Characteristic("calls from"),
-            True,
-        ),
-        (
-            "687e79.ghidra.be2",
-            "function=0x1070e8",
-            capa.features.common.Characteristic("calls from"),
-            False,
-        ),
-        # function/characteristic(calls to)
-        (
-            "687e79.ghidra.be2",
-            "function=0x1075c0",
-            capa.features.common.Characteristic("calls to"),
-            True,
-        ),
-        # file/function-name
-        (
-            "687e79.ghidra.be2",
-            "file",
-            capa.features.file.FunctionName("__libc_init"),
-            "xfail: TODO should this be a function-name?",
-        ),
-        # os & format & arch
-        ("687e79.ghidra.be2", "file", OS(OS_ANDROID), True),
-        ("687e79.ghidra.be2", "file", OS(OS_LINUX), False),
-        ("687e79.ghidra.be2", "file", OS(OS_WINDOWS), False),
-        # os & format & arch are also global features
-        ("687e79.ghidra.be2", "function=0x107588", OS(OS_ANDROID), True),
-        ("687e79.ghidra.be2", "function=0x1075c0,bb=0x1076c0", OS(OS_ANDROID), True),
-        ("687e79.ghidra.be2", "file", Arch(ARCH_I386), False),
-        ("687e79.ghidra.be2", "file", Arch(ARCH_AMD64), False),
-        ("687e79.ghidra.be2", "file", Arch(ARCH_AARCH64), True),
-        ("687e79.ghidra.be2", "function=0x107588", Arch(ARCH_AARCH64), True),
-        ("687e79.ghidra.be2", "function=0x1075c0,bb=0x1076c0", Arch(ARCH_AARCH64), True),
-        ("687e79.ghidra.be2", "file", Format(FORMAT_ELF), True),
-        ("687e79.ghidra.be2", "file", Format(FORMAT_PE), False),
-        ("687e79.ghidra.be2", "function=0x107588", Format(FORMAT_ELF), True),
-        ("687e79.ghidra.be2", "function=0x107588", Format(FORMAT_PE), False),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="binexport",
+    get_extractor=fixtures.get_binexport_extractor,
+    include_tags={"binexport"},
 )
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    FEATURE_PRESENCE_TESTS_BE2_ELF_AARCH64,
-    indirect=["sample", "scope"],
-)
-def test_binexport_features_elf_aarch64(sample, scope, feature, expected):
-    if not isinstance(expected, bool):
-        # (for now) xfails indicates using string like: "xfail: not implemented yet"
-        pytest.xfail(expected)
-    fixtures.do_test_feature_presence(fixtures.get_binexport_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_binexport_features_elf_aarch64(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
 
 
 @fixtures.parametrize(
@@ -426,12 +40,16 @@ def test_binexport_features_pe_x86(sample, scope, feature, expected):
     if "mimikatz.exe_" not in sample.name:
         pytest.skip("for now only testing mimikatz.exe_ Ghidra BinExport file")
 
-    if isinstance(feature, capa.features.common.Characteristic) and "stack string" in cast(str, feature.value):
+    if isinstance(
+        feature, capa.features.common.Characteristic
+    ) and "stack string" in cast(str, feature.value):
         pytest.skip("for now only testing basic features")
 
     sample = sample.parent / "binexport2" / (sample.name + ".ghidra.BinExport")
     assert sample.exists()
-    fixtures.do_test_feature_presence(fixtures.get_binexport_extractor, sample, scope, feature, expected)
+    fixtures.do_test_feature_presence(
+        fixtures.get_binexport_extractor, sample, scope, feature, expected
+    )
 
 
 @fixtures.parametrize(
@@ -444,7 +62,9 @@ def test_binexport_feature_counts_ghidra(sample, scope, feature, expected):
         pytest.skip("for now only testing mimikatz.exe_ Ghidra BinExport file")
     sample = sample.parent / "binexport2" / (sample.name + ".ghidra.BinExport")
     assert sample.exists()
-    fixtures.do_test_feature_count(fixtures.get_binexport_extractor, sample, scope, feature, expected)
+    fixtures.do_test_feature_count(
+        fixtures.get_binexport_extractor, sample, scope, feature, expected
+    )
 
 
 @fixtures.parametrize(
@@ -455,4 +75,6 @@ def test_binexport_feature_counts_ghidra(sample, scope, feature, expected):
 def test_binexport_feature_counts_intel(sample, scope, feature, expected):
     sample = sample.parent / "binexport2" / (sample.name + ".ghidra.BinExport")
     assert sample.exists()
-    fixtures.do_test_feature_count(fixtures.get_binexport_extractor, sample, scope, feature, expected)
+    fixtures.do_test_feature_count(
+        fixtures.get_binexport_extractor, sample, scope, feature, expected
+    )

--- a/tests/test_binexport_features.py
+++ b/tests/test_binexport_features.py
@@ -11,60 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import cast
-
 import fixtures
-import pytest
-
-import capa.features.common
-
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="binexport",
-    get_extractor=fixtures.get_binexport_extractor,
-    include_tags={"binexport"},
-)
 
 
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
-def test_binexport_features_elf_aarch64(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_binexport_features_pe_x86(sample, scope, feature, expected):
-    if "mimikatz.exe_" not in sample.name:
-        pytest.skip("for now only testing mimikatz.exe_ Ghidra BinExport file")
-
-    if isinstance(
-        feature, capa.features.common.Characteristic
-    ) and "stack string" in cast(str, feature.value):
-        pytest.skip("for now only testing basic features")
-
-    sample = sample.parent / "binexport2" / (sample.name + ".ghidra.BinExport")
-    assert sample.exists()
-    fixtures.do_test_feature_presence(
-        fixtures.get_binexport_extractor, sample, scope, feature, expected
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="binexport",
+        include_tags={"binexport"},
     )
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_COUNT_TESTS_GHIDRA,
-    indirect=["sample", "scope"],
 )
-def test_binexport_feature_counts_ghidra(sample, scope, feature, expected):
-    if "mimikatz.exe_" not in sample.name:
-        pytest.skip("for now only testing mimikatz.exe_ Ghidra BinExport file")
-    sample = sample.parent / "binexport2" / (sample.name + ".ghidra.BinExport")
-    assert sample.exists()
-    fixtures.do_test_feature_count(
-        fixtures.get_binexport_extractor, sample, scope, feature, expected
-    )
+def test_binexport_features(feature_fixture):
+    extractor = fixtures.get_binexport_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 
 
 @fixtures.parametrize(

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import logging
-from pathlib import Path
 
 import fixtures
 import pytest
 
-import capa.features.common
 import capa.main
 
 logger = logging.getLogger(__file__)
@@ -41,23 +39,22 @@ except ImportError:
     pass
 
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="binja",
-    # binja also loads .bndb database files natively, so include `binja-db`
-    # alongside the regular static-binary fixtures.
-    get_extractor=fixtures.get_binja_extractor,
-    include_tags={"static", "binja-db"},
-    exclude_tags={"dotnet", "ghidra"},
-)
-
-
 @pytest.mark.skipif(
     binja_present is False,
     reason="Skip binja tests if the binaryninja Python API is not installed",
 )
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="binja",
+        # binja also loads .bndb database files natively, so include `binja-db`
+        # alongside the regular static-binary fixtures.
+        include_tags={"static", "binja-db"},
+        exclude_tags={"dotnet", "ghidra"},
+    )
+)
 def test_binja_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_binja_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 
 
 @pytest.mark.skipif(
@@ -65,10 +62,7 @@ def test_binja_features(feature_fixture):
     reason="Skip binja tests if the binaryninja Python API is not installed",
 )
 def test_standalone_binja_backend():
-    CD = Path(__file__).resolve().parent
-    test_path = (
-        CD / ".." / "tests" / "data" / "Practical Malware Analysis Lab 01-01.exe_"
-    )
+    test_path = fixtures.CD / "data" / "Practical Malware Analysis Lab 01-01.exe_"
     assert capa.main.main([str(test_path), "-b", capa.main.BACKEND_BINJA]) == 0
 
 

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -14,8 +14,8 @@
 
 import logging
 
-import fixtures
 import pytest
+import fixtures
 
 import capa.main
 
@@ -30,9 +30,7 @@ try:
     try:
         binaryninja.load(source=b"\x90")
     except RuntimeError:
-        logger.warning(
-            "Binary Ninja license is not valid, provide via $BN_LICENSE or license.dat"
-        )
+        logger.warning("Binary Ninja license is not valid, provide via $BN_LICENSE or license.dat")
     else:
         binja_present = True
 except ImportError:

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -15,9 +15,10 @@
 import logging
 from pathlib import Path
 
-import pytest
 import fixtures
+import pytest
 
+import capa.features.common
 import capa.main
 
 logger = logging.getLogger(__file__)
@@ -31,41 +32,50 @@ try:
     try:
         binaryninja.load(source=b"\x90")
     except RuntimeError:
-        logger.warning("Binary Ninja license is not valid, provide via $BN_LICENSE or license.dat")
+        logger.warning(
+            "Binary Ninja license is not valid, provide via $BN_LICENSE or license.dat"
+        )
     else:
         binja_present = True
 except ImportError:
     pass
 
 
-@pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS + fixtures.FEATURE_SYMTAB_FUNC_TESTS + fixtures.FEATURE_BINJA_DATABASE_TESTS,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="binja",
+    # binja also loads .bndb database files natively, so include `binja-db`
+    # alongside the regular static-binary fixtures.
+    get_extractor=fixtures.get_binja_extractor,
+    include_tags={"static", "binja-db"},
+    exclude_tags={"dotnet", "ghidra"},
 )
-def test_binja_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_binja_extractor, sample, scope, feature, expected)
 
 
-@pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
+@pytest.mark.skipif(
+    binja_present is False,
+    reason="Skip binja tests if the binaryninja Python API is not installed",
 )
-def test_binja_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_binja_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_binja_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
 
 
-@pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
+@pytest.mark.skipif(
+    binja_present is False,
+    reason="Skip binja tests if the binaryninja Python API is not installed",
+)
 def test_standalone_binja_backend():
     CD = Path(__file__).resolve().parent
-    test_path = CD / ".." / "tests" / "data" / "Practical Malware Analysis Lab 01-01.exe_"
+    test_path = (
+        CD / ".." / "tests" / "data" / "Practical Malware Analysis Lab 01-01.exe_"
+    )
     assert capa.main.main([str(test_path), "-b", capa.main.BACKEND_BINJA]) == 0
 
 
-@pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
+@pytest.mark.skipif(
+    binja_present is False,
+    reason="Skip binja tests if the binaryninja Python API is not installed",
+)
 def test_binja_version():
     version = binaryninja.core_version_info()  # type: ignore[possibly-undefined]  # guarded by skipif binja_present
     assert (version.major, version.minor) >= (5, 3)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -14,10 +14,10 @@
 
 import textwrap
 
-import capa.rules
-import capa.features.common
 import fixtures
 
+import capa.rules
+import capa.features.common
 import capa.capabilities.common
 import capa.features.extractors.null
 from capa.features.address import AbsoluteVirtualAddress

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -17,6 +17,7 @@ import textwrap
 import capa.rules
 import capa.features.common
 import fixtures
+
 import capa.capabilities.common
 import capa.features.extractors.null
 from capa.features.address import AbsoluteVirtualAddress

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -16,6 +16,7 @@ import textwrap
 
 import capa.rules
 import capa.features.common
+import fixtures
 import capa.capabilities.common
 import capa.features.extractors.null
 from capa.features.address import AbsoluteVirtualAddress
@@ -212,7 +213,8 @@ def test_byte_matching(z9324d_extractor):
     assert "byte match test" in capabilities.matches
 
 
-def test_com_feature_matching(z395eb_extractor):
+def test_com_feature_matching():
+    extractor = fixtures.get_viv_extractor(fixtures.CD / "data" / "395eb0ddd99d2c9e37b6d0b73485ee9c.exe_")
     rules = capa.rules.RuleSet([
         capa.rules.Rule.from_yaml(
             textwrap.dedent("""
@@ -230,7 +232,7 @@ def test_com_feature_matching(z395eb_extractor):
                     """)
         )
     ])
-    capabilities = capa.capabilities.common.find_capabilities(rules, z395eb_extractor)
+    capabilities = capa.capabilities.common.find_capabilities(rules, extractor)
     assert "initialize IWebBrowser2" in capabilities.matches
 
 

--- a/tests/test_cape_features.py
+++ b/tests/test_cape_features.py
@@ -11,17 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="cape",
-    get_extractor=fixtures.get_cape_extractor,
-    include_tags={"cape"},
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="cape",
+        include_tags={"cape"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_cape_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_cape_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)

--- a/tests/test_cape_features.py
+++ b/tests/test_cape_features.py
@@ -15,106 +15,13 @@
 
 import fixtures
 
-import capa.features.file
-import capa.features.insn
-import capa.features.common
-
-DYNAMIC_CAPE_FEATURE_PRESENCE_TESTS = sorted(
-    [
-        # file/string
-        ("0000a657", "file", capa.features.common.String("T_Ba?.BcRJa"), True),
-        ("0000a657", "file", capa.features.common.String("GetNamedPipeClientSessionId"), True),
-        ("0000a657", "file", capa.features.common.String("nope"), False),
-        # file/sections
-        ("0000a657", "file", capa.features.file.Section(".rdata"), True),
-        ("0000a657", "file", capa.features.file.Section(".nope"), False),
-        # file/imports
-        ("0000a657", "file", capa.features.file.Import("NdrSimpleTypeUnmarshall"), True),
-        ("0000a657", "file", capa.features.file.Import("Nope"), False),
-        # file/exports
-        ("0000a657", "file", capa.features.file.Export("Nope"), False),
-        # process/environment variables
-        (
-            "0000a657",
-            "process=(1180:3052)",
-            capa.features.common.String("C:\\Users\\comp\\AppData\\Roaming\\Microsoft\\Jxoqwnx\\jxoqwn.exe"),
-            True,
-        ),
-        ("0000a657", "process=(1180:3052)", capa.features.common.String("nope"), False),
-        # thread/api calls
-        ("0000a657", "process=(2900:2852),thread=2904", capa.features.insn.API("RegQueryValueExA"), True),
-        ("0000a657", "process=(2900:2852),thread=2904", capa.features.insn.API("RegQueryValueEx"), True),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.API("NtQueryValueKey"), True),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.API("GetActiveWindow"), False),
-        # thread/number call argument
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.Number(0x000000EC), True),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.Number(110173), False),
-        # thread/string call argument
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.common.String("SetThreadUILanguage"), True),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.common.String("nope"), False),
-        ("0000a657", "process=(2852:3052),thread=2804,call=56", capa.features.insn.API("NtQueryValueKey"), True),
-        ("0000a657", "process=(2852:3052),thread=2804,call=1958", capa.features.insn.API("nope"), False),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
-)
-
-DYNAMIC_CAPE_FEATURE_COUNT_TESTS = sorted(
-    # TODO(yelhamer): use the same sample for testing CAPE and DRAKVUF extractors
-    # https://github.com/mandiant/capa/issues/2180
-    [
-        # file/string
-        ("0000a657", "file", capa.features.common.String("T_Ba?.BcRJa"), 1),
-        ("0000a657", "file", capa.features.common.String("GetNamedPipeClientSessionId"), 1),
-        ("0000a657", "file", capa.features.common.String("nope"), 0),
-        # file/sections
-        ("0000a657", "file", capa.features.file.Section(".rdata"), 1),
-        ("0000a657", "file", capa.features.file.Section(".nope"), 0),
-        # file/imports
-        ("0000a657", "file", capa.features.file.Import("NdrSimpleTypeUnmarshall"), 1),
-        ("0000a657", "file", capa.features.file.Import("Nope"), 0),
-        # file/exports
-        ("0000a657", "file", capa.features.file.Export("Nope"), 0),
-        # process/environment variables
-        (
-            "0000a657",
-            "process=(1180:3052)",
-            capa.features.common.String("C:\\Users\\comp\\AppData\\Roaming\\Microsoft\\Jxoqwnx\\jxoqwn.exe"),
-            2,
-        ),
-        ("0000a657", "process=(1180:3052)", capa.features.common.String("nope"), 0),
-        # thread/api calls
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.API("NtQueryValueKey"), 7),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.API("GetActiveWindow"), 0),
-        # thread/number call argument
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.Number(0x000000EC), 1),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.insn.Number(110173), 0),
-        # thread/string call argument
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.common.String("SetThreadUILanguage"), 1),
-        ("0000a657", "process=(2852:3052),thread=2804", capa.features.common.String("nope"), 0),
-        ("0000a657", "process=(2852:3052),thread=2804,call=56", capa.features.insn.API("NtQueryValueKey"), 1),
-        ("0000a657", "process=(2852:3052),thread=2804,call=1958", capa.features.insn.API("nope"), 0),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="cape",
+    get_extractor=fixtures.get_cape_extractor,
+    include_tags={"cape"},
 )
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_CAPE_FEATURE_PRESENCE_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_cape_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_cape_extractor, sample, scope, feature, expected)
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_CAPE_FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_cape_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_cape_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_cape_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)

--- a/tests/test_cape_model.py
+++ b/tests/test_cape_model.py
@@ -14,7 +14,6 @@
 
 import gzip
 from typing import Type
-from pathlib import Path
 
 import pytest
 import fixtures
@@ -25,8 +24,7 @@ from capa.features.extractors.cape.models import Call, CapeReport
 from capa.features.extractors.cape.thread import get_calls
 from capa.features.extractors.base_extractor import ThreadHandle, ProcessHandle
 
-CD = Path(__file__).resolve().parent
-CAPE_DIR = CD / "data" / "dynamic" / "cape"
+CAPE_DIR = fixtures.CD / "data" / "dynamic" / "cape"
 
 
 @fixtures.parametrize(

--- a/tests/test_dnfile_features.py
+++ b/tests/test_dnfile_features.py
@@ -31,16 +31,16 @@ CD = Path(__file__).resolve().parent
 
 DOTNET_DIR = Path(__file__).resolve().parent / "data" / "dotnet"
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="dnfile",
-    get_extractor=fixtures.get_dnfile_extractor,
-    include_tags={"dotnet"},
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="dnfile",
+        include_tags={"dotnet"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_dnfile_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_dnfile_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 
 
 def test_get_dotnet_table_row_first_row():

--- a/tests/test_dnfile_features.py
+++ b/tests/test_dnfile_features.py
@@ -31,23 +31,16 @@ CD = Path(__file__).resolve().parent
 
 DOTNET_DIR = Path(__file__).resolve().parent / "data" / "dotnet"
 
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS_DOTNET,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="dnfile",
+    get_extractor=fixtures.get_dnfile_extractor,
+    include_tags={"dotnet"},
 )
-def test_dnfile_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_dnfile_extractor, sample, scope, feature, expected)
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_COUNT_TESTS_DOTNET,
-    indirect=["sample", "scope"],
-)
-def test_dnfile_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_dnfile_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_dnfile_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
 
 
 def test_get_dotnet_table_row_first_row():

--- a/tests/test_dotnetfile_features.py
+++ b/tests/test_dotnetfile_features.py
@@ -14,37 +14,53 @@
 
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="dotnetfile",
-    get_extractor=fixtures.get_dotnetfile_extractor,
-    include_tags={"dotnet"},
-    exclude_tags={
-        # dotnetfile is a file-scope extractor; drop non-file scopes
-        "function",
-        "basic-block",
-        "instruction",
-        # and drop feature types dotnetfile doesn't produce
-        "function-name",
-    },
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="dotnetfile",
+        include_tags={"dotnet"},
+        exclude_tags={
+            # dotnetfile is a file-scope extractor; drop non-file scopes
+            "function",
+            "basic-block",
+            "instruction",
+            # and drop feature types dotnetfile doesn't produce
+            "function-name",
+        },
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_dotnetfile_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_dotnetfile_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 
 
-@fixtures.parametrize(
-    "extractor,function,expected",
-    [
-        ("b9f5b_dotnetfile_extractor", "is_dotnet_file", True),
-        ("b9f5b_dotnetfile_extractor", "is_mixed_mode", False),
-        ("mixed_mode_64_dotnetfile_extractor", "is_mixed_mode", True),
-        ("b9f5b_dotnetfile_extractor", "get_entry_point", 0x6000007),
-        ("b9f5b_dotnetfile_extractor", "get_runtime_version", (2, 5)),
-        ("b9f5b_dotnetfile_extractor", "get_meta_version_string", "v2.0.50727"),
-    ],
-)
-def test_dotnetfile_extractor(request, extractor, function, expected):
-    extractor_function = getattr(request.getfixturevalue(extractor), function)
-    assert extractor_function() == expected
+def test_dotnetfile_extractor_is_dotnet_file():
+    extractor = fixtures.get_dotnetfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_")
+    assert extractor.is_dotnet_file() is True
+
+
+def test_dotnetfile_extractor_is_not_mixed_mode():
+    extractor = fixtures.get_dotnetfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_")
+    assert extractor.is_mixed_mode() is False
+
+
+def test_dotnetfile_extractor_mixed_mode_64_is_mixed_mode():
+    extractor = fixtures.get_dotnetfile_extractor(
+        fixtures.DNFILE_TESTFILES / "mixed-mode" / "ModuleCode" / "bin" / "ModuleCode_amd64.exe"
+    )
+    assert extractor.is_mixed_mode() is True
+
+
+def test_dotnetfile_extractor_get_entry_point():
+    extractor = fixtures.get_dotnetfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_")
+    assert extractor.get_entry_point() == 0x6000007
+
+
+def test_dotnetfile_extractor_get_runtime_version():
+    extractor = fixtures.get_dotnetfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_")
+    assert extractor.get_runtime_version() == (2, 5)
+
+
+def test_dotnetfile_extractor_get_meta_version_string():
+    extractor = fixtures.get_dotnetfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_")
+    assert extractor.get_meta_version_string() == "v2.0.50727"

--- a/tests/test_dotnetfile_features.py
+++ b/tests/test_dotnetfile_features.py
@@ -12,25 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import fixtures
 
-import capa.features.file
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS_DOTNET,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="dotnetfile",
+    get_extractor=fixtures.get_dotnetfile_extractor,
+    include_tags={"dotnet"},
+    exclude_tags={
+        # dotnetfile is a file-scope extractor; drop non-file scopes
+        "function",
+        "basic-block",
+        "instruction",
+        # and drop feature types dotnetfile doesn't produce
+        "function-name",
+    },
 )
-def test_dotnetfile_features(sample, scope, feature, expected):
-    if scope.__name__ != "file":
-        pytest.xfail("dotnetfile only extracts file scope features")
 
-    if isinstance(feature, capa.features.file.FunctionName):
-        pytest.xfail("dotnetfile doesn't extract function names")
 
-    fixtures.do_test_feature_presence(fixtures.get_dotnetfile_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_dotnetfile_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
 
 
 @fixtures.parametrize(

--- a/tests/test_drakvuf_features.py
+++ b/tests/test_drakvuf_features.py
@@ -11,17 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="drakvuf",
-    get_extractor=fixtures.get_drakvuf_extractor,
-    include_tags={"drakvuf"},
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="drakvuf",
+        include_tags={"drakvuf"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_drakvuf_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_drakvuf_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)

--- a/tests/test_drakvuf_features.py
+++ b/tests/test_drakvuf_features.py
@@ -15,87 +15,13 @@
 
 import fixtures
 
-import capa.features.file
-import capa.features.insn
-import capa.features.common
-
-DYNAMIC_DRAKVUF_FEATURE_PRESENCE_TESTS = sorted(
-    [
-        ("93b2d1-drakvuf", "file", capa.features.common.String("\\Program Files\\WindowsApps\\does_not_exist"), False),
-        # file/imports
-        ("93b2d1-drakvuf", "file", capa.features.file.Import("SetUnhandledExceptionFilter"), True),
-        # thread/api calls
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592", capa.features.insn.API("LdrLoadDll"), True),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592", capa.features.insn.API("DoesNotExist"), False),
-        # call/api
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=4716,call=17", capa.features.insn.API("CreateWindowExW"), True),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=4716,call=17", capa.features.insn.API("CreateWindowEx"), True),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.API("LdrLoadDll"), True),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.API("DoesNotExist"), False),
-        # call/string argument
-        (
-            "93b2d1-drakvuf",
-            "process=(3564:4852),thread=6592,call=1",
-            capa.features.common.String('0x667e2beb40:"api-ms-win-core-fibers-l1-1-1"'),
-            True,
-        ),
-        (
-            "93b2d1-drakvuf",
-            "process=(3564:4852),thread=6592,call=1",
-            capa.features.common.String("non_existant"),
-            False,
-        ),
-        # call/number argument
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.Number(0x801), True),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.Number(0x010101010101), False),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
-)
-
-DYNAMIC_DRAKVUF_FEATURE_COUNT_TESTS = sorted(
-    [
-        ("93b2d1-drakvuf", "file", capa.features.common.String("\\Program Files\\WindowsApps\\does_not_exist"), False),
-        # file/imports
-        ("93b2d1-drakvuf", "file", capa.features.file.Import("SetUnhandledExceptionFilter"), 1),
-        # thread/api calls
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592", capa.features.insn.API("LdrLoadDll"), 9),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592", capa.features.insn.API("DoesNotExist"), False),
-        # call/api
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.API("LdrLoadDll"), 1),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.API("DoesNotExist"), 0),
-        # call/string argument
-        (
-            "93b2d1-drakvuf",
-            "process=(3564:4852),thread=6592,call=1",
-            capa.features.common.String('0x667e2beb40:"api-ms-win-core-fibers-l1-1-1"'),
-            1,
-        ),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.common.String("non_existant"), 0),
-        # call/number argument
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.Number(0x801), 1),
-        ("93b2d1-drakvuf", "process=(3564:4852),thread=6592,call=1", capa.features.insn.Number(0x010101010101), 0),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="drakvuf",
+    get_extractor=fixtures.get_drakvuf_extractor,
+    include_tags={"drakvuf"},
 )
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_DRAKVUF_FEATURE_PRESENCE_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_drakvuf_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_drakvuf_extractor, sample, scope, feature, expected)
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_DRAKVUF_FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_drakvuf_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_drakvuf_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_drakvuf_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)

--- a/tests/test_dynamic_span_of_calls_scope.py
+++ b/tests/test_dynamic_span_of_calls_scope.py
@@ -64,7 +64,14 @@ def filter_threads(extractor: DynamicFeatureExtractor, ppid: int, pid: int, tid:
 
 @lru_cache(maxsize=1)
 def get_0000a657_thread3064():
-    extractor = fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
+    extractor = fixtures.get_cape_extractor(
+        fixtures.CD
+        / "data"
+        / "dynamic"
+        / "cape"
+        / "v2.2"
+        / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+    )
     extractor = filter_threads(extractor, 2456, 3052, 3064)
     return extractor
 

--- a/tests/test_dynamic_span_of_calls_scope.py
+++ b/tests/test_dynamic_span_of_calls_scope.py
@@ -64,7 +64,7 @@ def filter_threads(extractor: DynamicFeatureExtractor, ppid: int, pid: int, tid:
 
 @lru_cache(maxsize=1)
 def get_0000a657_thread3064():
-    extractor = fixtures.get_cape_extractor(fixtures.get_data_path_by_name("0000a657"))
+    extractor = fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
     extractor = filter_threads(extractor, 2456, 3052, 3064)
     return extractor
 

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -16,7 +16,6 @@ import io
 from pathlib import Path
 
 import fixtures
-
 from elftools.elf.elffile import ELFFile
 
 from capa.features.extractors.elffile import extract_file_export_names, extract_file_import_names

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -15,13 +15,14 @@
 import io
 from pathlib import Path
 
+import fixtures
+
 from elftools.elf.elffile import ELFFile
 
 from capa.features.extractors.elffile import extract_file_export_names, extract_file_import_names
 
-CD = Path(__file__).resolve().parent
-SAMPLE_PATH = CD / "data" / "055da8e6ccfe5a9380231ea04b850e18.elf_"
-STRIPPED_SAMPLE_PATH = CD / "data" / "bb38149ff4b5c95722b83f24ca27a42b.elf_"
+SAMPLE_PATH = fixtures.CD / "data" / "055da8e6ccfe5a9380231ea04b850e18.elf_"
+STRIPPED_SAMPLE_PATH = fixtures.CD / "data" / "bb38149ff4b5c95722b83f24ca27a42b.elf_"
 
 
 def check_import_features(sample_path, expected_imports):

--- a/tests/test_extractor_hashing.py
+++ b/tests/test_extractor_hashing.py
@@ -32,9 +32,7 @@ def test_viv_hash_extraction():
 
 
 def test_pefile_hash_extraction():
-    assert fixtures.get_pefile_extractor(
-        fixtures.CD / "data" / "mimikatz.exe_"
-    ).get_sample_hashes() == SampleHashes(
+    assert fixtures.get_pefile_extractor(fixtures.CD / "data" / "mimikatz.exe_").get_sample_hashes() == SampleHashes(
         md5="5f66b82558ca92e54e77f216ef4c066c",
         sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
         sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
@@ -42,7 +40,9 @@ def test_pefile_hash_extraction():
 
 
 def test_dnfile_hash_extraction():
-    assert fixtures.get_dnfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_").get_sample_hashes() == SampleHashes(
+    assert fixtures.get_dnfile_extractor(
+        fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_"
+    ).get_sample_hashes() == SampleHashes(
         md5="b9f5bd514485fb06da39beff051b9fdc",
         sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
         sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
@@ -60,7 +60,14 @@ def test_dotnetfile_hash_extraction():
 
 
 def test_cape_hash_extraction():
-    assert fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz").get_sample_hashes() == SampleHashes(
+    assert fixtures.get_cape_extractor(
+        fixtures.CD
+        / "data"
+        / "dynamic"
+        / "cape"
+        / "v2.2"
+        / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+    ).get_sample_hashes() == SampleHashes(
         md5="e2147b5333879f98d515cd9aa905d489",
         sha1="ad4d520fb7792b4a5701df973d6bd8a6cbfbb57f",
         sha256="0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82",

--- a/tests/test_extractor_hashing.py
+++ b/tests/test_extractor_hashing.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_viv_hash_extraction():
-    assert fixtures.get_viv_extractor(fixtures.get_data_path_by_name("mimikatz")).get_sample_hashes() == SampleHashes(
+    assert fixtures.get_viv_extractor(fixtures.CD / "data" / "mimikatz.exe_").get_sample_hashes() == SampleHashes(
         md5="5f66b82558ca92e54e77f216ef4c066c",
         sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
         sha256="131314a6f6d1d263c75b9909586b3e1bd837036329ace5e69241749e861ac01d",
@@ -33,7 +33,7 @@ def test_viv_hash_extraction():
 
 def test_pefile_hash_extraction():
     assert fixtures.get_pefile_extractor(
-        fixtures.get_data_path_by_name("mimikatz")
+        fixtures.CD / "data" / "mimikatz.exe_"
     ).get_sample_hashes() == SampleHashes(
         md5="5f66b82558ca92e54e77f216ef4c066c",
         sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",
@@ -42,7 +42,7 @@ def test_pefile_hash_extraction():
 
 
 def test_dnfile_hash_extraction():
-    assert fixtures.get_dnfile_extractor(fixtures.get_data_path_by_name("b9f5b")).get_sample_hashes() == SampleHashes(
+    assert fixtures.get_dnfile_extractor(fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_").get_sample_hashes() == SampleHashes(
         md5="b9f5bd514485fb06da39beff051b9fdc",
         sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
         sha256="34acc4c0b61b5ce0b37c3589f97d1f23e6d84011a241e6f85683ee517ce786f1",
@@ -51,7 +51,7 @@ def test_dnfile_hash_extraction():
 
 def test_dotnetfile_hash_extraction():
     assert fixtures.get_dotnetfile_extractor(
-        fixtures.get_data_path_by_name("b9f5b")
+        fixtures.CD / "data" / "b9f5bd514485fb06da39beff051b9fdc.exe_"
     ).get_sample_hashes() == SampleHashes(
         md5="b9f5bd514485fb06da39beff051b9fdc",
         sha1="c72a2e50410475a51d897d29ffbbaf2103754d53",
@@ -60,7 +60,7 @@ def test_dotnetfile_hash_extraction():
 
 
 def test_cape_hash_extraction():
-    assert fixtures.get_cape_extractor(fixtures.get_data_path_by_name("0000a657")).get_sample_hashes() == SampleHashes(
+    assert fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz").get_sample_hashes() == SampleHashes(
         md5="e2147b5333879f98d515cd9aa905d489",
         sha1="ad4d520fb7792b4a5701df973d6bd8a6cbfbb57f",
         sha256="0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82",
@@ -84,7 +84,7 @@ except ImportError:
 
 @pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
 def test_binja_hash_extraction():
-    extractor = fixtures.get_binja_extractor(fixtures.get_data_path_by_name("mimikatz"))
+    extractor = fixtures.get_binja_extractor(fixtures.CD / "data" / "mimikatz.exe_")
     hashes = SampleHashes(
         md5="5f66b82558ca92e54e77f216ef4c066c",
         sha1="e4f82e4d7f22938dc0a0ff8a4a7ad2a763643d38",

--- a/tests/test_fixture_manifests.py
+++ b/tests/test_fixture_manifests.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,15 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import fixtures
+
+from fixtures import get_fixture_files
 
 
-@fixtures.parametrize_backend_feature_fixtures(
-    fixtures.BackendFeaturePolicy(
-        name="binexport",
-        include_tags={"binexport"},
-    )
-)
-def test_binexport_features(feature_fixture):
-    extractor = fixtures.get_binexport_extractor(feature_fixture.sample_path)
-    fixtures.run_feature_fixture(extractor, feature_fixture)
+def test_no_orphaned_file_entries():
+    for manifest_path, data in get_fixture_files():
+        feature_refs = {feat["file"] for feat in data.get("features", [])}
+        for entry in data["files"]:
+            assert entry["key"] in feature_refs, (
+                f"file entry {entry['key']!r} in {manifest_path.name} is not referenced by any feature"
+            )

--- a/tests/test_freeze_dynamic.py
+++ b/tests/test_freeze_dynamic.py
@@ -156,7 +156,7 @@ def test_freeze_bytes_roundtrip():
 def test_freeze_load_sample(tmpdir):
     o = tmpdir.mkdir("capa").join("test.frz")
 
-    extractor = fixtures.get_cape_extractor(fixtures.get_data_path_by_name("d46900"))
+    extractor = fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz")
 
     Path(o.strpath).write_bytes(capa.features.freeze.dump(extractor))
 

--- a/tests/test_freeze_dynamic.py
+++ b/tests/test_freeze_dynamic.py
@@ -156,7 +156,14 @@ def test_freeze_bytes_roundtrip():
 def test_freeze_load_sample(tmpdir):
     o = tmpdir.mkdir("capa").join("test.frz")
 
-    extractor = fixtures.get_cape_extractor(fixtures.CD / "data" / "dynamic" / "cape" / "v2.2" / "d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz")
+    extractor = fixtures.get_cape_extractor(
+        fixtures.CD
+        / "data"
+        / "dynamic"
+        / "cape"
+        / "v2.2"
+        / "d46900384c78863420fb3e297d0a2f743cd2b6b3f7f82bf64059a168e07aceb7.json.gz"
+    )
 
     Path(o.strpath).write_bytes(capa.features.freeze.dump(extractor))
 

--- a/tests/test_freeze_static.py
+++ b/tests/test_freeze_static.py
@@ -15,7 +15,7 @@
 import textwrap
 from pathlib import Path
 
-import pytest
+import fixtures
 
 import capa.main
 import capa.rules
@@ -190,26 +190,15 @@ def test_no_address_lt_irreflexivity():
     assert not (no_addr < no_addr)
 
 
-def test_freeze_sample(tmpdir, z9324d_extractor):
+def test_freeze_sample(tmpdir):
     # tmpdir fixture handles cleanup
     o = tmpdir.mkdir("capa").join("test.frz").strpath
-    path = z9324d_extractor.path
+    path = str(fixtures.CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
     assert capa.features.freeze.main([path, o, "-v"]) == 0
 
 
-@pytest.mark.parametrize(
-    "extractor",
-    [
-        pytest.param("z9324d_extractor"),
-    ],
-)
-def test_freeze_load_sample(tmpdir, request, extractor):
+def test_freeze_load_sample(tmpdir, z9324d_extractor):
     o = tmpdir.mkdir("capa").join("test.frz")
-
-    extractor = request.getfixturevalue(extractor)
-
-    Path(o.strpath).write_bytes(capa.features.freeze.dump(extractor))
-
+    Path(o.strpath).write_bytes(capa.features.freeze.dump(z9324d_extractor))
     null_extractor = capa.features.freeze.load(Path(o.strpath).read_bytes())
-
-    compare_extractors(extractor, null_extractor)
+    compare_extractors(z9324d_extractor, null_extractor)

--- a/tests/test_ghidra_features.py
+++ b/tests/test_ghidra_features.py
@@ -23,15 +23,14 @@ ghidra_present = (
 )
 
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="ghidra",
-    get_extractor=fixtures.get_ghidra_extractor,
-    include_tags={"static"},
-    exclude_tags={"dotnet"},
-)
-
-
 @pytest.mark.skipif(ghidra_present is False, reason="PyGhidra not installed")
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="ghidra",
+        include_tags={"static"},
+        exclude_tags={"dotnet"},
+    )
+)
 def test_ghidra_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_ghidra_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)

--- a/tests/test_ghidra_features.py
+++ b/tests/test_ghidra_features.py
@@ -11,42 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import importlib.util
+import os
 
-import pytest
 import fixtures
+import pytest
 
-import capa.features.common
+ghidra_present = (
+    importlib.util.find_spec("pyghidra") is not None
+    and "GHIDRA_INSTALL_DIR" in os.environ
+)
 
-ghidra_present = importlib.util.find_spec("pyghidra") is not None and "GHIDRA_INSTALL_DIR" in os.environ
+
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="ghidra",
+    get_extractor=fixtures.get_ghidra_extractor,
+    include_tags={"static"},
+    exclude_tags={"dotnet"},
+)
 
 
 @pytest.mark.skipif(ghidra_present is False, reason="PyGhidra not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    [
-        (
-            pytest.param(
-                *t,
-                marks=pytest.mark.xfail(
-                    reason="specific to Vivisect and basic blocks do not align with Ghidra's analysis"
-                ),
-            )
-            if t[0] == "294b8d..." and t[2] == capa.features.common.String("\r\n\x00:ht")
-            else t
-        )
-        for t in fixtures.FEATURE_PRESENCE_TESTS
-    ],
-    indirect=["sample", "scope"],
-)
-def test_ghidra_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_ghidra_extractor, sample, scope, feature, expected)
-
-
-@pytest.mark.skipif(ghidra_present is False, reason="PyGhidra not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected", fixtures.FEATURE_COUNT_TESTS_GHIDRA, indirect=["sample", "scope"]
-)
-def test_ghidra_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_ghidra_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_ghidra_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)

--- a/tests/test_ghidra_features.py
+++ b/tests/test_ghidra_features.py
@@ -11,16 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import importlib.util
 import os
+import importlib.util
 
-import fixtures
 import pytest
+import fixtures
 
-ghidra_present = (
-    importlib.util.find_spec("pyghidra") is not None
-    and "GHIDRA_INSTALL_DIR" in os.environ
-)
+ghidra_present = importlib.util.find_spec("pyghidra") is not None and "GHIDRA_INSTALL_DIR" in os.environ
 
 
 @pytest.mark.skipif(ghidra_present is False, reason="PyGhidra not installed")

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 import logging
 
-import fixtures
 import pytest
+import fixtures
 
 import capa.features.extractors.ida.idalib as idalib
-from capa.features.common import Characteristic
 from capa.features.file import FunctionName
 from capa.features.insn import API
+from capa.features.common import Characteristic
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +57,7 @@ def test_idalib_features(feature_fixture):
     statement = feature_fixture.statement
 
     if kernel_version in {"9.0", "9.1"} and sample_name.startswith("2bf18d"):
-        if (
-            isinstance(statement, (API, FunctionName))
-            and statement.value == "__libc_connect"
-        ):
+        if isinstance(statement, (API, FunctionName)) and statement.value == "__libc_connect":
             # see discussion here: https://github.com/mandiant/capa/pull/2742#issuecomment-3674146335
             #
             # > i confirmed that there were changes in 9.2 related to the ELF loader handling names,
@@ -68,9 +65,7 @@ def test_idalib_features(feature_fixture):
             # > prevented this name from surfacing.
             pytest.xfail(f"IDA {kernel_version} does not extract all ELF symbols")
 
-    if kernel_version in {"9.0"} and sample_name.startswith(
-        "Practical Malware Analysis Lab 12-04.exe_"
-    ):
+    if kernel_version in {"9.0"} and sample_name.startswith("Practical Malware Analysis Lab 12-04.exe_"):
         if isinstance(statement, Characteristic) and statement.value == "embedded pe":
             # see discussion here: https://github.com/mandiant/capa/pull/2742#issuecomment-3667086165
             #

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -77,12 +77,5 @@ def test_idalib_features(feature_fixture):
             # idalib for IDA 9.0 doesn't support argv arguments, so we can't ask that resources are loaded
             pytest.xfail("idalib 9.0 does not support loading resource segments")
 
-    try:
-        extractor = fixtures.get_idalib_extractor(feature_fixture.sample_path)
+    with fixtures.get_idalib_extractor(feature_fixture.sample_path) as extractor:
         fixtures.run_feature_fixture(extractor, feature_fixture)
-    finally:
-        import idapro
-
-        logger.debug("closing database...")
-        idapro.close_database(save=False)
-        logger.debug("closed database.")

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -12,39 +12,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from pathlib import Path
 
-import pytest
 import fixtures
+import pytest
 
 import capa.features.extractors.ida.idalib
+from capa.features.common import Characteristic
 from capa.features.file import FunctionName
 from capa.features.insn import API
-from capa.features.common import Characteristic
 
 logger = logging.getLogger(__name__)
 
 idalib_present = capa.features.extractors.ida.idalib.has_idalib()
 if idalib_present:
     try:
-        import idapro  # noqa: F401 [imported but unused]
         import ida_kernwin
+        import idapro  # noqa: F401 [imported but unused]
 
         kernel_version: str = ida_kernwin.get_kernel_version()
     except ImportError:
         idalib_present = False
         kernel_version = "0.0"
+else:
+    kernel_version = "0.0"
 
 
-@pytest.mark.skipif(idalib_present is False, reason="Skip idalib tests if the idalib Python API is not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS + fixtures.FEATURE_SYMTAB_FUNC_TESTS,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="idalib",
+    get_extractor=fixtures.get_idalib_extractor,
+    include_tags={"static"},
+    exclude_tags={"dotnet", "ghidra"},
 )
-def test_idalib_features(sample: Path, scope, feature, expected):
-    if kernel_version in {"9.0", "9.1"} and sample.name.startswith("2bf18d"):
-        if isinstance(feature, (API, FunctionName)) and feature.value == "__libc_connect":
+
+
+@pytest.mark.skipif(
+    idalib_present is False,
+    reason="Skip idalib tests if the idalib Python API is not installed",
+)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_idalib_features(feature_fixture):
+    # apply runtime-conditional xfails for specific IDA versions.
+    # version-specific behavior stays in the test body because it
+    # depends on the installed IDA, not on the fixture data.
+    sample_name = feature_fixture.sample_path.name
+    statement = feature_fixture.statement
+
+    if kernel_version in {"9.0", "9.1"} and sample_name.startswith("2bf18d"):
+        if (
+            isinstance(statement, (API, FunctionName))
+            and statement.value == "__libc_connect"
+        ):
             # see discussion here: https://github.com/mandiant/capa/pull/2742#issuecomment-3674146335
             #
             # > i confirmed that there were changes in 9.2 related to the ELF loader handling names,
@@ -52,35 +69,20 @@ def test_idalib_features(sample: Path, scope, feature, expected):
             # > prevented this name from surfacing.
             pytest.xfail(f"IDA {kernel_version} does not extract all ELF symbols")
 
-    if kernel_version in {"9.0"} and sample.name.startswith("Practical Malware Analysis Lab 12-04.exe_"):
-        if isinstance(feature, Characteristic) and feature.value == "embedded pe":
+    if kernel_version in {"9.0"} and sample_name.startswith(
+        "Practical Malware Analysis Lab 12-04.exe_"
+    ):
+        if isinstance(statement, Characteristic) and statement.value == "embedded pe":
             # see discussion here: https://github.com/mandiant/capa/pull/2742#issuecomment-3667086165
             #
             # idalib for IDA 9.0 doesn't support argv arguments, so we can't ask that resources are loaded
             pytest.xfail("idalib 9.0 does not support loading resource segments")
 
     try:
-        fixtures.do_test_feature_presence(fixtures.get_idalib_extractor, sample, scope, feature, expected)
+        fixtures.run_feature_fixture(BACKEND, feature_fixture)
     finally:
-        logger.debug("closing database...")
         import idapro
 
-        idapro.close_database(save=False)
-        logger.debug("closed database.")
-
-
-@pytest.mark.skipif(idalib_present is False, reason="Skip idalib tests if the idalib Python API is not installed")
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_idalib_feature_counts(sample, scope, feature, expected):
-    try:
-        fixtures.do_test_feature_count(fixtures.get_idalib_extractor, sample, scope, feature, expected)
-    finally:
         logger.debug("closing database...")
-        import idapro
-
         idapro.close_database(save=False)
         logger.debug("closed database.")

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -16,18 +16,19 @@ import logging
 import fixtures
 import pytest
 
-import capa.features.extractors.ida.idalib
+import capa.features.extractors.ida.idalib as idalib
 from capa.features.common import Characteristic
 from capa.features.file import FunctionName
 from capa.features.insn import API
 
 logger = logging.getLogger(__name__)
 
-idalib_present = capa.features.extractors.ida.idalib.has_idalib()
+idalib_present = idalib.has_idalib()
 if idalib_present:
     try:
+        if True:
+            import idapro  # noqa: F401 [imported but unused]
         import ida_kernwin
-        import idapro  # noqa: F401 [imported but unused]
 
         kernel_version: str = ida_kernwin.get_kernel_version()
     except ImportError:
@@ -37,19 +38,17 @@ else:
     kernel_version = "0.0"
 
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="idalib",
-    get_extractor=fixtures.get_idalib_extractor,
-    include_tags={"static"},
-    exclude_tags={"dotnet", "ghidra"},
-)
-
-
 @pytest.mark.skipif(
     idalib_present is False,
     reason="Skip idalib tests if the idalib Python API is not installed",
 )
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="idalib",
+        include_tags={"static"},
+        exclude_tags={"dotnet", "ghidra"},
+    )
+)
 def test_idalib_features(feature_fixture):
     # apply runtime-conditional xfails for specific IDA versions.
     # version-specific behavior stays in the test body because it
@@ -79,7 +78,8 @@ def test_idalib_features(feature_fixture):
             pytest.xfail("idalib 9.0 does not support loading resource segments")
 
     try:
-        fixtures.run_feature_fixture(BACKEND, feature_fixture)
+        extractor = fixtures.get_idalib_extractor(feature_fixture.sample_path)
+        fixtures.run_feature_fixture(extractor, feature_fixture)
     finally:
         import idapro
 

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -16,30 +16,26 @@ import logging
 import pytest
 import fixtures
 
-import capa.features.extractors.ida.idalib as idalib
 from capa.features.file import FunctionName
 from capa.features.insn import API
 from capa.features.common import Characteristic
 
 logger = logging.getLogger(__name__)
 
-idalib_present = idalib.has_idalib()
-if idalib_present:
-    try:
-        if True:
-            # in order to use idalib, we have to import the idapro package
-            # which manipulates the search path as a side effect.
-            # we have to do this before importing ida_* packages.
-            # but isort wants to put idapro after ida_kernwin, so we use
-            # this dumb branch to keep the ordering correct.
-            import idapro  # noqa: F401 [imported but unused]
-        import ida_kernwin
+try:
+    if True:
+        # in order to use idalib, we have to import the idapro package
+        # which manipulates the search path as a side effect.
+        # we have to do this before importing ida_* packages.
+        # but isort wants to put idapro after ida_kernwin, so we use
+        # this dumb branch to keep the ordering correct.
+        import idapro  # noqa: F401 [imported but unused]
+    import ida_kernwin
 
-        kernel_version: str = ida_kernwin.get_kernel_version()
-    except ImportError:
-        idalib_present = False
-        kernel_version = "0.0"
-else:
+    kernel_version: str = ida_kernwin.get_kernel_version()
+    idalib_present = True
+except ImportError:
+    idalib_present = False
     kernel_version = "0.0"
 
 

--- a/tests/test_idalib_features.py
+++ b/tests/test_idalib_features.py
@@ -27,6 +27,11 @@ idalib_present = idalib.has_idalib()
 if idalib_present:
     try:
         if True:
+            # in order to use idalib, we have to import the idapro package
+            # which manipulates the search path as a side effect.
+            # we have to do this before importing ida_* packages.
+            # but isort wants to put idapro after ida_kernwin, so we use
+            # this dumb branch to keep the ordering correct.
             import idapro  # noqa: F401 [imported but unused]
         import ida_kernwin
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,7 +82,7 @@ def test_main_non_ascii_filename_nonexistent(tmpdir, caplog):
 
 def test_main_shellcode():
     path = str(fixtures.CD / "./data/499c2a85f6e8142c3f48d4251c9c7cd6.raw32")
-    
+
     assert capa.main.main([path, "-vv", "-f", "sc32"]) == 0
     assert capa.main.main([path, "-v", "-f", "sc32"]) == 0
     assert capa.main.main([path, "-j", "-f", "sc32"]) == 0
@@ -294,7 +294,11 @@ def extract_cape_report(tmp_path: Path, gz: Path) -> Path:
 
 
 def test_main_cape1(tmp_path):
-    path = extract_cape_report(tmp_path, fixtures.CD / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
+    path = extract_cape_report(
+        tmp_path,
+        fixtures.CD
+        / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz",
+    )
 
     # TODO(williballenthin): use default rules set
     # https://github.com/mandiant/capa/pull/1696
@@ -343,5 +347,8 @@ def test_main_cape1(tmp_path):
 
 def test_main_cape_gzip():
     # tests successful execution of .json.gz
-    path = str(fixtures.CD / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
+    path = str(
+        fixtures.CD
+        / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz"
+    )
     assert capa.main.main([path]) == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,9 +23,9 @@ import capa.main
 import capa.rules
 
 
-def test_main(z9324d_extractor):
+def test_main():
     # tests rules can be loaded successfully and all output modes
-    path = z9324d_extractor.path
+    path = str(fixtures.PMA1601)
     assert capa.main.main([path, "-vv"]) == 0
     assert capa.main.main([path, "-v"]) == 0
     assert capa.main.main([path, "-j"]) == 0
@@ -33,7 +33,7 @@ def test_main(z9324d_extractor):
     assert capa.main.main([path]) == 0
 
 
-def test_main_single_rule(z9324d_extractor, tmpdir):
+def test_main_single_rule(tmpdir):
     # tests a single rule can be loaded successfully
     RULE_CONTENT = textwrap.dedent("""
         rule:
@@ -47,12 +47,11 @@ def test_main_single_rule(z9324d_extractor, tmpdir):
             features:
               - string: test
         """)
-    path = z9324d_extractor.path
     rule_file = tmpdir.mkdir("capa").join("rule.yml")
     rule_file.write(RULE_CONTENT)
     assert (
         capa.main.main([
-            path,
+            str(fixtures.PMA1601),
             "-v",
             "-r",
             rule_file.strpath,
@@ -61,16 +60,17 @@ def test_main_single_rule(z9324d_extractor, tmpdir):
     )
 
 
-def test_main_non_ascii_filename(pingtaest_extractor, tmpdir, capsys):
+def test_main_non_ascii_filename(tmpdir, capsys):
     # here we print a string with unicode characters in it
     # (specifically, a byte string with utf-8 bytes in it, see file encoding)
     # only use one rule to speed up analysis
-    assert capa.main.main(["-q", pingtaest_extractor.path, "-r", "rules/communication/icmp"]) == 0
+    path = str(fixtures.CD / "./data/ping_täst.exe_")
+    assert capa.main.main(["-q", path, "-r", "rules/communication/icmp"]) == 0
 
     std = capsys.readouterr()
     # but here, we have to use a unicode instance,
     # because capsys has decoded the output for us.
-    assert pingtaest_extractor.path in std.out
+    assert path in std.out
 
 
 def test_main_non_ascii_filename_nonexistent(tmpdir, caplog):
@@ -80,8 +80,9 @@ def test_main_non_ascii_filename_nonexistent(tmpdir, caplog):
     assert NON_ASCII_FILENAME in caplog.text
 
 
-def test_main_shellcode(z499c2_extractor):
-    path = z499c2_extractor.path
+def test_main_shellcode():
+    path = str(fixtures.CD / "./data/499c2a85f6e8142c3f48d4251c9c7cd6.raw32")
+    
     assert capa.main.main([path, "-vv", "-f", "sc32"]) == 0
     assert capa.main.main([path, "-v", "-f", "sc32"]) == 0
     assert capa.main.main([path, "-j", "-f", "sc32"]) == 0
@@ -198,8 +199,8 @@ def test_ruleset():
     assert len(rules.call_rules) == 2
 
 
-def test_fix262(pma16_01_extractor, capsys):
-    path = pma16_01_extractor.path
+def test_fix262(capsys):
+    path = str(fixtures.CD / "./data/Practical Malware Analysis Lab 16-01.exe_")
     assert capa.main.main([path, "-vv", "-t", "send HTTP request", "-q"]) == 0
 
     std = capsys.readouterr()
@@ -207,11 +208,11 @@ def test_fix262(pma16_01_extractor, capsys):
     assert "www.practicalmalwareanalysis.com" not in std.out
 
 
-def test_not_render_rules_also_matched(z9324d_extractor, capsys):
+def test_not_render_rules_also_matched(capsys):
     # rules that are also matched by other rules should not get rendered by default.
     # this cuts down on the amount of output while giving approx the same detail.
     # see #224
-    path = z9324d_extractor.path
+    path = str(fixtures.CD / "./data/9324d1a8ae37a36ae560c37448c9705a.exe_")
 
     # `act as TCP client` matches on
     # `connect TCP client` matches on
@@ -234,7 +235,7 @@ def test_not_render_rules_also_matched(z9324d_extractor, capsys):
 
 
 def test_json_meta(capsys):
-    path = str(fixtures.get_data_path_by_name("pma01-01"))
+    path = str(fixtures.CD / "./data/Practical Malware Analysis Lab 01-01.dll_")
     assert capa.main.main([path, "-j"]) == 0
     std = capsys.readouterr()
     std_json = json.loads(std.out)
@@ -248,9 +249,9 @@ def test_json_meta(capsys):
             assert {"address": {"type": "absolute", "value": 0x1000108C}} in func["matched_basic_blocks"]
 
 
-def test_main_dotnet(_1c444_dotnetfile_extractor):
+def test_main_dotnet():
     # tests successful execution and all output modes
-    path = _1c444_dotnetfile_extractor.path
+    path = str(fixtures.CD / "./data/dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_")
     assert capa.main.main([path, "-vv"]) == 0
     assert capa.main.main([path, "-v"]) == 0
     assert capa.main.main([path, "-j"]) == 0
@@ -258,27 +259,27 @@ def test_main_dotnet(_1c444_dotnetfile_extractor):
     assert capa.main.main([path]) == 0
 
 
-def test_main_dotnet2(_692f_dotnetfile_extractor):
+def test_main_dotnet2():
     # tests successful execution and one rendering
     # above covers all output modes
-    path = _692f_dotnetfile_extractor.path
+    path = str(fixtures.CD / "./data/dotnet/692f7fd6d198e804d6af98eb9e390d61.exe_")
     assert capa.main.main([path, "-vv"]) == 0
 
 
-def test_main_dotnet3(_0953c_dotnetfile_extractor):
+def test_main_dotnet3():
     # tests successful execution and one rendering
-    path = _0953c_dotnetfile_extractor.path
+    path = str(fixtures.CD / "./data/0953cc3b77ed2974b09e3a00708f88de931d681e2d0cb64afbaf714610beabe6.exe_")
     assert capa.main.main([path, "-vv"]) == 0
 
 
-def test_main_dotnet4(_039a6_dotnetfile_extractor):
+def test_main_dotnet4():
     # tests successful execution and one rendering
-    path = _039a6_dotnetfile_extractor.path
+    path = str(fixtures.CD / "./data/039a6336d0802a2255669e6867a5679c7eb83313dbc61fb1c7232147379bd304.exe_")
     assert capa.main.main([path, "-vv"]) == 0
 
 
 def test_main_rd():
-    path = str(fixtures.get_data_path_by_name("pma01-01-rd"))
+    path = str(fixtures.CD / "./data/rd/Practical Malware Analysis Lab 01-01.dll_.json")
     assert capa.main.main([path, "-vv"]) == 0
     assert capa.main.main([path, "-v"]) == 0
     assert capa.main.main([path, "-j"]) == 0
@@ -293,7 +294,7 @@ def extract_cape_report(tmp_path: Path, gz: Path) -> Path:
 
 
 def test_main_cape1(tmp_path):
-    path = extract_cape_report(tmp_path, fixtures.get_data_path_by_name("0000a657"))
+    path = extract_cape_report(tmp_path, fixtures.CD / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
 
     # TODO(williballenthin): use default rules set
     # https://github.com/mandiant/capa/pull/1696
@@ -342,5 +343,5 @@ def test_main_cape1(tmp_path):
 
 def test_main_cape_gzip():
     # tests successful execution of .json.gz
-    path = str(fixtures.get_data_path_by_name("0000a657"))
+    path = str(fixtures.CD / "./data/dynamic/cape/v2.2/0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz")
     assert capa.main.main([path]) == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,7 +70,7 @@ def test_main_non_ascii_filename(tmpdir, capsys):
     std = capsys.readouterr()
     # but here, we have to use a unicode instance,
     # because capsys has decoded the output for us.
-    assert path in std.out
+    assert Path(path).as_posix() in std.out
 
 
 def test_main_non_ascii_filename_nonexistent(tmpdir, caplog):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -63,7 +63,7 @@ def test_optimizer_order():
                     - arch: amd64
                     - mnemonic: cmp
                     - and:
-                      - bytes: 3
+                      - bytes: 03 04 05
                       - offset: 2
                     - or:
                       - number: 1

--- a/tests/test_os_detection.py
+++ b/tests/test_os_detection.py
@@ -14,9 +14,8 @@
 
 import io
 import zlib
-from pathlib import Path
 
-from fixtures import get_data_path_by_name
+import fixtures
 
 import capa.features.extractors.elf
 import capa.features.extractors.common
@@ -31,8 +30,8 @@ def test_elf_sh_notes():
     # guess: ABI versions needed: None
     # guess: symtab: None
     # guess: needed dependencies: None
-    path = get_data_path_by_name("2f7f5f")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "2f7f5fb5de175e770d7eae87666f9831.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "linux"
 
 
@@ -44,8 +43,8 @@ def test_elf_pt_notes():
     # guess: ABI versions needed: OS.LINUX
     # guess: symtab: None
     # guess: needed dependencies: None
-    path = get_data_path_by_name("7351f.elf")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "7351f8a40c5450557b24622417fc478d.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "linux"
 
 
@@ -57,8 +56,8 @@ def test_elf_so_needed():
     # guess: ABI versions needed: OS.HURD
     # guess: symtab: None
     # guess: needed dependencies: OS.HURD
-    path = get_data_path_by_name("b5f052")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "b5f0524e69b3a3cf636c7ac366ca57bf5e3a8fdc8a9f01caf196c611a7918a87.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "hurd"
 
 
@@ -70,8 +69,8 @@ def test_elf_abi_version_hurd():
     # guess: ABI versions needed: OS.HURD
     # guess: symtab: None
     # guess: needed dependencies: None
-    path = get_data_path_by_name("bf7a9c")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "bf7a9c8bdfa6d47e01ad2b056264acc3fd90cf43fe0ed8deec93ab46b47d76cb.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "hurd"
 
 
@@ -83,8 +82,8 @@ def test_elf_symbol_table():
     # guess: ABI versions needed: None
     # guess: symtab: OS.LINUX
     # guess: needed dependencies: None
-    path = get_data_path_by_name("2bf18d")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "2bf18d0403677378adad9001b1243211.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "linux"
 
 
@@ -95,14 +94,14 @@ def test_elf_android_notes():
     # DEBUG:capa.features.extractors.elf:guess: linker: None
     # DEBUG:capa.features.extractors.elf:guess: ABI versions needed: None
     # DEBUG:capa.features.extractors.elf:guess: needed dependencies: OS.ANDROID
-    path = get_data_path_by_name("1038a2")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "1038a23daad86042c66bfe6c9d052d27048de9653bde5750dc0f240c792d9ac8.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "android"
 
 
 def test_elf_go_buildinfo():
-    path = get_data_path_by_name("3da7c")
-    with Path(path).open("rb") as f:
+    path = fixtures.CD / "data" / "3da7c2c70a2d93ac4643f20339d5c7d61388bddd77a4a5fd732311efad78e535.elf_"
+    with path.open("rb") as f:
         assert capa.features.extractors.elf.detect_elf_os(f) == "linux"
 
 

--- a/tests/test_pefile_features.py
+++ b/tests/test_pefile_features.py
@@ -12,24 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import fixtures
 
-import capa.features.file
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="pefile",
+    get_extractor=fixtures.get_pefile_extractor,
+    include_tags={"static"},
+    exclude_tags={
+        "dotnet",
+        "elf",
+        # pefile is a file-scope extractor; drop non-file scopes
+        "function",
+        "basic-block",
+        "instruction",
+        # and drop feature types pefile doesn't produce
+        "function-name",
+    },
 )
-def test_pefile_features(sample, scope, feature, expected):
-    if scope.__name__ != "file":
-        pytest.xfail("pefile only extracts file scope features")
 
-    if isinstance(feature, capa.features.file.FunctionName):
-        pytest.xfail("pefile doesn't extract function names")
 
-    if ".elf" in sample.name:
-        pytest.xfail("pefile doesn't handle ELF files")
-    fixtures.do_test_feature_presence(fixtures.get_pefile_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_pefile_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)

--- a/tests/test_pefile_features.py
+++ b/tests/test_pefile_features.py
@@ -11,26 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="pefile",
-    get_extractor=fixtures.get_pefile_extractor,
-    include_tags={"static"},
-    exclude_tags={
-        "dotnet",
-        "elf",
-        # pefile is a file-scope extractor; drop non-file scopes
-        "function",
-        "basic-block",
-        "instruction",
-        # and drop feature types pefile doesn't produce
-        "function-name",
-    },
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="pefile",
+        include_tags={"static"},
+        exclude_tags={
+            "dotnet",
+            "elf",
+            # pefile is a file-scope extractor; drop non-file scopes
+            "function",
+            "basic block",
+            "instruction",
+            # and drop feature types pefile doesn't produce
+            "function-name",
+        },
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_pefile_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_pefile_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -14,6 +14,7 @@
 
 import copy
 from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -26,21 +27,26 @@ import capa.render.result_document as rd
 import capa.features.freeze.features
 from capa.helpers import assert_never
 
+CD = Path(__file__).resolve().parent
 
-@pytest.mark.parametrize(
-    "rd_file",
-    [
-        pytest.param("a3f3bbc_rd"),
-        pytest.param("al_khaserx86_rd"),
-        pytest.param("al_khaserx64_rd"),
-        pytest.param("a076114_rd"),
-        pytest.param("pma0101_rd"),
-        pytest.param("dotnet_1c444e_rd"),
-        pytest.param("dynamic_a0000a6_rd"),
-    ],
+STATIC_RD_FILES = [
+    pytest.param(CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json", id="a3f3bbc"),
+    pytest.param(CD / "data" / "rd" / "al-khaser_x86.exe_.json", id="al_khaserx86"),
+    pytest.param(CD / "data" / "rd" / "al-khaser_x64.exe_.json", id="al_khaserx64"),
+    pytest.param(CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json", id="a076114"),
+    pytest.param(CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json", id="pma0101"),
+    pytest.param(CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json", id="dotnet_1c444e"),
+]
+
+DYNAMIC_RD_FILE = pytest.param(
+    CD / "data" / "rd" / "0000a65749f5902c4d82ffa701198038f0b4870b00a27cfca109f8f933476d82.json.gz",
+    id="dynamic_a0000a6",
 )
-def test_doc_to_pb2(request, rd_file):
-    src: rd.ResultDocument = request.getfixturevalue(rd_file)
+
+
+@pytest.mark.parametrize("rd_path", STATIC_RD_FILES + [DYNAMIC_RD_FILE])
+def test_doc_to_pb2(rd_path):
+    src = rd.ResultDocument.from_file(rd_path)
     dst = capa.render.proto.doc_to_pb2(src)
 
     assert_meta(src.meta, dst.meta)
@@ -398,18 +404,7 @@ def assert_round_trip(doc: rd.ResultDocument):
     assert one_bytes != three_bytes
 
 
-@pytest.mark.parametrize(
-    "rd_file",
-    [
-        pytest.param("a3f3bbc_rd"),
-        pytest.param("al_khaserx86_rd"),
-        pytest.param("al_khaserx64_rd"),
-        pytest.param("a076114_rd"),
-        pytest.param("pma0101_rd"),
-        pytest.param("dotnet_1c444e_rd"),
-        pytest.param("dynamic_a0000a6_rd"),
-    ],
-)
-def test_round_trip(request, rd_file):
-    doc: rd.ResultDocument = request.getfixturevalue(rd_file)
+@pytest.mark.parametrize("rd_path", STATIC_RD_FILES + [DYNAMIC_RD_FILE])
+def test_round_trip(rd_path):
+    doc = rd.ResultDocument.from_file(rd_path)
     assert_round_trip(doc)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -254,8 +254,11 @@ def test_render_vverbose_feature(feature, expected):
     assert output == expected
 
 
-def test_render_default_returns_non_empty(pma0101_rd):
-    output = capa.render.default.render_default(pma0101_rd)
+def test_render_default_returns_non_empty():
+    rd = capa.render.result_document.ResultDocument.from_file(
+        fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
+    )
+    output = capa.render.default.render_default(rd)
     assert output != ""
     assert "md5" in output
     assert "290934c61de9176ad682ffdd65f0a669" in output

--- a/tests/test_result_document.py
+++ b/tests/test_result_document.py
@@ -284,12 +284,12 @@ def test_round_trip(request, rd_file):
 
 
 def test_json_to_rdoc():
-    path = fixtures.get_data_path_by_name("pma01-01-rd")
+    path = fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
     assert isinstance(rdoc.ResultDocument.from_file(path), rdoc.ResultDocument)
 
 
 def test_rdoc_to_capa():
-    path = fixtures.get_data_path_by_name("pma01-01-rd")
+    path = fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
 
     rd = rdoc.ResultDocument.from_file(path)
 

--- a/tests/test_result_document.py
+++ b/tests/test_result_document.py
@@ -268,18 +268,18 @@ def assert_round_trip(rd: rdoc.ResultDocument):
 
 
 @pytest.mark.parametrize(
-    "rd_file",
+    "rd_path",
     [
-        pytest.param("a3f3bbc_rd"),
-        pytest.param("al_khaserx86_rd"),
-        pytest.param("al_khaserx64_rd"),
-        pytest.param("a076114_rd"),
-        pytest.param("pma0101_rd"),
-        pytest.param("dotnet_1c444e_rd"),
+        pytest.param(fixtures.CD / "data" / "rd" / "3f3bbcf8fd90bdcdcdc5494314ed4225.exe_.json", id="a3f3bbc"),
+        pytest.param(fixtures.CD / "data" / "rd" / "al-khaser_x86.exe_.json", id="al_khaserx86"),
+        pytest.param(fixtures.CD / "data" / "rd" / "al-khaser_x64.exe_.json", id="al_khaserx64"),
+        pytest.param(fixtures.CD / "data" / "rd" / "0761142efbda6c4b1e801223de723578.dll_.json", id="a076114"),
+        pytest.param(fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json", id="pma0101"),
+        pytest.param(fixtures.CD / "data" / "rd" / "1c444ebeba24dcba8628b7dfe5fec7c6.exe_.json", id="dotnet_1c444e"),
     ],
 )
-def test_round_trip(request, rd_file):
-    rd: rdoc.ResultDocument = request.getfixturevalue(rd_file)
+def test_round_trip(rd_path):
+    rd = rdoc.ResultDocument.from_file(rd_path)
     assert_round_trip(rd)
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -29,11 +29,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_script_path(s: str):
-    return str(fixtures.CD /".." / "scripts" / s)
+    return str(fixtures.CD / ".." / "scripts" / s)
 
 
 def get_binary_file_path():
-    return str(fixtures.CD /"data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
+    return str(fixtures.CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
 
 
 def get_cape_report_file_path():
@@ -48,11 +48,11 @@ def get_cape_report_file_path():
 
 
 def get_binexport2_file_path():
-    return str(fixtures.CD /"data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
+    return str(fixtures.CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
 
 
 def get_rules_path():
-    return str(fixtures.CD /".." / "rules")
+    return str(fixtures.CD / ".." / "rules")
 
 
 def get_rule_path():
@@ -66,7 +66,7 @@ def get_rule_path():
         pytest.param("capafmt.py", [get_rule_path()]),
         pytest.param(
             "capa2sarif.py",
-            [fixtures.CD /"data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"],
+            [fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"],
         ),
         # testing some variations of linter script
         pytest.param("lint.py", ["-t", "create directory", get_rules_path()]),
@@ -109,7 +109,7 @@ def test_bulk_process(tmp_path):
     t = tmp_path / "test"
     t.mkdir()
 
-    source_file = fixtures.CD /"data" / "ping_täst.exe_"
+    source_file = fixtures.CD / "data" / "ping_täst.exe_"
     dest_file = t / "test.exe_"
 
     dest_file.write_bytes(source_file.read_bytes())
@@ -148,7 +148,7 @@ def run_program(script_path, args):
 def test_proto_conversion(tmp_path):
     t = tmp_path / "proto-test"
     t.mkdir()
-    json_file = fixtures.CD /"data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
+    json_file = fixtures.CD / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
 
     p = run_program(get_script_path("proto-from-results.py"), [json_file])
     assert p.returncode == 0

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -23,23 +23,22 @@ from pathlib import Path
 import pytest
 
 import capa.rules
+import fixtures
 
 logger = logging.getLogger(__name__)
 
-CD = Path(__file__).resolve().parent
-
 
 def get_script_path(s: str):
-    return str(CD / ".." / "scripts" / s)
+    return str(fixtures.CD /".." / "scripts" / s)
 
 
 def get_binary_file_path():
-    return str(CD / "data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
+    return str(fixtures.CD /"data" / "9324d1a8ae37a36ae560c37448c9705a.exe_")
 
 
 def get_cape_report_file_path():
     return str(
-        CD
+        fixtures.CD
         / "data"
         / "dynamic"
         / "cape"
@@ -49,11 +48,11 @@ def get_cape_report_file_path():
 
 
 def get_binexport2_file_path():
-    return str(CD / "data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
+    return str(fixtures.CD /"data" / "binexport2" / "mimikatz.exe_.ghidra.BinExport")
 
 
 def get_rules_path():
-    return str(CD / ".." / "rules")
+    return str(fixtures.CD /".." / "rules")
 
 
 def get_rule_path():
@@ -67,7 +66,7 @@ def get_rule_path():
         pytest.param("capafmt.py", [get_rule_path()]),
         pytest.param(
             "capa2sarif.py",
-            [Path(__file__).resolve().parent / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"],
+            [fixtures.CD /"data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"],
         ),
         # testing some variations of linter script
         pytest.param("lint.py", ["-t", "create directory", get_rules_path()]),
@@ -98,7 +97,7 @@ def test_scripts(script, args):
 )
 def test_binexport_scripts(script, args):
     # define sample bytes location
-    os.environ["CAPA_SAMPLES_DIR"] = str(Path(CD / "data"))
+    os.environ["CAPA_SAMPLES_DIR"] = str(fixtures.CD / "data")
 
     script_path = get_script_path(script)
     p = run_program(script_path, args)
@@ -110,7 +109,7 @@ def test_bulk_process(tmp_path):
     t = tmp_path / "test"
     t.mkdir()
 
-    source_file = Path(__file__).resolve().parent / "data" / "ping_täst.exe_"
+    source_file = fixtures.CD /"data" / "ping_täst.exe_"
     dest_file = t / "test.exe_"
 
     dest_file.write_bytes(source_file.read_bytes())
@@ -149,7 +148,7 @@ def run_program(script_path, args):
 def test_proto_conversion(tmp_path):
     t = tmp_path / "proto-test"
     t.mkdir()
-    json_file = Path(__file__).resolve().parent / "data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
+    json_file = fixtures.CD /"data" / "rd" / "Practical Malware Analysis Lab 01-01.dll_.json"
 
     p = run_program(get_script_path("proto-from-results.py"), [json_file])
     assert p.returncode == 0

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -21,11 +21,13 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
-import capa.rules
 import fixtures
 
+import capa.rules
+
 logger = logging.getLogger(__name__)
+
+CD = Path(__file__).resolve().parent
 
 
 def get_script_path(s: str):

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -14,20 +14,14 @@
 
 import fixtures
 
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_PRESENCE_TESTS + fixtures.FEATURE_SYMTAB_FUNC_TESTS,
-    indirect=["sample", "scope"],
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="viv",
+    get_extractor=fixtures.get_viv_extractor,
+    include_tags={"static"},
+    exclude_tags={"dotnet", "ghidra"},
 )
-def test_viv_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_viv_extractor, sample, scope, feature, expected)
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    fixtures.FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_viv_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_viv_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_viv_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -11,17 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="viv",
-    get_extractor=fixtures.get_viv_extractor,
-    include_tags={"static"},
-    exclude_tags={"dotnet", "ghidra"},
+
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="viv",
+        include_tags={"static"},
+        exclude_tags={"dotnet", "ghidra"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_viv_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_viv_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -14,7 +14,6 @@
 import fixtures
 
 
-
 @fixtures.parametrize_backend_feature_fixtures(
     fixtures.BackendFeaturePolicy(
         name="viv",

--- a/tests/test_vmray_features.py
+++ b/tests/test_vmray_features.py
@@ -11,24 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import fixtures
 
-BACKEND = fixtures.BackendFeaturePolicy(
-    name="vmray",
-    get_extractor=fixtures.get_vmray_extractor,
-    include_tags={"vmray"},
+
+@fixtures.parametrize_backend_feature_fixtures(
+    fixtures.BackendFeaturePolicy(
+        name="vmray",
+        include_tags={"vmray"},
+    )
 )
-
-
-@fixtures.parametrize_backend_feature_fixtures(BACKEND)
 def test_vmray_features(feature_fixture):
-    fixtures.run_feature_fixture(BACKEND, feature_fixture)
+    extractor = fixtures.get_vmray_extractor(feature_fixture.sample_path)
+    fixtures.run_feature_fixture(extractor, feature_fixture)
 
 
 def test_vmray_processes():
     # see #2394
-    path = fixtures.get_data_path_by_name("2f8a79-vmray")
+    path = fixtures.CD / "data" / "dynamic" / "vmray" / "2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip"
     vmre = fixtures.get_vmray_extractor(path)
     assert len(vmre.analysis.monitor_processes) == 9

--- a/tests/test_vmray_features.py
+++ b/tests/test_vmray_features.py
@@ -27,6 +27,12 @@ def test_vmray_features(feature_fixture):
 
 def test_vmray_processes():
     # see #2394
-    path = fixtures.CD / "data" / "dynamic" / "vmray" / "2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip"
+    path = (
+        fixtures.CD
+        / "data"
+        / "dynamic"
+        / "vmray"
+        / "2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip"
+    )
     vmre = fixtures.get_vmray_extractor(path)
     assert len(vmre.analysis.monitor_processes) == 9

--- a/tests/test_vmray_features.py
+++ b/tests/test_vmray_features.py
@@ -15,128 +15,16 @@
 
 import fixtures
 
-import capa.features.file
-import capa.features.insn
-import capa.features.common
-
-DYNAMIC_VMRAY_FEATURE_PRESENCE_TESTS = sorted(
-    [
-        ("93b2d1-vmray", "file", capa.features.common.String("api.%x%x.%s"), True),
-        ("93b2d1-vmray", "file", capa.features.common.String("\\Program Files\\WindowsApps\\does_not_exist"), False),
-        # file/imports
-        ("93b2d1-vmray", "file", capa.features.file.Import("GetAddrInfoW"), True),
-        ("93b2d1-vmray", "file", capa.features.file.Import("GetAddrInfo"), True),
-        # thread/api calls
-        ("93b2d1-vmray", "process=(2176:0),thread=2180", capa.features.insn.API("LoadLibraryExA"), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2180", capa.features.insn.API("LoadLibraryEx"), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("GetAddrInfoW"), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("GetAddrInfo"), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("DoesNotExist"), False),
-        # call/api
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2361", capa.features.insn.API("GetAddrInfoW"), True),
-        ("eb1287-vmray", "process=(4968:0),thread=5992,call=10981", capa.features.insn.API("CreateMutexW"), True),
-        # call/string argument
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2420,call=10323",
-            capa.features.common.String("raw.githubusercontent.com"),
-            True,
-        ),
-        # backslashes in paths; see #2428
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2180,call=267",
-            capa.features.common.String("C:\\Users\\WhuOXYsD\\Desktop\\filename.exe"),
-            True,
-        ),
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2180,call=267",
-            capa.features.common.String("C:\\\\Users\\\\WhuOXYsD\\\\Desktop\\\\filename.exe"),
-            False,
-        ),
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2204,call=2395",
-            capa.features.common.String("Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"),
-            True,
-        ),
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2204,call=2395",
-            capa.features.common.String("Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Policies\\\\System"),
-            False,
-        ),
-        # call/number argument
-        # VirtualAlloc(4096, 4)
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2358", capa.features.insn.Number(4096), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2358", capa.features.insn.Number(4), True),
-        # call/number argument - registry API parameters (issue #2)
-        # RegOpenKeyExW(Software\Microsoft\Windows\CurrentVersion\Policies\System, 0, 131078)
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(2147483649), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(0), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(131078), True),
-        # RegOpenKeyExW call 2397 (same parameters)
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2397", capa.features.insn.Number(2147483649), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2397", capa.features.insn.Number(0), True),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2397", capa.features.insn.Number(131078), True),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
-)
-
-DYNAMIC_VMRAY_FEATURE_COUNT_TESTS = sorted(
-    [
-        # file/imports
-        ("93b2d1-vmray", "file", capa.features.file.Import("GetAddrInfoW"), 1),
-        # thread/api calls
-        ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("free"), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420", capa.features.insn.API("GetAddrInfoW"), 5),
-        # call/api
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2345", capa.features.insn.API("free"), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2345", capa.features.insn.API("GetAddrInfoW"), 0),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=2361", capa.features.insn.API("GetAddrInfoW"), 1),
-        # call/string argument
-        (
-            "93b2d1-vmray",
-            "process=(2176:0),thread=2420,call=10323",
-            capa.features.common.String("raw.githubusercontent.com"),
-            1,
-        ),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=10323", capa.features.common.String("non_existant"), 0),
-        # call/number argument
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=10315", capa.features.insn.Number(4096), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=10315", capa.features.insn.Number(4), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2420,call=10315", capa.features.insn.Number(404), 0),
-        # call/number argument - registry API parameters (issue #2)
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(2147483649), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(0), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(131078), 1),
-        ("93b2d1-vmray", "process=(2176:0),thread=2204,call=2395", capa.features.insn.Number(999999), 0),
-    ],
-    # order tests by (file, item)
-    # so that our LRU cache is most effective.
-    key=lambda t: (t[0], t[1]),
+BACKEND = fixtures.BackendFeaturePolicy(
+    name="vmray",
+    get_extractor=fixtures.get_vmray_extractor,
+    include_tags={"vmray"},
 )
 
 
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_VMRAY_FEATURE_PRESENCE_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_vmray_features(sample, scope, feature, expected):
-    fixtures.do_test_feature_presence(fixtures.get_vmray_extractor, sample, scope, feature, expected)
-
-
-@fixtures.parametrize(
-    "sample,scope,feature,expected",
-    DYNAMIC_VMRAY_FEATURE_COUNT_TESTS,
-    indirect=["sample", "scope"],
-)
-def test_vmray_feature_counts(sample, scope, feature, expected):
-    fixtures.do_test_feature_count(fixtures.get_vmray_extractor, sample, scope, feature, expected)
+@fixtures.parametrize_backend_feature_fixtures(BACKEND)
+def test_vmray_features(feature_fixture):
+    fixtures.run_feature_fixture(BACKEND, feature_fixture)
 
 
 def test_vmray_processes():


### PR DESCRIPTION
closes #2743

This PR refactors our test suite with the primary goal of making the feature tests data-driven; that is, we now have a collection of JSON files that describe where backends should find various features. This enables non-Python implementations of capa to demonstrate that they extract the features we'd expect.

Along the way, I also made some other cleanups. In particular, I tried to simplify `fixtures.py` a bit. I removed a lot of the symbolic extractors (e.g., `pma01_03_extractor`) since many were used only once or twice in other modules; I inlined this logic with more explicit code. I figure, more obvious code -> easier to mechanically port to another language. Pytest fixtures as magic test function parameter names is not that easy to reason about...

To the reviewers, I request a thorough review of not just the code style, but of the underlying implementation, design, decisions, etc. I think you should set aside an hour for this.

Here's how I'd recommend that you review these changes:
- read the new [`test_viv_extractor.py`](https://github.com/mandiant/capa/blob/data-fixtures-2/tests/test_viv_features.py) to see how a backend test now looks
- read [`tests/fixtures/features/README.md`](https://github.com/mandiant/capa/blob/data-fixtures-2/tests/fixtures/features/README.md) and [`static.json`](https://github.com/mandiant/capa/blob/data-fixtures-2/tests/fixtures/features/static.json) to see how the features are declared
- read [`fixtures.py`](https://github.com/mandiant/capa/blob/data-fixtures-2/tests/fixtures.py) for familiarity. don't read the diff, read the final.
- read various diffs when they're reasonable, but i'm afraid there's a bunch of churn, so it may not be easy to parse. focus on the end result, imho, and possibly ask Gemini for any hotspots.

To be clear, there's moderate risk here: I've translated the existing feature test cases to a new format, and I might have missed or corrupted some of them. In some scenarios, I tried to consolidate feature test cases (like when IDA only worked on some samples, and Ghidra on a different set) and it's possible that I mangled the underlying intent. However, I did my best and the test suite probably high quality. I believe we should accept this risk, but you should think about this, too.


### Checklist

- [x] This submission includes AI-generated code and I have provided details in the description.
