### PR TITLE
tests: update expected Binary Ninja version to 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### capa Explorer IDA Pro plugin
 
 ### Development
+- tests: update binja version to 5.3 @mr-tz #3011
 - ci: use explicit and per job permissions @mike-hunhoff #3002
 - replace black/isort/flake8 with ruff @mike-hunhoff #2992
 

--- a/tests/test_binja_features.py
+++ b/tests/test_binja_features.py
@@ -70,4 +70,4 @@ def test_standalone_binja_backend():
 @pytest.mark.skipif(binja_present is False, reason="Skip binja tests if the binaryninja Python API is not installed")
 def test_binja_version():
     version = binaryninja.core_version_info()
-    assert version.major == 5 and version.minor == 2
+    assert (version.major, version.minor) >= (5, 3)


### PR DESCRIPTION
Updates the expected Binary Ninja version in test_binja_version to 5.3. This fix addresses the test failure caused by the recent update of Binary Ninja to version 5.3 in the environment.