### PR TITLE
fix: elffile: degrade instead of aborting on a malformed dynamic segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: elffile: don't abort the run when a malformed dynamic segment can't be parsed @arpitjain099 #3170 #3171
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012

--- a/capa/features/extractors/elffile.py
+++ b/capa/features/extractors/elffile.py
@@ -17,6 +17,7 @@ import logging
 from typing import Iterator
 from pathlib import Path
 
+from elftools.common.exceptions import ELFError
 from elftools.elf.dynamic import DynamicSegment
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
@@ -28,6 +29,46 @@ from capa.features.address import NO_ADDRESS, Address, AbsoluteVirtualAddress
 from capa.features.extractors.base_extractor import SampleHashes, StaticFeatureExtractor
 
 logger = logging.getLogger(__name__)
+
+# pyelftools reads the dynamic tables on demand and trusts that a table tag
+# comes with the companion tags that describe it. A file where that is not true
+# makes it raise out of capa's extraction and abort the whole run, which for a
+# tool that is pointed at hostile files is the wrong trade: the rest of the
+# features are still recoverable. See issues #3170 and #3171.
+# StopIteration belongs here: pyelftools reads the companion tags with bare
+# next() calls, and because the extractors are generators, PEP 479 turns an
+# escaping StopIteration into a RuntimeError only at the generator boundary,
+# which is above the call site. Catching RuntimeError alone would miss it.
+MALFORMED_DYNAMIC_ERRORS = (ValueError, RuntimeError, StopIteration, ELFError)
+
+
+def get_dynamic_symbols(segment: DynamicSegment) -> list:
+    """Read a dynamic segment's symbols, or none if the segment cannot be parsed.
+
+    The symbol count comes from DT_GNU_HASH or DT_HASH, so a binary whose hash
+    section was stripped while the tag was left behind (`strip
+    --remove-section=.gnu.hash`) makes pyelftools call max() on an empty bucket
+    list.
+    """
+    try:
+        return list(segment.iter_symbols())
+    except MALFORMED_DYNAMIC_ERRORS as e:
+        logger.debug("Dynamic segment has an unreadable symbol table: %s", e)
+        return []
+
+
+def get_relocation_tables(segment: DynamicSegment) -> dict:
+    """Read a dynamic segment's relocation tables, or none if they cannot be parsed.
+
+    Each table is gated on its own tag, then sized from companion tags read
+    without a default, so a DT_RELA with no DT_RELAENT raises rather than being
+    skipped.
+    """
+    try:
+        return segment.get_relocation_tables()
+    except MALFORMED_DYNAMIC_ERRORS as e:
+        logger.debug("Dynamic segment has unreadable relocation tables: %s", e)
+        return {}
 
 
 def extract_file_export_names(elf: ELFFile, **kwargs):
@@ -68,9 +109,10 @@ def extract_file_export_names(elf: ELFFile, **kwargs):
             logger.debug("Dynamic segment doesn't contain DT_SYMTAB")
             continue
 
-        logger.debug("Dynamic segment contains %s symbols: ", segment.num_symbols())
+        symbols = get_dynamic_symbols(segment)
+        logger.debug("Dynamic segment contains %s symbols: ", len(symbols))
 
-        for symbol in segment.iter_symbols():
+        for symbol in symbols:
             # The following conditions are based on the following article
             # http://www.m4b.io/elf/export/binary/analysis/2015/05/25/what-is-an-elf-export.html
             if not symbol.name:
@@ -98,7 +140,7 @@ def extract_file_import_names(elf: ELFFile, **kwargs):
             logger.debug("Dynamic segment doesn't contain DT_SYMTAB")
             continue
 
-        for i, symbol in enumerate(segment.iter_symbols()):
+        for i, symbol in enumerate(get_dynamic_symbols(segment)):
             # The following conditions are based on the following article
             # http://www.m4b.io/elf/export/binary/analysis/2015/05/25/what-is-an-elf-export.html
             if not symbol.name:
@@ -118,7 +160,7 @@ def extract_file_import_names(elf: ELFFile, **kwargs):
         if not isinstance(segment, DynamicSegment):
             continue
 
-        relocation_tables = segment.get_relocation_tables()
+        relocation_tables = get_relocation_tables(segment)
         logger.debug("Dynamic Segment contains %s relocation tables:", len(relocation_tables))
 
         for relocation_table in relocation_tables.values():

--- a/tests/test_elffile_features.py
+++ b/tests/test_elffile_features.py
@@ -16,6 +16,9 @@ import io
 from pathlib import Path
 
 import fixtures
+import pytest
+from elftools.common.exceptions import ELFError
+from elftools.elf.dynamic import DynamicSegment
 from elftools.elf.elffile import ELFFile
 
 from capa.features.extractors.elffile import extract_file_export_names, extract_file_import_names
@@ -103,3 +106,61 @@ def test_elffile_export_features():
         "__libc_csu_init",
     ]
     check_export_features(SAMPLE_PATH, expected_exports)
+
+
+class _RaisingDynamicSegment(DynamicSegment):
+    """A dynamic segment whose tables cannot be read.
+
+    pyelftools reaches for companion tags with bare next() calls and sizes the
+    symbol table from a hash section that may have been stripped, so a malformed
+    file raises out of these two methods rather than returning nothing.
+    """
+
+    def __init__(self, exception):
+        self.exception = exception
+
+    def get_table_offset(self, name):
+        # DT_SYMTAB is present; it is the tables read off it that are broken.
+        return (0x1000, 0x1000)
+
+    def num_symbols(self):
+        # This is where the DT_GNU_HASH failure actually surfaces: pyelftools
+        # resolves the count through the hash table.
+        raise self.exception
+
+    def iter_symbols(self):
+        raise self.exception
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    def get_relocation_tables(self):
+        raise self.exception
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        # DT_GNU_HASH left pointing at a zeroed region, capa#3170
+        ValueError("max() iterable argument is empty"),
+        # a relocation table tag with no companion size tag, capa#3171. The bare
+        # StopIteration is what escapes pyelftools; PEP 479 only rewrites it
+        # into a RuntimeError at the generator boundary above the call site.
+        StopIteration(),
+        RuntimeError("generator raised StopIteration"),
+        ELFError("bad section header"),
+    ],
+    ids=["gnu-hash", "stop-iteration", "runtime-error", "elf-error"],
+)
+def test_malformed_dynamic_segment_does_not_abort(exception, monkeypatch):
+    segment = _RaisingDynamicSegment(exception)
+
+    class FakeELF:
+        def iter_sections(self):
+            return iter(())
+
+        def iter_segments(self):
+            return iter((segment,))
+
+    # A file capa cannot fully parse should yield no exports or imports rather
+    # than ending the run, since the remaining features are still extractable.
+    assert list(extract_file_export_names(FakeELF())) == []
+    assert list(extract_file_import_names(FakeELF())) == []


### PR DESCRIPTION
Closes #3170. Closes #3171.

Both reports are the same shape, so they are fixed together: pyelftools reads the dynamic tables lazily and trusts that a table tag arrives with the companion tags describing it. When that does not hold, the exception escapes capa's extractors and ends the run, and capa reports nothing at all for a file the rest of which is perfectly analyzable. For a tool aimed at hostile files that is the wrong trade, and this file already takes the other side of it a few lines down, where an invalid relocation table is caught and skipped with a comment saying the ELF is corrupt.

`iter_symbols` and `get_relocation_tables` now go through two small helpers that log and return nothing when the segment cannot be read.

`StopIteration` is in the caught set alongside `ValueError`, `RuntimeError` and `ELFError`, and that detail is easy to get wrong. pyelftools reads the companion tags with bare `next()` calls, so the raw exception is `StopIteration`; because the extractors are generators, PEP 479 rewrites it into `RuntimeError` only at the generator boundary, which is above the call site. Catching `RuntimeError` alone leaves the bug in place, which I found by trying exactly that first.

Verified against real files rather than reasoned about. Starting from `055da8e6ccfe5a9380231ea04b850e18.elf_` in capa-testfiles, I made the two malformed variants the issues describe, one with the `DT_GNU_HASH` target zero-filled and one with `DT_RELAENT` relabelled to `DT_DEBUG`, and ran the two extractors over all three:

    base     extract_file_export_names -> 19    extract_file_import_names -> 5
    gnuhash  extract_file_export_names -> ValueError: max() iterable argument is empty
    relaent  extract_file_import_names -> RuntimeError: generator raised StopIteration

After the change the unmodified file is still 19 and 5, and the two malformed files return partial results instead of raising. The stripped-hash file keeps all 19 exports, since those come from the section table.

The committed test does not need a sample. It drives both extractors with a dynamic segment whose table accessors raise, once per exception type, and asserts nothing propagates; against the current code all four fail with the exception escaping. I kept it sample-free deliberately so this does not require new binaries in capa-testfiles, but I am happy to contribute the two crafted files there if you would rather have end-to-end coverage.

`pytest tests/test_elffile_features.py` is 4 passed, with the four pre-existing `FileNotFound` failures from the test-data submodule not being checked out here. Ruff reports the same 7 errors and the same 2 files needing formatting before and after this branch, so it looks like my ruff differs from the pinned one rather than anything this change introduced.