### PR TITLE
deps: update vivisect to 1.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,6 @@ setuptools==80.10.1
 six==1.17.0
 sortedcontainers==2.4.0
 viv-utils==0.8.0
-vivisect==1.3.1
+vivisect==1.3.2
 msgspec==0.20.0
 bump-my-version==1.3.0


### PR DESCRIPTION
This PR updates the vivisect dependency to version 1.3.2 in requirements.txt.

- [x] No CHANGELOG update needed
- [x] No new tests needed
- [x] No documentation update needed