### PR TITLE
incorrect bytes() constructor usage in buf_filled_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 - fix: replace assert with isinstance guard in get_callee for invalid MethodSpec tokens @williballenthin
 - fix: assign ConfigDict to model_config in ConciseModel so extra="ignore" is actually applied @williballenthin (SURF-42)
 - fix: replace assert with isinstance guard in get_callee for invalid MethodSpec tokens @williballenthin (SURF-41)
+- fix: incorrect bytes() constructor usage in buf_filled_with @mike-hunhoff #3077
 
 ### capa Explorer Web
 

--- a/capa/features/extractors/strings.py
+++ b/capa/features/extractors/strings.py
@@ -57,7 +57,7 @@ def buf_filled_with(buf: bytes, character: int) -> bool:
         return all(b == character for b in buf)
 
     # single big allocation, re-used each loop
-    dupe_chunk = bytes(character) * SLICE_SIZE
+    dupe_chunk = bytes([character]) * SLICE_SIZE
 
     for offset in range(0, len(buf), SLICE_SIZE):
         # bytes objects are immutable, so the slices share the underlying array,

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -34,6 +34,12 @@ def test_buf_filled_with():
     assert buf_filled_with(b"", 0x00) is False  # Empty buffer
     assert buf_filled_with(b"\x00", 0x00) is True  # Single byte
 
+    # Large buffers (exercise chunked processing)
+    assert buf_filled_with(b"A" * 5000, ord("A")) is True
+    assert buf_filled_with(b"A" * 5000 + b"B", ord("A")) is False
+    assert buf_filled_with(b"\xff" * 5000, 0xFF) is True
+    assert buf_filled_with(b"\x00" * 5000, 0x00) is True
+
 
 def test_extract_ascii_strings():
     # test empty buffer


### PR DESCRIPTION
## Bug Fix: Incorrect `bytes()` constructor usage in `buf_filled_with`

### Description
In `capa/features/extractors/strings.py:buf_filled_with`, the code used `bytes(character) * SLICE_SIZE` to create a repeating chunk of a specific character. However, in Python 3, `bytes(int)` creates a null-filled buffer of that length, rather than a single byte with that value. 

This caused the chunked comparison for large buffers (>= 4096 bytes) to fail for characters in the `REPEATS` set (like `'A'`, `0xFE`, `0xFF`), because the constructed `dupe_chunk` had an incorrect length and content. This effectively disabled the optimization intended to skip large blocks of filler data (like section padding), causing unnecessary regex scanning overhead.

### Fix
Changed `bytes(character)` to `bytes([character])` to correctly create a 1-byte buffer containing the character value before multiplying by `SLICE_SIZE`.

### Tests
Added unit tests in `tests/test_strings.py` with buffers larger than 4096 bytes to ensure coverage of the chunked processing logic in `buf_filled_with`.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [x] This submission includes AI-generated code and I have provided details in the description.
