### PR TITLE
fix duplicate rule candidate evaluation in optimized matching engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - fix: incorrect bytes() constructor usage in buf_filled_with @mike-hunhoff #3077
 - fix: remove redundant code related to cli loading @mike-hunhoff #3076
 - fix: optimize all_zeros using fast bytes comparison @mike-hunhoff #3078
+- fix: duplicate rule candidate evaluation in optimized matching engine @mike-hunhoff #3080
 
 ### capa Explorer Web
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -2269,12 +2269,10 @@ class RuleSet:
                     new_candidates: set[str] = set()
                     for new_feature in new_features:
                         for candidate_name in feature_index.rules_by_feature.get(new_feature, ()):
-                            # Prevent duplicate candidate evaluation across two cases:
-                            # Case 1 (Global): Do not add rules already in `candidate_rule_names` (which tracks all
-                            # rule names ever seeded or evaluated in previous iterations of the loop).
-                            # Case 2 (Local): By using a `set` for `new_candidates`, we prevent a rule from being
-                            # added twice in the *same* iteration if it gets triggered by both the matched rule
-                            # name and its namespace.
+                            # Deduplicate candidate rules at two levels:
+                            # 1. Globally: Ensure we don't re-queue rules already evaluated or waiting in `candidate_rule_names`.
+                            # 2. Locally: The `new_candidates` set prevents duplicates if a rule is triggered
+                            #    by both the matched rule name and its namespace in the same pass.
                             if candidate_name not in candidate_rule_names:
                                 new_candidates.add(candidate_name)
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -2266,9 +2266,17 @@ class RuleSet:
                     new_features.append(capa.features.common.MatchedRule(namespace))
 
                 if new_features:
-                    new_candidates: list[str] = []
+                    new_candidates: set[str] = set()
                     for new_feature in new_features:
-                        new_candidates.extend(feature_index.rules_by_feature.get(new_feature, ()))
+                        for candidate_name in feature_index.rules_by_feature.get(new_feature, ()):
+                            # Prevent duplicate candidate evaluation across two cases:
+                            # Case 1 (Global): Do not add rules already in `candidate_rule_names` (which tracks all
+                            # rule names ever seeded or evaluated in previous iterations of the loop).
+                            # Case 2 (Local): By using a `set` for `new_candidates`, we prevent a rule from being
+                            # added twice in the *same* iteration if it gets triggered by both the matched rule
+                            # name and its namespace.
+                            if candidate_name not in candidate_rule_names:
+                                new_candidates.add(candidate_name)
 
                     if new_candidates:
                         candidate_rule_names.update(new_candidates)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -973,9 +973,9 @@ def test_match_no_duplicate_candidate_evaluations():
     """
     Ensure that when a rule has multiple candidate paths to trigger it,
     it is evaluated only once and does not create duplicate match results.
-    Covers both Case 1 (Global deduplication against already-queued/evaluated rules)
-    and Case 2 (Local deduplication when multiple features trigger the same candidate
-    within the same iteration).
+    Verifies both global deduplication (avoiding re-queuing rules already
+    evaluated/queued) and local deduplication (avoiding duplicate queueing when
+    multiple features trigger the same candidate in a single pass).
     """
     rules = [
         capa.rules.Rule.from_yaml(

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -967,3 +967,82 @@ def test_bytes_prefix_index_mixed_short_and_long_patterns():
     )
     assert "test short pattern rule" not in matches
     assert "test long pattern rule" in matches
+
+
+def test_match_no_duplicate_candidate_evaluations():
+    """
+    Ensure that when a rule has multiple candidate paths to trigger it,
+    it is evaluated only once and does not create duplicate match results.
+    Covers both Case 1 (Global deduplication against already-queued/evaluated rules)
+    and Case 2 (Local deduplication when multiple features trigger the same candidate
+    within the same iteration).
+    """
+    rules = [
+        capa.rules.Rule.from_yaml(
+            textwrap.dedent("""
+                rule:
+                    meta:
+                        name: Dependency Rule 1
+                        scopes:
+                            static: function
+                            dynamic: process
+                    features:
+                        - number: 100
+                """)
+        ),
+        capa.rules.Rule.from_yaml(
+            textwrap.dedent("""
+                rule:
+                    meta:
+                        name: Dependency Rule 2
+                        scopes:
+                            static: function
+                            dynamic: process
+                        namespace: testns
+                    features:
+                        - number: 300
+                """)
+        ),
+        capa.rules.Rule.from_yaml(
+            textwrap.dedent("""
+                rule:
+                    meta:
+                        name: Target Rule
+                        scopes:
+                            static: function
+                            dynamic: process
+                    features:
+                        - or:
+                            # Trigger Case 1 (Global): Target Rule is seeded by number 200,
+                            # and also gets triggered later when Dependency Rule 1 matches.
+                            - match: Dependency Rule 1
+                            - number: 200
+
+                            # Trigger Case 2 (Local): Target Rule depends on both rule name and namespace,
+                            # which will try to add it twice in the same iteration when Dependency Rule 2 matches.
+                            - and:
+                                - match: Dependency Rule 2
+                                - match: testns
+                """)
+        ),
+    ]
+
+    # Seed all features to trigger both Case 1 and Case 2
+    features = {
+        capa.features.insn.Number(100): {0x0},
+        capa.features.insn.Number(200): {0x0},
+        capa.features.insn.Number(300): {0x0},
+    }
+
+    _, matches = match(
+        capa.rules.topologically_order_rules(rules),
+        features,
+        0x0,
+    )
+
+    assert "Dependency Rule 1" in matches
+    assert "Dependency Rule 2" in matches
+    assert "Target Rule" in matches
+
+    # Ensure Target Rule was evaluated and returned exactly ONCE
+    assert len(matches["Target Rule"]) == 1


### PR DESCRIPTION
### Summary
In `capa`'s optimized matching engine (`RuleSet._match()`), when a rule successfully matches, `capa` extends the active candidate queue (`candidate_rules`) with its dependent rules (e.g. via `match:` statements). 

However, if a dependent rule had multiple matching pathways—such as being triggered by both a matched rule name and its namespace in the same iteration, or having already been seeded early on—the engine pushed the dependent rule onto the queue multiple times. This forced `capa` to run the entire AST evaluation tree redundantly for the same rule at the same address, resulting in wasted CPU cycles and duplicate matches leaking into the final result document.

### Fix
Implemented a two-layered de-duplication check before extending the queue:
* **Global**: Avoid adding rules already present in the historical `candidate_rule_names` set (which tracks all rules ever seeded or evaluated in this scope).
* **Local**: Upgraded `new_candidates` to a `set` to prevent a rule from being queued twice in the *same* iteration (e.g., when triggered by both a matched rule name and its namespace).

---

### Before & After (`-vv` CLI Output on `c91887d861d9bd4a5872249b641bc9f9.exe_`)

#### Before (Defective Output)
`capa` evaluates and outputs `"create reverse shell"` three times for the exact same address, resulting in inflated match counts:
```text
create reverse shell (3 matches)
namespace    communication/c2/shell
scope        function
matches      0x401a77
             0x401a77
             0x401a77
```

### After (Correct Optimized Output)
Deduplication prevents redundant queue pushes. The rule evaluates once and outputs correctly:
```text
create reverse shell
namespace    communication/c2/shell
scope        function
matches      0x401a77
```

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [X] This submission includes AI-generated code and I have provided details in the description.
