### PR TITLE
fix: reject and rebuild stale rules caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: reject stale rules caches with an incompatible ruleset schema and rebuild them instead of crashing at match time (missing `bytes_prefix_index`) @MP-GOWTHAM #2961
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012

--- a/capa/rules/__init__.py
+++ b/capa/rules/__init__.py
@@ -1576,10 +1576,35 @@ class RuleSet:
         self._rule_index_by_scope: dict[Scope, dict[str, int]] = {
             scope: {rule.name: i for i, rule in enumerate(self.rules_by_scope[scope])} for scope in scopes
         }
+        self._rule_index_by_scope: dict[Scope, dict[str, int]] = {
+            scope: {rule.name: i for i, rule in enumerate(self.rules_by_scope[scope])} for scope in scopes
+        }
 
     @property
     def file_rules(self):
         return self.rules_by_scope[Scope.FILE]
+
+    def _validate_feature_index(self) -> None:
+        """
+        Verify that the feature indexes match the current schema.
+
+        The feature index structures are unstable and may change before
+        the next major release. A ruleset loaded from a cache written by
+        an older build may contain indexes with a different schema, which
+        would crash with an AttributeError at match time (e.g. a missing
+        ``bytes_prefix_index``, see #2961).
+
+        Raise AssertionError when the loaded structures are incompatible,
+        so cache loading code can treat the entry as a cache miss.
+        """
+        if not hasattr(self, "_feature_indexes_by_scopes") or not hasattr(self, "_rule_index_by_scope"):
+            raise AssertionError("ruleset is missing precomputed indexes")
+
+        expected = set(RuleSet._RuleFeatureIndex.__annotations__.keys())
+        for scope, index in self._feature_indexes_by_scopes.items():
+            missing = expected - set(index.__dict__.keys())
+            if missing:
+                raise AssertionError(f"feature index for scope {scope} is missing fields: {sorted(missing)}")
 
     @property
     def process_rules(self):

--- a/capa/rules/cache.py
+++ b/capa/rules/cache.py
@@ -78,7 +78,9 @@ def get_cache_path(cache_dir: Path, id: CacheIdentifier) -> Path:
 
 
 MAGIC = b"capa"
-VERSION = b"\x00\x00\x00\x01"
+# bump when the serialized ruleset schema changes (e.g. new RuleSet
+# fields), so stale caches from previous builds are rejected and rebuilt.
+VERSION = b"\x00\x00\x00\x02"
 
 
 @dataclass
@@ -91,13 +93,16 @@ class RuleCache:
 
     @staticmethod
     def load(data):
-        assert data.startswith(MAGIC + VERSION)
+        if not data.startswith(MAGIC + VERSION):
+            raise AssertionError(f"invalid cache magic or format version: {data[:8]!r}")
 
         id = data[0x8:0x48].decode("ascii")
         cache = pickle.loads(zlib.decompress(data[0x48:]))
 
-        assert isinstance(cache, RuleCache)
-        assert cache.id == id
+        if not isinstance(cache, RuleCache):
+            raise AssertionError(f"unexpected cache type: {type(cache).__name__}")
+        if cache.id != id:
+            raise AssertionError(f"cache id mismatch: expected {id}, got {cache.id}")
 
         return cache
 
@@ -158,7 +163,8 @@ def load_cached_ruleset(cache_dir: Path, rule_contents: list[bytes]) -> Optional
 
     try:
         cache = RuleCache.load(buf)
-    except AssertionError:
+        cache.ruleset._validate_feature_index()
+    except (AssertionError, AttributeError):
         logger.debug("rule set cache is invalid: %s", path)
         # delete the cache that seems to be invalid.
         path.unlink()

--- a/tests/test_rule_cache.py
+++ b/tests/test_rule_cache.py
@@ -121,6 +121,60 @@ def test_ruleset_cache_invalid():
     assert not path.exists()
 
 
+def test_ruleset_cache_old_format_version():
+    # caches written with an older cache format version must be rejected
+    # and rebuilt, not loaded (the serialized ruleset schema may have
+    # changed between builds, see #2961).
+    rs = capa.rules.RuleSet([R1])
+    content = capa.rules.cache.get_ruleset_content(rs)
+    id = capa.rules.cache.compute_cache_identifier(content)
+    cache_dir = capa.rules.cache.get_default_cache_directory()
+    path = capa.rules.cache.get_cache_path(cache_dir, id)
+    with contextlib.suppress(OSError):
+        path.unlink()
+
+    capa.rules.cache.cache_ruleset(cache_dir, rs)
+    assert path.exists()
+
+    buf = path.read_bytes()
+
+    # rewrite the version field as if the cache was written by the
+    # previous format (MAGIC is 4 bytes, VERSION is 4 bytes)
+    assert buf[:4] == capa.rules.cache.MAGIC
+    assert buf[4:8] != b"\x00\x00\x00\x01"
+    buf = buf[:4] + b"\x00\x00\x00\x01" + buf[8:]
+    path.write_bytes(buf)
+
+    assert capa.rules.cache.load_cached_ruleset(cache_dir, content) is None
+    # the invalid cache should be deleted
+    assert not path.exists()
+
+
+def test_ruleset_cache_stale_feature_index_schema():
+    # a cache written by an older build may contain feature indexes that
+    # miss fields used by the current matching code; loading it must be
+    # treated as a cache miss instead of crashing at match time (#2961).
+    rs = capa.rules.RuleSet([R1])
+    content = capa.rules.cache.get_ruleset_content(rs)
+    id = capa.rules.cache.compute_cache_identifier(content)
+    cache_dir = capa.rules.cache.get_default_cache_directory()
+    path = capa.rules.cache.get_cache_path(cache_dir, id)
+    with contextlib.suppress(OSError):
+        path.unlink()
+
+    # simulate a stale schema: drop bytes_prefix_index from the indexes
+    # before the ruleset is serialized to disk
+    for index in rs._feature_indexes_by_scopes.values():
+        index.__dict__.pop("bytes_prefix_index", None)
+    cache = capa.rules.cache.RuleCache(id, rs)
+    path.write_bytes(cache.dump())
+
+    assert path.exists()
+    assert capa.rules.cache.load_cached_ruleset(cache_dir, content) is None
+    # the invalid cache should be deleted
+    assert not path.exists()
+
+
 def test_rule_cache_dev_environment():
     # generate rules cache
     rs = capa.rules.RuleSet([R2])


### PR DESCRIPTION
Fixes #2961

A ruleset loaded from a rules cache written by an older build may contain feature indexes with a different schema, which crashed at match time with:

```
AttributeError: '_RuleFeatureIndex' object has no attribute 'bytes_prefix_index'
```

## Changes

- **Bump the cache format version** (`VERSION` `\x00\x00\x00\x01` -> `\x00\x00\x00\x02`), so caches written by the previous format are rejected and rebuilt.
- **Validate the loaded ruleset schema** on cache load: `RuleSet._validate_feature_index()` checks the precomputed feature indexes against the fields the current matching code expects. Any mismatch is treated as a cache miss — the invalid entry is deleted and the ruleset is rebuilt, instead of crashing mid-analysis.
- **Harden `RuleCache.load`**: the magic/version/type/id checks no longer rely on `assert` (which is stripped under `python -O`); they raise `AssertionError` explicitly so the invalid-cache path always triggers.

## Tests

- `test_ruleset_cache_old_format_version` — a cache with the previous format version is rejected and deleted.
- `test_ruleset_cache_stale_feature_index_schema` — a cache whose feature indexes are missing `bytes_prefix_index` is rejected and deleted instead of crashing at match time.

## Verification

- `pytest tests/test_rule_cache.py tests/test_rules.py tests/test_match.py tests/test_rules_insn_scope.py`: 56 passed, 2 xfailed
- `ruff check` and `ruff format --check` (with `.github/ruff.toml`): clean
