### PR TITLE
fix: dotnetfile.py: missing import for capa.features.extractors.common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 -
 
 ### Bug Fixes
+- fix: dotnetfile.py: missing import for capa.features.extractors.common @williballenthin #3026
 
 ### capa Explorer Web
 

--- a/capa/features/extractors/dotnetfile.py
+++ b/capa/features/extractors/dotnetfile.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import dnfile
 import pefile
 
+import capa.features.extractors.common
 import capa.features.extractors.helpers
 from capa.features.file import Import, FunctionName
 from capa.features.common import (


### PR DESCRIPTION
Closes #3026