### PR TITLE
fix: add IDA 8.5 compatibility

### DIFF
--- a/capa/ida/helpers.py
+++ b/capa/ida/helpers.py
@@ -55,7 +55,7 @@ NETNODE_RULES_CACHE_ID = "rules-cache-id"
 
 # wrappers for IDA Pro (IDAPython) 7, 8 and 9 compability
 version = float(idaapi.get_kernel_version())
-if version < 9.0:
+if version < 8.5:
 
     def get_filetype() -> "ida_ida.filetype_t":
         return idaapi.get_inf_structure().filetype


### PR DESCRIPTION
This is just simple 1 line fix. 
As seen in the link below IDA 8.5 uses the same (to my knowledge) updated api a IDA 9 as such the version comparison in capa/ida/helpers.py:59 mistakenly does not include ida 8.5 to the upgraded api. This lead to a failure on loading the plugin on ida 8.5 because idaapi.get_inf_structure() has been removed in that idaapi for both 8.5 and 9.x. but for ida 8.5 the path for the old api is taken. 

The reason for this bug probably is that 8.5 was released after 9.0 so the helpers.py was never updated for the 8.5 release

Tested by loading the plugin with IDA 8.5. 
REFERENCE
https://docs.hex-rays.com/8.5/developer-guide/idapython/idapython-porting-guide-ida-9#inf_structure-accessors


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/mandiant/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
<!-- Please indicate if and how you have used AI to generate (parts of) your code submission. Include your prompt, model, tool, etc. -->
- [ ] This submission includes AI-generated code and I have provided details in the description.
