### PR TITLE
build: bump vivisect dependency to >=1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Bug Fixes
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
+- fix: bump vivisect dependency to >=1.3.0 to fix viv_utils version mismatch #3079
 - fix: render_default always returns empty string @williballenthin #3012
 - fix: elf.py vdso_guess exception handler clobbers symtab_guess @williballenthin #3013
 - fix: _NoAddress.__eq__ unconditionally returns True @williballenthin #3014
@@ -2504,7 +2505,6 @@ Download a standalone binary below and checkout the readme [here on GitHub](http
 - extractor: fix segmentation violation from vivisect @williballenthin
 - main: fix crash when .viv cannot be saved #168 @secshoggoth @williballenthin
 - main: fix shellcode .viv save path @williballenthin
-- bump vivisect dependency to >=1.3.0 to fix viv_utils version mismatch @williballenthin
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2504,6 +2504,7 @@ Download a standalone binary below and checkout the readme [here on GitHub](http
 - extractor: fix segmentation violation from vivisect @williballenthin
 - main: fix crash when .viv cannot be saved #168 @secshoggoth @williballenthin
 - main: fix shellcode .viv save path @williballenthin
+- bump vivisect dependency to >=1.3.0 to fix viv_utils version mismatch @williballenthin
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # so we provide a minimum patch version that includes the
     # latest bug fixes we need here.
     "viv-utils[flirt]>=0.7.9",
-    "vivisect>=1.1.1",
+    "vivisect>=1.3.0",
     "dncil>=1.0.2",
 
     # ---------------------------------------


### PR DESCRIPTION
Fixes #3079

Bumped the minimum `vivisect` dependency in `pyproject.toml` to `1.3.0` to resolve the `viv_utils` version mismatch warning reported during execution.