### PR TITLE
fix: optimizer doesn't recurse into And/Or/Some children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- fix: optimizer doesn't recurse into And/Or/Some children @williballenthin #3020
+
 ### capa Explorer Web
 
 ### capa Explorer IDA Pro plugin

--- a/capa/optimizer.py
+++ b/capa/optimizer.py
@@ -62,6 +62,8 @@ def optimize_statement(statement):
     if isinstance(statement, (ceng.And, ceng.Or, ceng.Some)):
         # has .children
         statement.children = sorted(statement.children, key=get_node_cost)
+        for child in statement.children:
+            optimize_statement(child)
         return
     elif isinstance(statement, (ceng.Not, ceng.Range)):
         # has .child

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -24,6 +24,33 @@ from capa.features.insn import Mnemonic
 from capa.features.common import Arch, Substring
 
 
+def test_optimizer_recurses_into_nested_compound():
+    rule = textwrap.dedent("""
+        rule:
+            meta:
+                name: test rule
+                scopes:
+                    static: function
+                    dynamic: process
+            features:
+                - and:
+                    - mnemonic: cmp
+                    - or:
+                      - substring: "foo"
+                      - arch: amd64
+        """)
+    r = capa.rules.Rule.from_yaml(rule)
+
+    capa.optimizer.optimize_rules([r])
+
+    outer_children = list(r.statement.get_children())
+    inner_or = next(c for c in outer_children if isinstance(c, Or))
+    inner_children = list(inner_or.get_children())
+
+    assert isinstance(inner_children[0], Arch)
+    assert isinstance(inner_children[1], Substring)
+
+
 def test_optimizer_order():
     rule = textwrap.dedent("""
         rule:


### PR DESCRIPTION
Closes #3020