### PR TITLE
Accept self-hosted CAPE version strings without warning

### DIFF
--- a/capa/features/extractors/cape/extractor.py
+++ b/capa/features/extractors/cape/extractor.py
@@ -36,7 +36,14 @@ from capa.features.extractors.base_extractor import (
 
 logger = logging.getLogger(__name__)
 
-TESTED_VERSIONS = {"2.2-CAPE", "2.4-CAPE", "2.5-CAPE"}
+TESTED_VERSIONS = {
+    "2.2",
+    "2.2-CAPE",
+    "2.4",
+    "2.4-CAPE",
+    "2.5",
+    "2.5-CAPE",
+}
 
 
 class CapeExtractor(DynamicFeatureExtractor):

--- a/tests/test_cape_model.py
+++ b/tests/test_cape_model.py
@@ -81,6 +81,14 @@ def test_cape_extractor(version: str, filename: str, exception: Type[BaseExcepti
         assert cr is not None
 
 
+def test_cape_tested_versions_include_self_hosted_strings():
+    from capa.features.extractors.cape.extractor import TESTED_VERSIONS
+
+    for version in ("2.2", "2.4", "2.5"):
+        assert version in TESTED_VERSIONS
+        assert f"{version}-CAPE" in TESTED_VERSIONS
+
+
 def test_get_calls_no_api_mutation():
     process_addr = ProcessAddress(pid=1, ppid=0)
     thread_addr = ThreadAddress(process=process_addr, tid=100)


### PR DESCRIPTION
﻿## Summary
- Include self-hosted CAPE version strings (2.2, 2.4, 2.5) alongside capesandbox.com suffixed forms in TESTED_VERSIONS
- Prevents spurious unsupported-version warnings on standard self-hosted CAPE reports

Fixes #3082

## Test plan
- [x] pytest tests/test_cape_model.py::test_cape_tested_versions_include_self_hosted_strings
