### PR TITLE
fix(extractors/ts): deduplicate qualified names and resolve module namespaces

### DIFF
--- a/capa/features/extractors/ts/function.py
+++ b/capa/features/extractors/ts/function.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Iterator
+from typing import Tuple, Iterable, Iterator
 from dataclasses import dataclass
 
 from tree_sitter import Node
@@ -55,10 +55,16 @@ def extract_integers(fn_node: Node, engine: TreeSitterExtractorEngine) -> Iterat
             continue
 
 
-def get_possible_full_names(name: str, namespaces: set[BaseNamespace]) -> Iterator[str]:
-    yield name
+def get_possible_full_names(name: str, namespaces: Iterable[BaseNamespace]) -> Iterator[str]:
+    seen = set()
+    if name:
+        seen.add(name)
+        yield name
     for namespace in namespaces:
-        yield namespace.join(name)
+        full_name = namespace.join(name)
+        if full_name and full_name not in seen:
+            seen.add(full_name)
+            yield full_name
 
 
 def get_default_constructor(fn_node: Node, engine: TreeSitterExtractorEngine) -> Iterator[str]:
@@ -84,7 +90,8 @@ def _extract_default_constructor(fn_node: Node, engine: TreeSitterExtractorEngin
     for name_node in engine.get_new_object_names(fn_node):
         for full_name in get_possible_full_names(engine.get_str(name_node), engine.namespaces):
             if engine.language_toolkit.is_imported_class(full_name):
-                yield Namespace(full_name), engine.get_address(name_node)
+                ns = engine.language_toolkit.get_namespace_from_name(full_name) or full_name
+                yield Namespace(ns), engine.get_address(name_node)
                 yield Class(engine.language_toolkit.format_imported_class(full_name)), engine.get_address(name_node)
                 yield (
                     API(engine.language_toolkit.format_imported_default_constructor(full_name)),
@@ -96,7 +103,8 @@ def _extract_custom_constructor(fn_node: Node, engine: TreeSitterExtractorEngine
     for name_node in engine.get_function_call_names(fn_node):
         for full_name in get_possible_full_names(engine.get_str(name_node), engine.namespaces):
             if engine.language_toolkit.is_imported_constructor(full_name):
-                yield Namespace(full_name), engine.get_address(name_node)
+                ns = engine.language_toolkit.get_namespace_from_name(full_name) or full_name
+                yield Namespace(ns), engine.get_address(name_node)
                 yield Class(engine.language_toolkit.format_imported_class(full_name)), engine.get_address(name_node)
                 yield (
                     API(engine.language_toolkit.format_imported_custom_constructor(full_name)),

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -1181,6 +1181,9 @@ FEATURE_PRESENCE_TESTS_SCRIPTS = sorted([
     ("py_24e48f", "function=icloud_phish", API("base64::encodestring"), True),
     ("py_24e48f", "function=icloud_phish", API("urllib2::urlopen"), True),
     ("py_24e48f", "function=get_itunes_backups", String("IMEI"), True),
+    ("py_24e48f", "function=get_itunes_backups", Namespace("socket"), True),
+    ("py_24e48f", "function=get_itunes_backups", Class("socket.socket"), True),
+    ("py_24e48f", "function=get_itunes_backups", API("socket.socket::ctor"), True),
     ("py_24e48f", "function=PSEUDO MAIN", String("[I] "), True),
     ("py_24e48f", "function=PSEUDO MAIN", Substring("[!]"), True),
     ("py_24e48f", "function=get_itunes_backups", Number(0), True),
@@ -1239,3 +1242,19 @@ def do_test_feature_count(get_extractor, sample, scope, feature, expected):
 def test_feature_presence_scripts(sample, location, feature, expected):
     scope = resolve_scope_ts(location)
     do_test_feature_presence(get_extractor_ts, sample, scope, feature, expected)
+
+
+FEATURE_COUNT_TESTS_SCRIPTS = (
+    ("py_24e48f", "function=get_itunes_backups", Namespace("socket"), 2),
+    ("py_24e48f", "function=get_itunes_backups", Class("socket.socket"), 1),
+    ("py_24e48f", "function=get_itunes_backups", API("socket.socket::ctor"), 1),
+)
+
+
+@parametrize(
+    "sample,location,feature,expected",
+    FEATURE_COUNT_TESTS_SCRIPTS,
+)
+def test_feature_count_scripts(sample, location, feature, expected):
+    scope = resolve_scope_ts(location)
+    do_test_feature_count(get_extractor_ts, sample, scope, feature, expected)


### PR DESCRIPTION
- Deduplicate candidate qualified names in get_possible_full_names() to prevent duplicate feature emissions when multiple imports are present.
- Extract parent module namespaces in default and custom constructors using get_namespace_from_name() instead of emitting full class names.
- Add parametrized presence and count regression tests in test_ts.py.

- [x] No CHANGELOG update needed
