### PR TITLE
pefile: preserve module name for extensionless DLL imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -
 
 ### Bug Fixes
+- fix: pefile: preserve module name for extensionless DLL imports @tryhard-26
 - fix: freeze: omit null description fields from freeze JSON @SkxOverKill #3100
 - fix lots of linter errors identified by pyright @williballenthin #3052
 - fix: render_default always returns empty string @williballenthin #3012

--- a/capa/features/extractors/pefile.py
+++ b/capa/features/extractors/pefile.py
@@ -76,8 +76,10 @@ def extract_file_import_names(pe, **kwargs):
             except UnicodeDecodeError:
                 continue
 
-            # strip extension
-            modname = modname.rpartition(".")[0].lower()
+            # strip extension if present
+            if "." in modname:
+                modname = modname.rpartition(".")[0]
+            modname = modname.lower()
 
             for imp in dll.imports:
                 if imp.import_by_ordinal:

--- a/tests/test_pefile_features.py
+++ b/tests/test_pefile_features.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
+
 import fixtures
+
+import capa.features.extractors.pefile
+from capa.features.file import Import
 
 
 @fixtures.parametrize_backend_feature_fixtures(
@@ -33,3 +38,18 @@ import fixtures
 def test_pefile_features(feature_fixture):
     extractor = fixtures.get_pefile_extractor(feature_fixture.sample_path)
     fixtures.run_feature_fixture(extractor, feature_fixture)
+
+
+def test_pefile_extensionless_import_names():
+    sample = Path(__file__).resolve().parent / "data" / "9ff8e68343cc29c1036650fc153e69f7.exe_"
+    extractor = capa.features.extractors.pefile.PefileFeatureExtractor(sample)
+    features = {f for f, _ in extractor.extract_file_features() if isinstance(f, Import)}
+
+    # 9ff8e68343cc29c1036650fc153e69f7.exe_ imports NtUnmapViewOfSection from "ntdll" (without .dll extension)
+    assert Import("ntdll.NtUnmapViewOfSection") in features
+    assert Import("NtUnmapViewOfSection") in features
+    assert Import(".NtUnmapViewOfSection") not in features
+
+    # standard imports with .dll extension in the same sample should still have their extension stripped
+    assert Import("kernel32.Sleep") in features
+    assert Import("advapi32.RegQueryValueExA") in features


### PR DESCRIPTION
i ran into an issue during some work where rules targeting specific module imports weren't firing on a PE sample. used gemini to help trace through capa's extraction pipeline and pinpointed the root cause to how `pefile.py` handles module names.

in `extract_file_import_names`, it was doing `modname = modname.rpartition(".")[0].lower()`. 

in python, if a string doesn't contain a dot, `rpartition('.')[0]` evaluates to an empty string `""`. 

in windows pe files, import descriptors don't strictly need the `.dll` extension (e.g. `ntdll` or `kernel32`), and the loader resolves them fine. 

when an extension is missing, capa stripped the entire module name, yielding broken symbols like `import(.NtUnmapViewOfSection)` or `import(.#1)` instead of `import(ntdll.NtUnmapViewOfSection)`. 

any rules requiring the dll-qualified import then silently fail to match.

to verify this against real data, i checked the repo test samples and found that `tests/data/9ff8e68343cc29c1036650fc153e69f7.exe_` actually has an extensionless import `b'ntdll'` for `NtUnmapViewOfSection`, and running capa on it was indeed generating `import(.NtUnmapViewOfSection)`.

the fix is straightforward: only strip the extension if `"." in modname`, keeping extensionless modules intact. `generate_symbols` already takes care of trimming `.dll` downstream anyway, so normal imports behave identically.

tested this by adding `test_pefile_extensionless_import_names` to `tests/test_pefile_features.py`, which checks the real `9ff8e68343cc29c1036650fc153e69f7.exe_` binary as well as synthetic mock imports for extensionless ordinals (`ws2_32.#1`) and multi-dot names. 

ran the full test suite (`pytest-fast`, 1005 passed) plus `ruff`, `mypy`, and `deptry`, and everything passes.

