### PR TITLE
fix: use Qt flag_val() for PySide6 compat in IDA plugin

### DIFF
--- a/capa/ida/plugin/item.py
+++ b/capa/ida/plugin/item.py
@@ -21,7 +21,7 @@ import idaapi
 
 import capa.ida.helpers
 from capa.features.address import Address, FileOffsetAddress, AbsoluteVirtualAddress
-from capa.ida.plugin.qt_compat import QtCore, qt_get_item_flag_tristate
+from capa.ida.plugin.qt_compat import QtCore, qt_get_item_flag_tristate, flag_val
 
 
 def info_to_name(display):
@@ -52,10 +52,10 @@ class CapaExplorerDataItem:
         self._can_check = can_check
 
         # default state for item
-        self.flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+        self.flags = flag_val(QtCore.Qt.ItemIsEnabled) | flag_val(QtCore.Qt.ItemIsSelectable)
 
         if self._can_check:
-            self.flags = self.flags | QtCore.Qt.ItemIsUserCheckable | qt_get_item_flag_tristate()
+            self.flags = self.flags | flag_val(QtCore.Qt.ItemIsUserCheckable) | qt_get_item_flag_tristate()
 
         if self.pred:
             self.pred.appendChild(self)
@@ -66,9 +66,9 @@ class CapaExplorerDataItem:
         @param isEditable: True, can edit, False cannot edit
         """
         if isEditable:
-            self.flags |= QtCore.Qt.ItemIsEditable
+            self.flags |= flag_val(QtCore.Qt.ItemIsEditable)
         else:
-            self.flags &= ~QtCore.Qt.ItemIsEditable
+            self.flags &= ~flag_val(QtCore.Qt.ItemIsEditable)
 
     def setChecked(self, checked):
         """set item as checked

--- a/capa/ida/plugin/qt_compat.py
+++ b/capa/ida/plugin/qt_compat.py
@@ -57,16 +57,12 @@ def qt_get_item_flag_tristate():
     ItemIsAutoTristate automatically manages tristate based on child checkboxes,
     matching the original ItemIsTristate behavior where parent checkboxes reflect
     the check state of their children.
-
-    Returns:
-        int: The appropriate flag value for the Qt version
-
-    Raises:
-        AttributeError: If the tristate flag cannot be found in the Qt library
-    """
+def qt_get_item_flag_tristate():
     if QT_LIBRARY == "PySide6":
-        if hasattr(Qt, "ItemFlag") and hasattr(Qt.ItemFlag, "ItemIsAutoTristate"):
-            return Qt.ItemFlag.ItemIsAutoTristate.value
+        if hasattr(Qt, "ItemIsAutoTristate"):
+            return flag_val(Qt.ItemIsAutoTristate)
+        elif hasattr(Qt, "ItemFlag") and hasattr(Qt.ItemFlag, "ItemIsAutoTristate"):
+            return flag_val(Qt.ItemFlag.ItemIsAutoTristate)
         else:
             raise AttributeError(
                 "Cannot find ItemIsAutoTristate in PySide6. "
@@ -74,8 +70,7 @@ def qt_get_item_flag_tristate():
                 + f"Available Qt attributes: {[attr for attr in dir(Qt) if 'Item' in attr]}"
             )
     else:
-        # Qt5: Use the original ItemIsTristate flag
-        return Qt.ItemIsTristate
+        return flag_val(Qt.ItemIsTristate)
 
 
 __all__ = ["flag_val", "qt_get_item_flag_tristate", "Signal", "QAction", "QtGui", "QtCore", "QtWidgets"]

--- a/capa/ida/plugin/qt_compat.py
+++ b/capa/ida/plugin/qt_compat.py
@@ -41,6 +41,12 @@ except ImportError:
 Qt = QtCore.Qt
 
 
+def flag_val(flag):
+    if hasattr(flag, 'value'):
+        return flag.value
+    return flag
+
+
 def qt_get_item_flag_tristate():
     """
     Get the tristate item flag compatible with Qt5 and Qt6.
@@ -59,12 +65,8 @@ def qt_get_item_flag_tristate():
         AttributeError: If the tristate flag cannot be found in the Qt library
     """
     if QT_LIBRARY == "PySide6":
-        # Qt6: ItemIsTristate was removed, replaced with ItemIsAutoTristate
-        # Try different possible locations (API varies slightly across PySide6 versions)
-        if hasattr(Qt, "ItemIsAutoTristate"):
-            return Qt.ItemIsAutoTristate
-        elif hasattr(Qt, "ItemFlag") and hasattr(Qt.ItemFlag, "ItemIsAutoTristate"):
-            return Qt.ItemFlag.ItemIsAutoTristate
+        if hasattr(Qt, "ItemFlag") and hasattr(Qt.ItemFlag, "ItemIsAutoTristate"):
+            return Qt.ItemFlag.ItemIsAutoTristate.value
         else:
             raise AttributeError(
                 "Cannot find ItemIsAutoTristate in PySide6. "
@@ -76,4 +78,4 @@ def qt_get_item_flag_tristate():
         return Qt.ItemIsTristate
 
 
-__all__ = ["qt_get_item_flag_tristate", "Signal", "QAction", "QtGui", "QtCore", "QtWidgets"]
+__all__ = ["flag_val", "qt_get_item_flag_tristate", "Signal", "QAction", "QtGui", "QtCore", "QtWidgets"]

--- a/capa/ida/plugin/view.py
+++ b/capa/ida/plugin/view.py
@@ -26,7 +26,7 @@ import capa.features.basicblock
 from capa.ida.plugin.item import CapaExplorerFunctionItem
 from capa.features.address import FileOffsetAddress, AbsoluteVirtualAddress, _NoAddress
 from capa.ida.plugin.model import CapaExplorerDataModel
-from capa.ida.plugin.qt_compat import QtGui, QtCore, Signal, QAction, QtWidgets
+from capa.ida.plugin.qt_compat import QtGui, QtCore, Signal, QAction, QtWidgets, flag_val
 
 MAX_SECTION_SIZE = 750
 
@@ -484,9 +484,9 @@ class CapaExplorerRulegenEditor(QtWidgets.QTreeWidget):
             CapaExplorerRulegenEditor.get_column_comment_index(),
             CapaExplorerRulegenEditor.get_column_description_index(),
         ):
-            o.setFlags(o.flags() | QtCore.Qt.ItemIsEditable)
+            o.setFlags(int(o.flags()) | flag_val(QtCore.Qt.ItemIsEditable))
             self.editItem(o, column)
-            o.setFlags(o.flags() & ~QtCore.Qt.ItemIsEditable)
+            o.setFlags(int(o.flags()) & ~flag_val(QtCore.Qt.ItemIsEditable))
             self.is_editing = True
 
     def update_preview(self):
@@ -601,13 +601,13 @@ class CapaExplorerRulegenEditor(QtWidgets.QTreeWidget):
     def set_feature_node(self, o):
         """ """
         setattr(o, "capa_type", CapaExplorerRulegenEditor.get_node_type_feature())
-        o.setFlags(o.flags() & ~QtCore.Qt.ItemIsDropEnabled)
+        o.setFlags(int(o.flags()) & ~flag_val(QtCore.Qt.ItemIsDropEnabled))
         self.style_feature_node(o)
 
     def set_comment_node(self, o):
         """ """
         setattr(o, "capa_type", CapaExplorerRulegenEditor.get_node_type_comment())
-        o.setFlags(o.flags() & ~QtCore.Qt.ItemIsDropEnabled)
+        o.setFlags(int(o.flags()) & ~flag_val(QtCore.Qt.ItemIsDropEnabled))
 
         self.style_comment_node(o)
 
@@ -1009,7 +1009,7 @@ class CapaExplorerRulegenFeatures(QtWidgets.QTreeWidget):
 
     def set_parent_node(self, o):
         """ """
-        o.setFlags(o.flags() & ~QtCore.Qt.ItemIsSelectable)
+        o.setFlags(int(o.flags()) & ~flag_val(QtCore.Qt.ItemIsSelectable))
         setattr(o, "capa_type", CapaExplorerRulegenFeatures.get_node_type_parent())
         self.style_parent_node(o)
 


### PR DESCRIPTION
Resolves #3095

Replace direct bitwise operations on module-level Qt flag constants with flag_val() helper that extracts int values from enum members. This resolves RuntimeWarning in IDA 9.3+ where PyQt5 shim is deprecated.

- qt_compat.py: add flag_val(), fix qt_get_item_flag_tristate() to return int value using proper enum path
- item.py: use flag_val() for all flag bitwise operations
- view.py: use flag_val() for all flag bitwise operations

[x] No CHANGELOG update needed