### PR TITLE
rules: anchor features offset to section header in rule formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: prevent capafmt from corrupting rules whose namespace contains `features` @SkxOverKill #3143
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012
 - fix: elf.py vdso_guess exception handler clobbers symtab_guess @williballenthin #3013

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1374,7 +1374,10 @@ class Rule:
         # see #263
         # only do this for the features section, so the meta description doesn't get reformatted
         # assumes features section always exists
-        features_offset = doc.find("features")
+        # anchor on the section header rather than the bare word "features",
+        # since a rule's namespace (e.g. `impact/features/persistence`)
+        # may contain that substring and mislead the offset. see #3134
+        features_offset = doc.find("\n  features:")
         doc = doc[:features_offset] + doc[features_offset:].replace("  description:", "    description:")
 
         # for negative hex numbers, yaml dump outputs:

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -148,3 +148,29 @@ def test_rule_reformat_string_description():
 
     rule = capa.rules.Rule.from_yaml(src)
     assert rule.to_yaml() == src
+
+
+def test_rule_reformat_namespace_with_features():
+    # regression test for #3134
+    # a namespace containing the substring "features"
+    # (e.g. `impact/features/persistence`) must not be mistaken for the
+    # `features:` section; otherwise the meta `description` gets
+    # incorrectly re-indented and the emitted YAML becomes invalid.
+    src = textwrap.dedent("""
+        rule:
+          meta:
+            name: test rule
+            namespace: impact/features/persistence
+            authors:
+              - user@domain.com
+            description: this is a description
+            scopes:
+              static: function
+              dynamic: process
+          features:
+            - and:
+              - string: foo
+                description: bar
+        """).lstrip()
+
+    assert capa.rules.Rule.from_yaml(src).to_yaml() == src


### PR DESCRIPTION
## Summary

Fixes #3134 by preventing `Rule.to_yaml()` / `capafmt` from corrupting rules whose namespace contains the substring `features`, such as `impact/features/persistence`.

## Relationship to #3135

This PR is functionally a duplicate of the earlier #3135: both address #3134 by anchoring the formatter's search to the actual top-level `features:` section and both add regression coverage for a metadata description combined with a `features` namespace.

#3135 predates this PR and has already received maintainer approval. This PR is retained only as a CLA-compliant fallback because #3135 remains blocked on its contributor's CLA. If #3135 becomes mergeable, this PR should be closed in its favor. Credit to @Makeph for the earlier contribution and analysis in #3135.

## Root Cause

The formatter located the start of the features block with:

```python
features_offset = doc.find("features")
```

Because `str.find()` returns the first matching substring, a namespace containing `features` caused the offset to point into rule metadata. The subsequent feature-description indentation adjustment then also modified the metadata description, producing invalid YAML.

## Implementation

- Anchor the offset to the top-level YAML section header: `\n  features:`.
- Add a round-trip regression test containing both `namespace: impact/features/persistence` and metadata/feature descriptions.
- Add the required entry under `master (unreleased)` in `CHANGELOG.md`.

## Verification

```text
python -m pytest tests/test_fmt.py tests/test_rules.py tests/test_rule_cache.py -q
45 passed in 0.35s

python -m ruff check --config .github/ruff.toml capa/rules/__init__.py tests/test_fmt.py
All checks passed!

python -m ruff format --check --config .github/ruff.toml capa/rules/__init__.py tests/test_fmt.py
2 files already formatted
```
