### PR TITLE
fix: anchor capafmt's features offset to the features block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - fix: remove redundant code related to cli loading @mike-hunhoff #3076
 - fix: optimize all_zeros using fast bytes comparison @mike-hunhoff #3078
 - fix: duplicate rule candidate evaluation in optimized matching engine @mike-hunhoff #3080
+- fix: capafmt corrupts rules whose namespace contains "features" @Makeph #3135
 
 ### capa Explorer Web
 

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1374,7 +1374,7 @@ class Rule:
         # see #263
         # only do this for the features section, so the meta description doesn't get reformatted
         # assumes features section always exists
-        features_offset = doc.find("features")
+        features_offset = doc.index("\n  features:") + 1
         doc = doc[:features_offset] + doc[features_offset:].replace("  description:", "    description:")
 
         # for negative hex numbers, yaml dump outputs:

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -148,3 +148,24 @@ def test_rule_reformat_string_description():
 
     rule = capa.rules.Rule.from_yaml(src)
     assert rule.to_yaml() == src
+
+
+def test_rule_reformat_meta_description_with_features_namespace():
+    src = textwrap.dedent("""
+        rule:
+          meta:
+            name: test rule
+            namespace: impact/features
+            authors:
+              - user@domain.com
+            description: test description
+            scopes:
+              static: function
+              dynamic: process
+          features:
+            - number: 1
+        """).lstrip()
+
+    formatted = capa.rules.Rule.from_yaml(src).to_yaml()
+    capa.rules.Rule.from_yaml(formatted)
+    assert formatted == src


### PR DESCRIPTION
Closes #3134.

### The bug

`Rule.to_yaml()` applies an indentation fix-up (added for #263) so that `description` fields *inside* the features section get two extra spaces, while the meta description is left alone. To know where "inside features" begins, it did:

```py
features_offset = doc.find("features")
```

`str.find` returns the first occurrence of the substring anywhere in the document. For a rule whose namespace contains the word `features` — say `namespace: impact/features` — that lands in the **meta** block. Everything after it, including the meta `description`, then gets re-indented from 4 spaces to 6, and the result is YAML that no parser will load. capafmt corrupts the rule it was asked to format.

### The fix

Anchor the search to the top-level `features:` key rather than a bare substring:

```py
features_offset = doc.index("\n  features:") + 1
```

One deliberate change in behaviour worth your call: I used `.index()` rather than `.find()`. The existing comment right above states *"assumes features section always exists"*, and `.find()` returning `-1` would silently apply the fix-up to the whole document — the same class of failure as this bug. `.index()` makes that assumption fail loudly instead. Happy to switch back to `.find()` if you'd rather keep the change strictly minimal.

### Why it took six years to surface

Only a handful of nursery rules use a `/features` namespace, and none carried a `description` field until mandiant/capa-rules#1173. It needed both to appear in the same rule.

### Testing

Added `test_rule_reformat_meta_description_with_features_namespace`, which round-trips a rule with `namespace: impact/features` **and** a meta description.

Verified locally against this branch:

- with the fix: `6 passed` in `tests/test_fmt.py`
- reverting only `capa/rules/__init__.py` and keeping the test: `1 failed, 5 passed`, failing with `yaml.parser.ParserError: while parsing a block collection ... did not find expected '-' indicator` — i.e. the test reproduces the exact corruption from the issue
- `tests/test_rules.py tests/test_fmt.py tests/test_rule_cache.py`: `45 passed`

---
Prepared with AI assistance; I reviewed every line and ran the verification above locally.