### PR TITLE
freeze: omit null description fields from freeze JSON (fixes #3100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012
 - fix: elf.py vdso_guess exception handler clobbers symtab_guess @williballenthin #3013

--- a/capa/features/freeze/__init__.py
+++ b/capa/features/freeze/__init__.py
@@ -454,7 +454,7 @@ def dumps_static(extractor: StaticFeatureExtractor, reproducible: bool = False) 
     )
     # type checkers are unable to recognise `base_address` as an argument due to alias
 
-    return freeze.model_dump_json()
+    return freeze.model_dump_json(exclude_none=True)
 
 
 def dumps_dynamic(extractor: DynamicFeatureExtractor, reproducible: bool = False) -> str:
@@ -573,7 +573,7 @@ def dumps_dynamic(extractor: DynamicFeatureExtractor, reproducible: bool = False
     )
     # type checkers are unable to recognise `base_address` as an argument due to alias
 
-    return freeze.model_dump_json()
+    return freeze.model_dump_json(exclude_none=True)
 
 
 def loads_static(s: str) -> StaticFeatureExtractor:

--- a/tests/test_freeze_dynamic.py
+++ b/tests/test_freeze_dynamic.py
@@ -153,6 +153,12 @@ def test_freeze_bytes_roundtrip():
     compare_extractors(EXTRACTOR, reanimated)
 
 
+def test_freeze_dump_omits_absent_description():
+    # features without a description must not serialize as "description": null
+    # see: https://github.com/mandiant/capa/issues/3100
+    assert '"description":null' not in capa.features.freeze.dumps_dynamic(EXTRACTOR)
+
+
 def test_freeze_load_sample(tmpdir):
     o = tmpdir.mkdir("capa").join("test.frz")
 

--- a/tests/test_freeze_static.py
+++ b/tests/test_freeze_static.py
@@ -162,6 +162,12 @@ def test_freeze_bytes_roundtrip():
     compare_extractors(EXTRACTOR, reanimated)
 
 
+def test_freeze_dump_omits_absent_description():
+    # features without a description must not serialize as "description": null
+    # see: https://github.com/mandiant/capa/issues/3100
+    assert '"description":null' not in capa.features.freeze.dumps_static(EXTRACTOR)
+
+
 def roundtrip_feature(feature):
     assert feature == capa.features.freeze.features.feature_from_capa(feature).to_capa()
 


### PR DESCRIPTION
## Summary

Fixes #3100 by omitting absent optional fields from static and dynamic freeze JSON. Features and statements without a description no longer serialize as `"description": null`; explicitly populated descriptions remain unchanged.

## Root Cause

The freeze serializers called Pydantic's `model_dump_json()` without `exclude_none`, causing every unset optional field to be emitted with a JSON `null` value.

## Implementation

- Apply `exclude_none=True` in both `dumps_static()` and `dumps_dynamic()`.
- Add regression coverage for static freeze serialization.
- Add equivalent regression coverage for dynamic freeze serialization.
- Document the fix in `CHANGELOG.md`.

## Compatibility and Impact

- Existing freeze files containing `"description": null` remain loadable through the unchanged validation path.
- Non-empty descriptions continue to be serialized.
- Newly generated freeze files are smaller and avoid redundant null-valued metadata.

## Verification

The recursive fixture submodules, including `tests/data`, were initialized before validation.

```text
python -m pytest tests/test_freeze_static.py tests/test_freeze_dynamic.py -q
13 passed in 20.22s
```

The exercised coverage includes static and dynamic string/byte round trips, fixture-backed sample loading, and the two null-description regressions.

## Fixture Update

The full CI matrix correctly detected byte-level drift in the five reproducible freeze snapshots affected by the serialization change. The regenerated fixtures and updated manifest provenance are submitted in mandiant/capa-testfiles#325. After that dependency is merged, this PR will update the `tests/data` submodule pointer and rerun the complete matrix.
