### PR TITLE
elffile: support 32-bit ARM architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: elffile: do not emit unsupported 32-bit ARM architecture @dev-rehaann #3155
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - freeze: add `--reproducible` flag that zeros dynamic header metadata
+- elffile: support 32-bit ARM architecture @dev-rehaann #3155
 
 ### Breaking Changes
 
@@ -26,7 +27,6 @@
 -
 
 ### Bug Fixes
-- fix: elffile: do not emit unsupported 32-bit ARM architecture @dev-rehaann #3155
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -443,11 +443,11 @@ class Bytes(Feature):
 # other candidates here: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types
 ARCH_I386 = "i386"
 ARCH_AMD64 = "amd64"
-ARCH_ARM = "arm"
+ARCH_AARCH32 = "aarch32"
 ARCH_AARCH64 = "aarch64"
 # dotnet
 ARCH_ANY = "any"
-VALID_ARCH = (ARCH_I386, ARCH_AMD64, ARCH_ARM, ARCH_AARCH64, ARCH_ANY)
+VALID_ARCH = (ARCH_I386, ARCH_AMD64, ARCH_AARCH32, ARCH_AARCH64, ARCH_ANY)
 
 
 class Arch(Feature):

--- a/capa/features/common.py
+++ b/capa/features/common.py
@@ -443,10 +443,11 @@ class Bytes(Feature):
 # other candidates here: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types
 ARCH_I386 = "i386"
 ARCH_AMD64 = "amd64"
+ARCH_ARM = "arm"
 ARCH_AARCH64 = "aarch64"
 # dotnet
 ARCH_ANY = "any"
-VALID_ARCH = (ARCH_I386, ARCH_AMD64, ARCH_AARCH64, ARCH_ANY)
+VALID_ARCH = (ARCH_I386, ARCH_AMD64, ARCH_ARM, ARCH_AARCH64, ARCH_ANY)
 
 
 class Arch(Feature):

--- a/capa/features/extractors/elffile.py
+++ b/capa/features/extractors/elffile.py
@@ -177,8 +177,6 @@ def extract_file_arch(elf: ELFFile, **kwargs):
         yield Arch("i386"), NO_ADDRESS
     elif arch == "x64":
         yield Arch("amd64"), NO_ADDRESS
-    elif arch == "ARM":
-        yield Arch("arm"), NO_ADDRESS
     elif arch == "AArch64":
         yield Arch("aarch64"), NO_ADDRESS
     else:

--- a/capa/features/extractors/elffile.py
+++ b/capa/features/extractors/elffile.py
@@ -178,7 +178,7 @@ def extract_file_arch(elf: ELFFile, **kwargs):
     elif arch == "x64":
         yield Arch("amd64"), NO_ADDRESS
     elif arch == "ARM":
-        yield Arch("arm"), NO_ADDRESS
+        yield Arch("aarch32"), NO_ADDRESS
     elif arch == "AArch64":
         yield Arch("aarch64"), NO_ADDRESS
     else:

--- a/capa/features/extractors/elffile.py
+++ b/capa/features/extractors/elffile.py
@@ -177,6 +177,8 @@ def extract_file_arch(elf: ELFFile, **kwargs):
         yield Arch("i386"), NO_ADDRESS
     elif arch == "x64":
         yield Arch("amd64"), NO_ADDRESS
+    elif arch == "ARM":
+        yield Arch("arm"), NO_ADDRESS
     elif arch == "AArch64":
         yield Arch("aarch64"), NO_ADDRESS
     else:

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 
 import io
+from types import SimpleNamespace
 from pathlib import Path
 
 import fixtures
 from elftools.elf.elffile import ELFFile
 
-from capa.features.extractors.elffile import extract_file_export_names, extract_file_import_names
+from capa.features.extractors.elffile import (
+    extract_file_arch,
+    extract_file_export_names,
+    extract_file_import_names,
+)
 
 SAMPLE_PATH = fixtures.CD / "data" / "055da8e6ccfe5a9380231ea04b850e18.elf_"
 STRIPPED_SAMPLE_PATH = fixtures.CD / "data" / "bb38149ff4b5c95722b83f24ca27a42b.elf_"
@@ -103,3 +108,8 @@ def test_elffile_export_features():
         "__libc_csu_init",
     ]
     check_export_features(SAMPLE_PATH, expected_exports)
+
+
+def test_elffile_unsupported_architecture():
+    elf = SimpleNamespace(get_machine_arch=lambda: "ARM")
+    assert list(extract_file_arch(elf)) == []

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import io
-from types import SimpleNamespace
+import struct
 from pathlib import Path
 
 import fixtures
 from elftools.elf.elffile import ELFFile
 
+from capa.features.common import VALID_ARCH
+from capa.features.address import NO_ADDRESS
 from capa.features.extractors.elffile import (
     extract_file_arch,
     extract_file_export_names,
@@ -110,6 +112,25 @@ def test_elffile_export_features():
     check_export_features(SAMPLE_PATH, expected_exports)
 
 
-def test_elffile_unsupported_architecture():
-    elf = SimpleNamespace(get_machine_arch=lambda: "ARM")
-    assert list(extract_file_arch(elf)) == []
+def test_elffile_arm_architecture():
+    elf_header = struct.pack(
+        "<16sHHIIIIIHHHHHH",
+        b"\x7fELF\x01\x01\x01" + b"\x00" * 9,
+        2,
+        40,
+        1,
+        0,
+        0,
+        0,
+        0,
+        52,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    elf = ELFFile(io.BytesIO(elf_header))
+    features = [(feature.value, address) for feature, address in extract_file_arch(elf)]
+    assert features == [("arm", NO_ADDRESS)]
+    assert features[0][0] in VALID_ARCH

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import fixtures
 from elftools.elf.elffile import ELFFile
 
-from capa.features.common import VALID_ARCH
+from capa.features.common import VALID_ARCH, ARCH_AARCH32
 from capa.features.address import NO_ADDRESS
 from capa.features.extractors.elffile import (
     extract_file_arch,
@@ -132,5 +132,5 @@ def test_elffile_arm_architecture():
     )
     elf = ELFFile(io.BytesIO(elf_header))
     features = [(feature.value, address) for feature, address in extract_file_arch(elf)]
-    assert features == [("arm", NO_ADDRESS)]
+    assert features == [(ARCH_AARCH32, NO_ADDRESS)]
     assert features[0][0] in VALID_ARCH


### PR DESCRIPTION
## Description

Add `aarch32` to capa's valid architecture values and map pyelftools' `EM_ARM` output to it. This keeps AArch64 behavior unchanged and allows the shared ELF extraction path to represent 32-bit ARM binaries consistently.

Closes #3155

## Testing

- `python -m pytest -p no:cacheprovider tests/test_elffile_features.py -k arm -q` (`1 passed, 4 deselected`)
- `ruff check --config .github/ruff.toml capa/features/common.py capa/features/extractors/elffile.py tests/test_elffile_features.py`
- `ruff format --check --config .github/ruff.toml capa/features/common.py capa/features/extractors/elffile.py tests/test_elffile_features.py`
- `git diff --check`

### Checklist

- [ ] No CHANGELOG update needed
- [ ] No new tests needed
- [x] No documentation update needed
- [x] This submission includes AI-generated code and I have provided details in the description.

AI disclosure: OpenAI Codex assisted with tracing the extractor and architecture-validation paths, preparing the patch and regression test, and running the checks listed above.